### PR TITLE
feat(new-project): add existing-folder linking option (#30)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "description": "10 SDLC workflow skills + 3 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -57,17 +57,13 @@ Then inside the Claude session:
 
 This creates the workspace structure, clones or initializes the repo, scaffolds the workspace CLAUDE.md, and runs `/rawgentic:setup` to auto-detect your tech stack.
 
-**Importing existing projects:** Copy or symlink your project folder into the workspace's `projects/` directory, then register it:
+**Importing existing projects:** Register a project that already exists elsewhere on disk:
 
-```bash
-# From your terminal (outside Claude)
-cp -r ~/code/my-existing-app my-org-workspace/projects/my-existing-app
-
-# Then inside Claude
+```
 /rawgentic:new-project my-existing-app
 ```
 
-`new-project` detects the existing directory and skips cloning — it registers the project and runs setup to generate `.rawgentic.json`.
+When the project isn't found in the workspace, `new-project` asks whether to create a new folder or link to an existing one. Choose "link" and provide the path — the project is registered in the workspace JSON without copying or moving files. External projects are stored with their absolute path.
 
 ### 3. Start using workflows
 
@@ -107,7 +103,7 @@ Multiple projects can be active simultaneously. Use `/rawgentic:switch` to bind 
 
 | Skill                       | Purpose                                              |
 | --------------------------- | ---------------------------------------------------- |
-| `/rawgentic:new-project`    | Register a new or existing project in the workspace  |
+| `/rawgentic:new-project`    | Register a new or existing project in the workspace. Can link to external folders without copying. |
 | `/rawgentic:setup`          | Auto-detect tech stack, optional critique for complex projects, generate `.rawgentic.json` |
 | `/rawgentic:switch`         | Bind this session to a project, list projects, or deactivate. Checks for config staleness and prompts for missing `defaultProtectionLevel`. |
 

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -50,7 +50,25 @@ Read `.rawgentic_workspace.json` if it exists. Search the `projects` array for a
   1. **Switch to it** → Run `/rawgentic:switch <name>` and stop.
   2. **Re-run setup** → Switch to it, then run `/rawgentic:setup` and stop.
 
-**If not found (or no workspace file exists):** Continue to Step 3.
+**If not found (or no workspace file exists):** Continue to Step 2b.
+
+---
+
+## Step 2b: Create or Link?
+
+Ask the user:
+
+> This project isn't registered yet. Would you like to:
+> 1. **Create a new project** — set up a new folder at `<path>`
+> 2. **Link to an existing folder** — register a project that already lives somewhere else
+
+**If create (1):** Continue to Step 3 (uses `<path>` from Step 1 as-is).
+
+**If link (2):**
+1. Ask: "Enter the path to your existing project folder:"
+2. Validate the provided path exists on disk and is a directory.
+   - **If it does not exist or is not a directory:** Tell the user: "That path doesn't exist. Please check and try again." Re-prompt for the path (do NOT create the directory).
+   - **If it exists:** Override `<path>` with the user-provided path. Skip Step 3 and continue directly to Step 3b (conformance check), then Step 4.
 
 ---
 
@@ -83,7 +101,7 @@ Check whether `<path>` exists on disk.
 
 ## Step 3b: Conformance Check (existing projects only)
 
-If the project directory already existed (Path B from Step 3), audit its Claude configuration for conformance with the three-layer architecture:
+If the project directory already existed (Path B from Step 3, or linked via Step 2b), audit its Claude configuration for conformance with the three-layer architecture:
 
 1. **Check for rawgentic pointer in project CLAUDE.md.** Read `<path>/CLAUDE.md` if it exists. Search for `## Rawgentic` or `Workspace config:` patterns.
    - **If found:** Tell the user: "The project CLAUDE.md contains a Rawgentic section. This belongs in the workspace-level CLAUDE.md, not in the project. I'll remove it." Remove the section (from `## Rawgentic` to the next `##` heading or end of file).
@@ -130,19 +148,21 @@ Read `.rawgentic_workspace.json`, then:
 ```json
 {
   "name": "<name>",
-  "path": "./<relative-path-from-workspace-root>",
+  "path": "<path>",
   "active": true,
   "lastUsed": "<current ISO 8601 timestamp>",
   "configured": false
 }
 ```
 
-**Path conversion:** The `path` field MUST be a relative path from the workspace root (e.g., `./projects/my-app`), NOT an absolute path. This ensures portability across machines. To convert: take the absolute path from Step 1, strip the `WORKSPACE_ROOT` prefix, and prepend `./`. If the path is already relative, use it as-is.
+**Path conversion rules:**
+- **If `<path>` is inside the workspace root** (i.e., it starts with or is under `{WORKSPACE_ROOT}`): store as a relative path from the workspace root (e.g., `./projects/my-app`). To convert: strip the `WORKSPACE_ROOT` prefix and prepend `./`.
+- **If `<path>` is outside the workspace root** (e.g., linked via Step 2b to `/home/user/repos/my-app`): store as an absolute path. External projects are inherently location-specific, so portability does not apply.
 
 2. Write the updated workspace file back (full read-modify-write -- never patch in place).
 3. **Register in session registry:** Create `claude_docs/session_notes/` directory if it doesn't exist. Append a line to `claude_docs/session_registry.jsonl`:
    ```json
-   {"session_id":"<your session_id>","project":"<name>","project_path":"./<relative-path>","started":"<current ISO 8601 timestamp>","cwd":"<WORKSPACE_ROOT>"}
+   {"session_id":"<your session_id>","project":"<name>","project_path":"<path>","started":"<current ISO 8601 timestamp>","cwd":"<WORKSPACE_ROOT>"}
    ```
 4. **Initialize session notes file:** If `claude_docs/session_notes/<name>.md` does not exist, create it with:
    ```markdown


### PR DESCRIPTION
## Summary

When a project name isn't registered in `.rawgentic_workspace.json`, the `/rawgentic:new-project` skill now offers a choice: create a new project (existing behavior) or link to an existing folder elsewhere on disk.

Closes #30

## Changes

- **`skills/new-project/SKILL.md`**: Added Step 2b (Create or Link?) between duplicate check and folder creation. Link flow asks for path, validates existence, and continues to conformance check. Updated Step 5 path storage to allow absolute paths for external projects. Updated session registry to use stored path.
- **`README.md`**: Updated import instructions and skill table description.
- **`.claude-plugin/plugin.json`**: Version bump 2.10.1 → 2.11.0.

## Design Decisions

- **Path storage over symlinks**: Stores the external project's path directly in workspace JSON rather than creating symlinks. This avoids path mismatch issues with `wal-bind-guard` (which uses string prefix matching) and keeps the implementation simple.
- **Absolute paths for external projects**: Projects inside the workspace root keep relative paths (portable). External projects use absolute paths (inherently location-specific).
- **No switch changes needed**: `/rawgentic:switch` already searches workspace JSON by name/path, not the filesystem.

## Verification

- 265 tests passed (pytest tests/ -v), 0 failures
- All 7 acceptance criteria mapped to implementation

## Quality Gate Summary

- Design critique (Step 4): Fast path reflect — no findings
- Plan drift check (Step 6): No drift
- Implementation drift check (Step 9): All ACs covered
- Code review (Step 11): Clean diff, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)