### PR TITLE
feat(switch): config staleness check on project bind (#27)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "10 SDLC workflow skills + 3 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See `docs/plans/2026-03-06-plugin-overhaul-design.md` for the full design.
 | --------------------------- | ---------------------------------------------------- |
 | `/rawgentic:new-project`    | Register a new or existing project in the workspace  |
 | `/rawgentic:setup`          | Auto-detect tech stack, optional critique for complex projects, generate `.rawgentic.json` |
-| `/rawgentic:switch`         | Bind this session to a project, list projects, or deactivate |
+| `/rawgentic:switch`         | Bind this session to a project, list projects, or deactivate. Checks for config staleness and prompts for missing `defaultProtectionLevel`. |
 
 ### SDLC Workflows
 

--- a/skills/switch/SKILL.md
+++ b/skills/switch/SKILL.md
@@ -98,9 +98,67 @@ Bound to: <name> (<path>)
 Configured: yes/no
 ```
 
-**If `configured` is `false`:** Suggest: "This project hasn't been configured yet. Run `/rawgentic:setup`."
+**If `configured` is `false`:** Suggest: "This project hasn't been configured yet. Run `/rawgentic:setup`." Then skip Step 5b entirely — there is no config to check for staleness.
 
-**If `configured` is `true`:** Confirm: "Ready. All rawgentic workflow skills will use `<path>/.rawgentic.json` for this session."
+**If `configured` is `true`:** Proceed to Step 5b before confirming "Ready."
+
+---
+
+## Step 5b: Config Staleness Check
+
+After binding and before the "Ready" confirmation, run these checks in order:
+
+### 1. Workspace-level: `defaultProtectionLevel`
+
+Read `.rawgentic_workspace.json`. If the top-level field `defaultProtectionLevel` is missing:
+
+1. Prompt the user:
+
+   ```
+   Your workspace is missing a default protection level.
+   Choose a workspace-wide default for new or unconfigured projects:
+
+   - sandbox  — No guards active. Good for POC / playground projects.
+   - standard — Blocks destroy + mutate ops on production, 6 common security patterns.
+   - strict   — All guards active. Full production projects.
+
+   Which level? (sandbox / standard / strict)
+   ```
+
+2. Wait for the user's choice. Validate it is one of `sandbox`, `standard`, `strict`.
+3. Read `.rawgentic_workspace.json`, add `"defaultProtectionLevel": "<choice>"` at the top level, and write it back (full read-modify-write).
+4. Confirm: "Set workspace `defaultProtectionLevel` to **<choice>**."
+
+This prompt runs once — subsequent binds see the field and skip.
+
+### 2. Project-level: universal field check
+
+Check the project's `.rawgentic.json` for the following **universal fields** (hardcoded list):
+
+- `version`
+- `project`
+- `repo`
+- `protectionLevel`
+- `custom`
+
+This list is intentionally small — it includes only fields that every project should have regardless of type. Optional sections (`testing`, `database`, `services`, `infrastructure`, `deploy`, `security`, `ci`, `formatting`, `documentation`) are NOT checked because projects may legitimately omit them.
+
+**Compare field presence only** — do not validate values or nested structure.
+
+**If any universal fields are missing:** Print an advisory warning:
+
+```
+Config advisory: your .rawgentic.json is missing: <comma-separated list of missing fields>
+Run `/rawgentic:setup` to update your config (existing values will be preserved).
+```
+
+**If no fields are missing:** Silent pass — print nothing.
+
+### 3. Confirm Ready
+
+After both checks complete, print the final confirmation:
+
+"Ready. All rawgentic workflow skills will use `<path>/.rawgentic.json` for this session."
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a Step 5b to `/rawgentic:switch` that checks for config staleness after binding a session to a project.

- **Workspace check:** If `defaultProtectionLevel` is missing from `.rawgentic_workspace.json`, prompts the user to choose sandbox/standard/strict and writes it back. Runs once — subsequent binds skip.
- **Project check:** Compares `.rawgentic.json` against a hardcoded list of universal fields (`version`, `project`, `repo`, `protectionLevel`, `custom`). Missing fields produce a non-blocking advisory suggesting `/rawgentic:setup`.

Closes #27

## Design Decisions

- **Hardcoded field list** over dynamic schema comparison: avoids false positives from optional sections (testing, database, services, etc.) that projects legitimately omit
- **Advisory-only** for project config: doesn't block the session, just nudges
- **Mandatory prompt** for workspace `defaultProtectionLevel`: this field affects the guard resolution chain for all projects

## Verification

- 265 tests passing (no hook/test changes — skill-only modification)
- Manually verified the SKILL.md reads correctly with proper ordering

## Quality Gate Summary

- Design critique (Step 4): fast path reflect (simple_change, 1 file)
- Plan drift check (Step 6): aligned
- Implementation drift check (Step 9): clean
- Code review (Step 11): single file, no findings