### PR TITLE
feat(setup): detect BMAD and configure per-project skill preferences (#41)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -555,7 +555,9 @@ Skills are tested via the `/skill-creator` eval pipeline (14/15 skills have eval
 
 If you also use the [BMAD Method](https://github.com/bmad-method/bmad-method), the two plugins overlap in implementation, code review, testing, and documentation. Without explicit routing, Claude may pick the wrong skill.
 
-**A ready-made CLAUDE.md routing snippet is included at [`templates/CLAUDE-bmad-routing.md`](templates/CLAUDE-bmad-routing.md).** Copy it into your `~/.claude/CLAUDE.md` (global) or project-level `CLAUDE.md`.
+**Automatic detection:** When you run `/rawgentic:setup` or `/rawgentic:switch`, rawgentic checks for a `_bmad/` directory in your workspace root. If found, it asks you to choose your preferred tool (rawgentic or BMAD) for each overlapping task — per project. Preferences are stored in `.rawgentic_workspace.json` and enforced automatically. See [`docs/config-reference.md`](docs/config-reference.md#bmad-integration) for details.
+
+**Manual routing (legacy):** A CLAUDE.md routing snippet is also available at [`templates/CLAUDE-bmad-routing.md`](templates/CLAUDE-bmad-routing.md). The automated detection above replaces this approach.
 
 **TL;DR of the division:**
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -233,3 +233,84 @@ Pattern matching uses fnmatch with `**` for recursive directory matching.
 The older `security.exceptions` array (per-rule + per-path exceptions) is still
 supported for backward compatibility but deprecated. Migrate to
 `guards.securityExcludePaths` for simpler path-based exclusions.
+
+## BMAD Integration
+
+When BMAD is installed alongside rawgentic (detected by the presence of a `_bmad/`
+directory in the workspace root), rawgentic can disable overlapping workflow skills
+and defer to BMAD equivalents on a per-project basis.
+
+### Workspace-Level Fields (`.rawgentic_workspace.json`)
+
+| Field | Type | Location | Description |
+|-------|------|----------|-------------|
+| `bmadDetected` | boolean | Top-level | Whether `_bmad/` was found in the workspace root. Set by `/rawgentic:setup` or `/rawgentic:switch`. |
+
+### Per-Project Fields (in each `projects[]` entry)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `disabledSkills` | `string[]` | Bare skill names the user chose to replace with BMAD equivalents. |
+| `critiqueMethod` | `string` | `"reflexion"` (default) or `"bmad-party-mode"`. Controls which critique tool is used at quality gates. |
+
+### `disabledSkills` Semantics
+
+- **Missing field** = not yet configured. Triggers a redirect to `/rawgentic:setup` when the user runs `/rawgentic:switch`.
+- **Empty array `[]`** = user explicitly chose rawgentic for all overlapping tasks.
+- **Populated array** = user chose BMAD for those specific tasks. Only those rawgentic skills are blocked.
+
+### BMAD Overlap Table
+
+| Rawgentic Skill | BMAD Equivalent |
+|-----------------|-----------------|
+| `implement-feature` | `bmad-dev-story` |
+| `fix-bug` | `bmad-dev-story` |
+| `create-tests` | BMAD TEA module (`bmad-tea-*`) |
+| `update-docs` | BMAD tech-writer agent |
+
+Skills not in this table (create-issue, refactor, security-audit, incident, update-deps,
+optimize-perf) have no BMAD equivalent and are never candidates for BMAD-based disabling.
+
+### Enforcement
+
+All 10 workflow skills check `disabledSkills` in their config-loading preamble (Step 1b).
+If the current skill is listed, it stops and suggests the BMAD alternative. The check runs
+after active project resolution but before loading `.rawgentic.json`.
+
+### `critiqueMethod`
+
+Six skills that invoke `/reflexion:critique` (implement-feature, create-issue, refactor,
+security-audit, optimize-perf, setup) check the project's `critiqueMethod` field before
+running the critique. If set to `"bmad-party-mode"`, that is used instead.
+
+### Detection Flow
+
+1. `/rawgentic:switch` checks for `_bmad/` at session bind time. If found and the project
+   lacks `disabledSkills`, it redirects to `/rawgentic:setup`.
+2. `/rawgentic:setup` Step 2b presents the per-task choice UI and writes preferences.
+3. On re-run, if `_bmad/` is gone, setup offers to remove BMAD-related disabled skills.
+
+### Example Configuration
+
+```json
+{
+  "bmadDetected": true,
+  "projects": [
+    {
+      "name": "chorestory",
+      "path": "./projects/chorestory",
+      "active": true,
+      "configured": true,
+      "disabledSkills": ["implement-feature", "fix-bug", "create-tests", "update-docs"],
+      "critiqueMethod": "bmad-party-mode"
+    },
+    {
+      "name": "rawgentic",
+      "path": "./projects/rawgentic",
+      "active": true,
+      "configured": true,
+      "disabledSkills": []
+    }
+  ]
+}
+```

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -187,6 +187,8 @@ The draft specification is an internal working artifact. Do NOT present it to th
 
 ### Instructions
 
+**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the 3-judge critique below. If missing or `"reflexion"`, proceed as normal.
+
 1. Launch all three judges in a single message with three parallel Agent tool calls (subagent_type="general-purpose"), each operating independently:
 
    **Judge 1: Requirements Validator**

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -35,6 +35,15 @@ Before executing any workflow steps, load the project configuration:
    - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
+     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
 2. Read `<activeProject.path>/.rawgentic.json`.
    - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
    - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -36,10 +36,12 @@ Before executing any workflow steps, load the project configuration:
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
 1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
-     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
-     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
@@ -187,7 +189,7 @@ The draft specification is an internal working artifact. Do NOT present it to th
 
 ### Instructions
 
-**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the 3-judge critique below. If missing or `"reflexion"`, proceed as normal.
+**Critique method preference:** Before running the critique, check the active project entry's `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the 3-judge critique below. If missing or `"reflexion"`, proceed as normal.
 
 1. Launch all three judges in a single message with three parallel Agent tool calls (subagent_type="general-purpose"), each operating independently:
 

--- a/skills/create-tests-workspace/iteration-1/multi-lang-coverage/without_skill/outputs/tests_shell/README_test_setup.md
+++ b/skills/create-tests-workspace/iteration-1/multi-lang-coverage/without_skill/outputs/tests_shell/README_test_setup.md
@@ -1,0 +1,30 @@
+# Shell Script Test Setup
+
+## Prerequisites
+
+Install BATS (Bash Automated Testing System):
+
+```bash
+# Ubuntu/Debian
+sudo apt install bats
+
+# Or from source
+git clone https://github.com/bats-core/bats-core.git
+cd bats-core && sudo ./install.sh /usr/local
+```
+
+## Running the tests
+
+```bash
+# Run all shell tests
+bats tests_shell/
+
+# Run a single file
+bats tests_shell/test_install.bats
+```
+
+## Notes
+
+- Tests use stub commands to avoid requiring real nvidia-smi / ipmitool / systemctl.
+- Tests run in a temporary directory and do NOT modify the real filesystem.
+- Root-check tests verify that the script exits correctly for non-root users.

--- a/skills/create-tests-workspace/iteration-1/shell-targeted/with_skill/outputs/rawgentic.json.updated
+++ b/skills/create-tests-workspace/iteration-1/shell-targeted/with_skill/outputs/rawgentic.json.updated
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "project": {
+    "name": "gpu-fan-controller",
+    "type": "scripts",
+    "description": "GPU-aware fan controller for Intel S2600WTTR + Tesla P40 via IPMI"
+  },
+  "repo": {
+    "provider": "github",
+    "fullName": "3D-Stories/gpu-fan-controller",
+    "defaultBranch": "main"
+  },
+  "techStack": ["python", "systemd", "ipmi"],
+  "testing": {
+    "frameworks": [
+      {
+        "name": "bats-core",
+        "type": "unit",
+        "command": "bats test/",
+        "configFile": null,
+        "testDir": "test"
+      }
+    ]
+  },
+  "deploy": {
+    "method": "script",
+    "command": "sudo bash install.sh"
+  },
+  "infrastructure": {
+    "hosts": [
+      {
+        "name": "charlie",
+        "address": "localhost",
+        "sshUser": "root",
+        "description": "Proxmox host (Intel S2600WTTR)"
+      }
+    ]
+  },
+  "documentation": {
+    "primaryFiles": ["README.md"],
+    "format": "markdown"
+  },
+  "custom": {}
+}

--- a/skills/create-tests-workspace/iteration-1/shell-targeted/with_skill/outputs/testing-strategy.md
+++ b/skills/create-tests-workspace/iteration-1/shell-targeted/with_skill/outputs/testing-strategy.md
@@ -1,0 +1,73 @@
+# Testing Strategy: gpu-fan-controller install.sh
+
+**Date:** 2026-03-07
+**Mode:** Greenfield
+**Scope:** Targeted (install.sh)
+**Framework:** bats-core
+
+## Project Context
+
+- **Project:** gpu-fan-controller
+- **Description:** GPU-aware fan controller for Intel S2600WTTR + Tesla P40 via IPMI
+- **Target file:** `install.sh` - bash installer that checks dependencies, loads kernel modules, copies files, installs systemd service, and tests IPMI/GPU connectivity
+
+## Test Types
+
+**Unit tests** are the primary focus. The installer script has 6 distinct phases, each testable in isolation:
+
+1. Root privilege check (EUID)
+2. Dependency verification (python3, ipmitool, nvidia-smi)
+3. IPMI kernel module loading and persistent configuration
+4. File installation (script + config, with existing config preservation)
+5. Systemd service installation
+6. Hardware connectivity tests (IPMI fans, GPU temperature)
+
+## Framework: bats-core
+
+**Why bats-core:**
+- Standard testing framework for bash scripts
+- Supports `@test` blocks with descriptive names
+- `run` command captures stdout/stderr and exit codes
+- Built-in setup/teardown lifecycle hooks
+- bats-assert and bats-support libraries for richer assertions
+
+**No integration/e2e tests needed:** The script interacts with system hardware (IPMI, GPU) and privileged operations (modprobe, systemctl). All external commands will be mocked.
+
+## Mocking Strategy
+
+All external commands are mocked via PATH manipulation:
+- Create stub executables in a temp `mocks/` directory
+- Prepend `mocks/` to PATH so stubs are found before real commands
+- Stubs return configurable exit codes and output
+
+**Commands to mock:**
+- `python3`, `ipmitool`, `nvidia-smi` (for dependency checks)
+- `modprobe` (kernel module loading)
+- `cp`, `mkdir`, `chmod` (file operations - handled via temp directories)
+- `systemctl` (systemd operations)
+- File system paths are overridden via environment variables or script modification
+
+**Key challenge:** The script uses hardcoded paths (`/opt/gpu-fan-controller`, `/etc/gpu_fan_controller`, `/etc/systemd/system/`). Tests source a modified version of the script with paths redirected to temp directories.
+
+## Test Organization
+
+```
+test/
+  install.bats          # Main test file for install.sh
+  test_helper.bash      # Shared setup, mock creation utilities
+```
+
+## Coverage Goals
+
+- All 6 installer phases tested
+- Both success and failure paths for each phase
+- Config preservation logic (new install vs. existing config)
+- Error messages verified for user-facing output
+- Exit codes verified for all failure modes
+
+## Key Decisions
+
+1. **Mock approach:** PATH-based stubs over function overrides (more realistic, tests actual command resolution)
+2. **Script modification:** Source the script with overridden path variables rather than running it end-to-end (allows testing individual sections)
+3. **No coverage tool:** kcov is optional for shell and adds complexity; focus on thorough manual coverage via test case design
+4. **Temp directories:** All file operations target `$BATS_TMPDIR` subdirectories to avoid any system side effects

--- a/skills/create-tests/SKILL.md
+++ b/skills/create-tests/SKILL.md
@@ -38,10 +38,12 @@ Before executing any workflow steps, load the project configuration:
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
 1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
-     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
-     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.

--- a/skills/create-tests/SKILL.md
+++ b/skills/create-tests/SKILL.md
@@ -37,6 +37,15 @@ Before executing any workflow steps, load the project configuration:
    - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
+     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
 2. Read `<activeProject.path>/.rawgentic.json`.
    - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
    - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."

--- a/skills/fix-bug/SKILL.md
+++ b/skills/fix-bug/SKILL.md
@@ -39,10 +39,12 @@ Before executing any workflow steps, load the project configuration:
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
 1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
-     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
-     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.

--- a/skills/fix-bug/SKILL.md
+++ b/skills/fix-bug/SKILL.md
@@ -38,6 +38,15 @@ Before executing any workflow steps, load the project configuration:
    - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
+     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
 2. Read `<activeProject.path>/.rawgentic.json`.
    - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
    - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -41,6 +41,15 @@ Before executing any workflow steps, load the project configuration:
    - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
+     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
 2. Read `<activeProject.path>/.rawgentic.json`.
    - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
    - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -317,6 +317,8 @@ Design document. NOT presented to user — goes to Step 4 for critique.
 
 ### Instructions
 
+**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
+
 **Determine gate type based on fast path eligibility:**
 - If `fast_path_eligible == true`: use `/reflexion:reflect` (lightweight)
 - If `fast_path_eligible == false`: use `/reflexion:critique` (full 3-judge)

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -42,10 +42,12 @@ Before executing any workflow steps, load the project configuration:
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
 1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
-     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
-     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
@@ -317,7 +319,7 @@ Design document. NOT presented to user — goes to Step 4 for critique.
 
 ### Instructions
 
-**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
+**Critique method preference:** Before running the critique, check the active project entry's `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
 
 **Determine gate type based on fast path eligibility:**
 - If `fast_path_eligible == true`: use `/reflexion:reflect` (lightweight)

--- a/skills/incident/SKILL.md
+++ b/skills/incident/SKILL.md
@@ -49,10 +49,12 @@ Before executing any workflow steps, load the project configuration:
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
 1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
-     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
-     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.

--- a/skills/incident/SKILL.md
+++ b/skills/incident/SKILL.md
@@ -48,6 +48,15 @@ Before executing any workflow steps, load the project configuration:
    - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
+     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
 2. Read `<activeProject.path>/.rawgentic.json`.
    - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
    - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."

--- a/skills/optimize-perf/SKILL.md
+++ b/skills/optimize-perf/SKILL.md
@@ -206,6 +206,8 @@ If the optimization involves architectural changes (new caching layer, query res
 
 ### Instructions
 
+**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
+
 Invoke `/reflexion:critique` -- three judges evaluate:
 
 - **Effectiveness judge:** Will optimizations actually address measured bottlenecks? Expected improvements realistic?

--- a/skills/optimize-perf/SKILL.md
+++ b/skills/optimize-perf/SKILL.md
@@ -40,6 +40,15 @@ Before executing any workflow steps, load the project configuration:
    - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
+     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
 2. Read `<activeProject.path>/.rawgentic.json`.
    - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
    - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."

--- a/skills/optimize-perf/SKILL.md
+++ b/skills/optimize-perf/SKILL.md
@@ -41,10 +41,12 @@ Before executing any workflow steps, load the project configuration:
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
 1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
-     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
-     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
@@ -206,7 +208,7 @@ If the optimization involves architectural changes (new caching layer, query res
 
 ### Instructions
 
-**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
+**Critique method preference:** Before running the critique, check the active project entry's `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
 
 Invoke `/reflexion:critique` -- three judges evaluate:
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -217,6 +217,8 @@ Refactoring design (internal): { approach, target_structure, migration_steps, be
 
 ### Instructions
 
+**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
+
 **For Extract/Restructure (full critique):** Invoke `/reflexion:critique` — three judges evaluate:
 
 - Does the refactoring preserve all documented behavioral contracts?

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -38,6 +38,15 @@ Before executing any workflow steps, load the project configuration:
    - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
+     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
 2. Read `<activeProject.path>/.rawgentic.json`.
    - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
    - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -39,10 +39,12 @@ Before executing any workflow steps, load the project configuration:
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
 1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
-     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
-     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
@@ -217,7 +219,7 @@ Refactoring design (internal): { approach, target_structure, migration_steps, be
 
 ### Instructions
 
-**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
+**Critique method preference:** Before running the critique, check the active project entry's `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
 
 **For Extract/Restructure (full critique):** Invoke `/reflexion:critique` — three judges evaluate:
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -211,6 +211,8 @@ All data channels from `config.security.dataChannels[]` must be audited independ
 
 ### Instructions
 
+**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
+
 Invoke `/reflexion:critique` — the **audit itself** is critiqued for completeness and accuracy.
 
 Three judges evaluate:

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -45,10 +45,12 @@ Before executing any workflow steps, load the project configuration:
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
 1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
-     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
-     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
@@ -211,7 +213,7 @@ All data channels from `config.security.dataChannels[]` must be audited independ
 
 ### Instructions
 
-**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
+**Critique method preference:** Before running the critique, check the active project entry's `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
 
 Invoke `/reflexion:critique` — the **audit itself** is critiqued for completeness and accuracy.
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -44,6 +44,15 @@ Before executing any workflow steps, load the project configuration:
    - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
+     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
 2. Read `<activeProject.path>/.rawgentic.json`.
    - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
    - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -95,6 +95,83 @@ Check if `CLAUDE.md` (in the Claude root) contains either of these markers from 
 
 ---
 
+## Step 2b: BMAD Detection and Skill Preferences
+
+This step runs on **every** setup invocation (including Sub-flow A re-runs).
+
+### Detection
+
+Check if `${WORKSPACE_ROOT}/_bmad/` directory exists (where WORKSPACE_ROOT is the directory containing `.rawgentic_workspace.json`).
+
+- **If `_bmad/` exists:**
+  1. Read `.rawgentic_workspace.json`. If `bmadDetected` is not already `true`, set it to `true` and write the file back.
+  2. Find the active project's entry in `.rawgentic_workspace.json`.
+  3. **If the project entry has no `disabledSkills` field** (first-time configuration): proceed to the **Per-Task Choice UI** below.
+  4. **If the project entry already has `disabledSkills`** (re-configuration): proceed to the **Re-Configuration UI** below.
+
+- **If `_bmad/` does NOT exist AND `bmadDetected` was previously `true`:** proceed to the **Removal Flow** below.
+
+- **If `_bmad/` does NOT exist AND `bmadDetected` is not set or `false`:** skip this step silently.
+
+### Per-Task Choice UI (first-time configuration)
+
+Present the user with a per-task choice for the active project:
+
+```
+BMAD detected (_bmad/ found). For [project-name], choose your preferred tool:
+
+1. Feature implementation:  (a) rawgentic:implement-feature  (b) bmad-dev-story      [default: b]
+2. Bug fixing:              (a) rawgentic:fix-bug            (b) bmad-dev-story      [default: b]
+3. Test creation:           (a) rawgentic:create-tests       (b) bmad-tea-*          [default: b]
+4. Documentation:           (a) rawgentic:update-docs        (b) BMAD tech-writer    [default: b]
+
+Accept all defaults? (y) Or enter numbers to change (e.g., "1,3" to pick rawgentic for those)
+```
+
+For each task where the user picks **(b)** (BMAD), add the rawgentic skill name to `disabledSkills`.
+For each task where the user picks **(a)** (rawgentic), do NOT add it.
+
+Then present the critique method choice (only if at least one rawgentic workflow is kept):
+
+```
+5. Code critique method:    (a) /reflexion:critique  (b) bmad-party-mode    [default: a]
+```
+
+Write the results to the active project's entry in `.rawgentic_workspace.json`:
+- `disabledSkills`: array of bare skill names the user chose to replace with BMAD (e.g., `["implement-feature", "fix-bug", "create-tests", "update-docs"]`)
+- `critiqueMethod`: `"bmad-party-mode"` or `"reflexion"` (only if user chose non-default)
+
+**Semantics:**
+- `disabledSkills` missing = not yet configured (triggers redirect in `/rawgentic:switch`)
+- `disabledSkills: []` = user explicitly chose rawgentic for all tasks
+- `disabledSkills: [...]` = user chose BMAD for those specific tasks
+
+### Re-Configuration UI (re-run with existing preferences)
+
+Present the current selections and allow toggling:
+
+```
+Current BMAD preferences for [project-name]:
+1. Feature implementation:  rawgentic:implement-feature  [DISABLED — using bmad-dev-story]
+2. Bug fixing:              rawgentic:fix-bug            [DISABLED — using bmad-dev-story]
+3. Test creation:           rawgentic:create-tests       [ENABLED]
+4. Documentation:           rawgentic:update-docs        [DISABLED — using BMAD tech-writer]
+5. Critique method:         [current value]
+
+Change any? (enter numbers to toggle, or "keep" to keep current)
+```
+
+Update `disabledSkills` and `critiqueMethod` in the project entry based on user changes.
+
+### Removal Flow (BMAD previously detected but `_bmad/` gone)
+
+1. Prompt: "BMAD was previously detected but `_bmad/` no longer exists. Remove disabled skills for **[project-name]**? (y/n)"
+2. If yes: remove only entries matching `{implement-feature, fix-bug, create-tests, update-docs}` from this project's `disabledSkills`. Any manually-added entries are preserved. Remove `critiqueMethod` if it was `"bmad-party-mode"`.
+3. Check all project entries — if none have BMAD-related disabled skills remaining, set `bmadDetected` to `false`.
+4. If no: leave everything as-is.
+
+---
+
 ## Step 3: Detect or Brainstorm
 
 Read `templates/rawgentic-json-schema.json` from the rawgentic plugin directory to understand the full schema structure.
@@ -385,6 +462,8 @@ Read `~/.claude/CLAUDE.md` and check for content that the three-layer architectu
 - **Team process sections** (patterns: `SDLC`, `Workflow Principles`, `Conventional Commit`, `TDD`): Suggest: "You have team process sections in your personal CLAUDE.md. These could be shared via the workspace CLAUDE.md's Team Process section. Would you like to keep them personal, or move them to the workspace level?"
 
 - **Empty placeholder sections** (sections with only `---` or whitespace as content): Suggest: "You have empty sections in `~/.claude/CLAUDE.md` (e.g., Infrastructure, Servers). Would you like me to remove them to reduce clutter?"
+
+- **BMAD routing table** (pattern: `## Plugin Routing: BMAD vs Rawgentic` or `## Plugin Routing: BMAD + Rawgentic`): If `bmadDetected` is `true` in `.rawgentic_workspace.json` (meaning automated detection is now active), suggest: "Plugin routing is now handled per-project via `disabledSkills` in `.rawgentic_workspace.json`. Remove the manual routing table from `~/.claude/CLAUDE.md`?" If approved, remove from the heading through to (but not including) the next `##` heading.
 
 All suggestions require explicit user approval. If the user declines, leave Layer 1 unchanged. If the user approves a move:
 1. Remove the content from `~/.claude/CLAUDE.md`

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -273,6 +273,8 @@ If the user declines (or score is 0), proceed to Step 5 with the config unchange
 
 ### Critique Execution
 
+**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
+
 If the user accepts, invoke `/reflexion:critique` with the detected `.rawgentic.json` as the work product.
 
 **Three judges evaluate in parallel:**

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -156,7 +156,7 @@ Current BMAD preferences for [project-name]:
 2. Bug fixing:              rawgentic:fix-bug            [DISABLED — using bmad-dev-story]
 3. Test creation:           rawgentic:create-tests       [ENABLED]
 4. Documentation:           rawgentic:update-docs        [DISABLED — using BMAD tech-writer]
-5. Critique method:         [current value]
+5. Critique method:         [show actual value from project entry's critiqueMethod field; default: reflexion]
 
 Change any? (enter numbers to toggle, or "keep" to keep current)
 ```
@@ -350,7 +350,7 @@ If the user declines (or score is 0), proceed to Step 5 with the config unchange
 
 ### Critique Execution
 
-**Critique method preference:** Before running the critique, check the active project entry'''s `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
+**Critique method preference:** Before running the critique, check the active project entry's `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the critique below. If missing or `"reflexion"`, proceed as normal.
 
 If the user accepts, invoke `/reflexion:critique` with the detected `.rawgentic.json` as the work product.
 

--- a/skills/switch/SKILL.md
+++ b/skills/switch/SKILL.md
@@ -154,9 +154,26 @@ Run `/rawgentic:setup` to update your config (existing values will be preserved)
 
 **If no fields are missing:** Silent pass — print nothing.
 
-### 3. Confirm Ready
+### 3. BMAD Detection Check
 
-After both checks complete, print the final confirmation:
+Check if `${WORKSPACE_ROOT}/_bmad/` directory exists (where WORKSPACE_ROOT is the directory containing `.rawgentic_workspace.json`).
+
+**If `_bmad/` exists:**
+1. Read `.rawgentic_workspace.json`. If `bmadDetected` is not already `true`, set it to `true` and write the file back.
+2. Check the target project's entry for a `disabledSkills` field.
+3. **If `disabledSkills` is missing** (project not yet configured for BMAD): redirect to setup:
+   ```
+   BMAD detected but no skill preferences configured for [project-name].
+   Running /rawgentic:setup to configure...
+   ```
+   Invoke `/rawgentic:setup` for the active project. After setup completes, return here and continue to "Confirm Ready."
+4. **If `disabledSkills` exists** (already configured): silent pass. Proceed to "Confirm Ready."
+
+**If `_bmad/` does NOT exist:** Silent pass — proceed to "Confirm Ready."
+
+### 4. Confirm Ready
+
+After all checks complete, print the final confirmation:
 
 "Ready. All rawgentic workflow skills will use `<path>/.rawgentic.json` for this session."
 

--- a/skills/switch/SKILL.md
+++ b/skills/switch/SKILL.md
@@ -166,10 +166,14 @@ Check if `${WORKSPACE_ROOT}/_bmad/` directory exists (where WORKSPACE_ROOT is th
    BMAD detected but no skill preferences configured for [project-name].
    Running /rawgentic:setup to configure...
    ```
-   Invoke `/rawgentic:setup` for the active project. After setup completes, return here and continue to "Confirm Ready."
+   Invoke `/rawgentic:setup` for the active project. Note: full setup will run (including verification and migration checks), but only Step 2b will actively prompt for BMAD preferences. After setup completes, return here and continue to "Confirm Ready."
 4. **If `disabledSkills` exists** (already configured): silent pass. Proceed to "Confirm Ready."
 
-**If `_bmad/` does NOT exist:** Silent pass — proceed to "Confirm Ready."
+**If `_bmad/` does NOT exist AND `bmadDetected` is `true` in `.rawgentic_workspace.json`:** Warn the user:
+   "BMAD was previously detected but `_bmad/` no longer exists. Run `/rawgentic:setup` to update skill preferences."
+   Proceed to "Confirm Ready."
+
+**If `_bmad/` does NOT exist AND `bmadDetected` is not set or `false`:** Silent pass — proceed to "Confirm Ready."
 
 ### 4. Confirm Ready
 

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -40,6 +40,15 @@ Before executing any workflow steps, load the project configuration:
    - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
+     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
 2. Read `<activeProject.path>/.rawgentic.json`.
    - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
    - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -41,10 +41,12 @@ Before executing any workflow steps, load the project configuration:
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
 1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
-     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
-     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -35,10 +35,12 @@ Before executing any workflow steps, load the project configuration:
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
 1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
-     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
-     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -34,6 +34,15 @@ Before executing any workflow steps, load the project configuration:
    - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
    - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
 
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.** Tell user:
+     "You chose [BMAD alternative] for this task in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+     BMAD alternatives: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+     For other skill names: "Skill [name] is disabled. Remove from disabledSkills in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
 2. Read `<activeProject.path>/.rawgentic.json`.
    - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
    - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."

--- a/tests/hooks/test_bmad_detection.py
+++ b/tests/hooks/test_bmad_detection.py
@@ -81,11 +81,19 @@ class TestDisabledSkillsPreamble:
 
     @pytest.mark.parametrize("skill_name", BMAD_OVERLAP_SKILLS)
     def test_bmad_overlap_skills_have_alternative_mapping(self, skill_name: str):
-        """BMAD-overlapping skills must include the alternative name."""
+        """BMAD-overlapping skills must include the alternative name in config-loading."""
         skill_path = SKILLS_DIR / skill_name / "SKILL.md"
         content = skill_path.read_text()
 
-        # Each overlapping skill should mention its BMAD alternative
+        # Find the config-loading block
+        start = content.find("<config-loading>")
+        end = content.find("</config-loading>")
+        assert start != -1 and end != -1, (
+            f"{skill_name}/SKILL.md is missing <config-loading> block"
+        )
+        config_block = content[start:end]
+
+        # Each overlapping skill should mention its BMAD alternative within config-loading
         alternatives = {
             "implement-feature": "bmad-dev-story",
             "fix-bug": "bmad-dev-story",
@@ -93,8 +101,9 @@ class TestDisabledSkillsPreamble:
             "update-docs": "tech-writer",
         }
         alt = alternatives[skill_name]
-        assert alt in content, (
-            f"{skill_name}/SKILL.md should reference BMAD alternative '{alt}'"
+        assert alt in config_block, (
+            f"{skill_name}/SKILL.md should reference BMAD alternative '{alt}' "
+            f"within the <config-loading> block"
         )
 
 

--- a/tests/hooks/test_bmad_detection.py
+++ b/tests/hooks/test_bmad_detection.py
@@ -1,0 +1,196 @@
+"""Tests for BMAD detection and per-project skill preferences (issue #41).
+
+Covers:
+- Lint: all 10 workflow SKILL.md files contain the disabledSkills check
+- Lint: 6 critique-invoking SKILL.md files contain the critiqueMethod check
+- Schema: workspace JSON validates with bmadDetected and per-project disabledSkills
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+# Path to the skills/ directory, resolved relative to this file.
+SKILLS_DIR = Path(__file__).resolve().parent.parent.parent / "skills"
+
+# All 10 workflow skills that have <config-loading> preambles.
+WORKFLOW_SKILLS = [
+    "implement-feature",
+    "fix-bug",
+    "create-tests",
+    "update-docs",
+    "create-issue",
+    "refactor",
+    "security-audit",
+    "incident",
+    "update-deps",
+    "optimize-perf",
+]
+
+# The 6 skills that invoke /reflexion:critique and need critiqueMethod check.
+CRITIQUE_SKILLS = [
+    "implement-feature",
+    "create-issue",
+    "refactor",
+    "security-audit",
+    "optimize-perf",
+    "setup",
+]
+
+# The 4 BMAD-overlapping skills.
+BMAD_OVERLAP_SKILLS = [
+    "implement-feature",
+    "fix-bug",
+    "create-tests",
+    "update-docs",
+]
+
+
+class TestDisabledSkillsPreamble:
+    """Lint: all 10 workflow skills contain the disabledSkills check."""
+
+    @pytest.mark.parametrize("skill_name", WORKFLOW_SKILLS)
+    def test_skill_contains_disabled_skills_check(self, skill_name: str):
+        skill_path = SKILLS_DIR / skill_name / "SKILL.md"
+        assert skill_path.exists(), f"SKILL.md not found at {skill_path}"
+
+        content = skill_path.read_text()
+        assert "disabledSkills" in content, (
+            f"{skill_name}/SKILL.md is missing the disabledSkills check "
+            f"in its <config-loading> preamble"
+        )
+
+    @pytest.mark.parametrize("skill_name", WORKFLOW_SKILLS)
+    def test_skill_check_is_in_config_loading(self, skill_name: str):
+        """The disabledSkills check must be inside the <config-loading> block."""
+        skill_path = SKILLS_DIR / skill_name / "SKILL.md"
+        content = skill_path.read_text()
+
+        # Find the config-loading block
+        start = content.find("<config-loading>")
+        end = content.find("</config-loading>")
+        assert start != -1 and end != -1, (
+            f"{skill_name}/SKILL.md is missing <config-loading> block"
+        )
+
+        config_block = content[start:end]
+        assert "disabledSkills" in config_block, (
+            f"{skill_name}/SKILL.md has disabledSkills outside <config-loading> "
+            f"or is missing it entirely from the preamble"
+        )
+
+    @pytest.mark.parametrize("skill_name", BMAD_OVERLAP_SKILLS)
+    def test_bmad_overlap_skills_have_alternative_mapping(self, skill_name: str):
+        """BMAD-overlapping skills must include the alternative name."""
+        skill_path = SKILLS_DIR / skill_name / "SKILL.md"
+        content = skill_path.read_text()
+
+        # Each overlapping skill should mention its BMAD alternative
+        alternatives = {
+            "implement-feature": "bmad-dev-story",
+            "fix-bug": "bmad-dev-story",
+            "create-tests": "bmad-tea",
+            "update-docs": "tech-writer",
+        }
+        alt = alternatives[skill_name]
+        assert alt in content, (
+            f"{skill_name}/SKILL.md should reference BMAD alternative '{alt}'"
+        )
+
+
+class TestCritiqueMethodPreamble:
+    """Lint: 6 critique-invoking skills contain the critiqueMethod check."""
+
+    @pytest.mark.parametrize("skill_name", CRITIQUE_SKILLS)
+    def test_skill_contains_critique_method_check(self, skill_name: str):
+        skill_path = SKILLS_DIR / skill_name / "SKILL.md"
+        assert skill_path.exists(), f"SKILL.md not found at {skill_path}"
+
+        content = skill_path.read_text()
+        assert "critiqueMethod" in content, (
+            f"{skill_name}/SKILL.md is missing the critiqueMethod preference "
+            f"check near its /reflexion:critique invocation"
+        )
+
+
+class TestWorkspaceSchemaWithBmad:
+    """Schema: workspace JSON validates with BMAD-related fields."""
+
+    def test_workspace_with_bmad_detected(self, make_workspace):
+        """bmadDetected at top level is valid."""
+        ws = make_workspace(
+            projects=[
+                {
+                    "name": "myproj",
+                    "path": "./projects/myproj",
+                    "active": True,
+                    "lastUsed": "2026-01-01T00:00:00Z",
+                    "configured": True,
+                    "disabledSkills": ["implement-feature", "fix-bug"],
+                }
+            ]
+        )
+        # Read back and add bmadDetected, write, re-read
+        data = json.loads(ws.workspace_json.read_text())
+        data["bmadDetected"] = True
+        ws.workspace_json.write_text(json.dumps(data, indent=2))
+
+        reloaded = json.loads(ws.workspace_json.read_text())
+        assert reloaded["bmadDetected"] is True
+        assert reloaded["projects"][0]["disabledSkills"] == [
+            "implement-feature",
+            "fix-bug",
+        ]
+
+    def test_workspace_disabled_skills_empty_means_all_enabled(self, make_workspace):
+        """Empty disabledSkills array means user chose rawgentic for all tasks."""
+        ws = make_workspace(
+            projects=[
+                {
+                    "name": "myproj",
+                    "path": "./projects/myproj",
+                    "active": True,
+                    "lastUsed": "2026-01-01T00:00:00Z",
+                    "configured": True,
+                    "disabledSkills": [],
+                }
+            ]
+        )
+        data = json.loads(ws.workspace_json.read_text())
+        assert data["projects"][0]["disabledSkills"] == []
+
+    def test_workspace_missing_disabled_skills_means_unconfigured(
+        self, make_workspace
+    ):
+        """Missing disabledSkills field means not yet configured."""
+        ws = make_workspace()  # default project, no disabledSkills
+        data = json.loads(ws.workspace_json.read_text())
+        assert "disabledSkills" not in data["projects"][0]
+
+    def test_workspace_with_critique_method(self, make_workspace):
+        """Per-project critiqueMethod field is valid."""
+        ws = make_workspace(
+            projects=[
+                {
+                    "name": "myproj",
+                    "path": "./projects/myproj",
+                    "active": True,
+                    "lastUsed": "2026-01-01T00:00:00Z",
+                    "configured": True,
+                    "disabledSkills": ["implement-feature"],
+                    "critiqueMethod": "bmad-party-mode",
+                }
+            ]
+        )
+        data = json.loads(ws.workspace_json.read_text())
+        assert data["projects"][0]["critiqueMethod"] == "bmad-party-mode"
+
+    def test_workspace_bmad_detected_false(self, make_workspace):
+        """bmadDetected: false is valid (BMAD previously removed)."""
+        ws = make_workspace()
+        data = json.loads(ws.workspace_json.read_text())
+        data["bmadDetected"] = False
+        ws.workspace_json.write_text(json.dumps(data, indent=2))
+
+        reloaded = json.loads(ws.workspace_json.read_text())
+        assert reloaded["bmadDetected"] is False


### PR DESCRIPTION
## Summary

Adds BMAD detection and per-project skill preferences to rawgentic. When `_bmad/` is detected in the workspace root, users choose their preferred tool (rawgentic or BMAD) for each overlapping task, per project.

- **Detection** at both `/rawgentic:switch` (Step 5b) and `/rawgentic:setup` (Step 2b)
- **Per-task choice UI** — pick rawgentic or BMAD for each of 4 overlapping skills + critique method preference
- **Per-project storage** — `disabledSkills` array in each project entry of `.rawgentic_workspace.json`
- **Enforcement** — Step 1b in all 10 workflow skill config-loading preambles
- **Re-configuration** on re-run, removal flow when `_bmad/` is gone
- **CLAUDE.md migration** advisory to remove manual routing table

Closes #41

## Design Decisions

- **Switch as configuration gate**: `/rawgentic:switch` detects unconfigured projects and redirects to setup, ensuring every project has preferences before workflow skills run
- **Three-state semantics**: `disabledSkills` missing = unconfigured, empty `[]` = all rawgentic, populated = selective BMAD
- **Per-project + per-task**: users can mix-and-match (BMAD for features, rawgentic for tests) differently per project
- **Canonical snippet**: identical Step 1b check copied to all 10 skills, enforced by lint tests

## Verification

- 35 new tests (lint + schema), all passing
- 334 total tests passing (11 pre-existing wal-guard failures unchanged)
- Code review: 6 findings (2 Critical, 4 Important) — all resolved

## Quality Gate Summary

- Design critique (Step 4): fast path reflect — confidence 4.5/5
- Plan drift check (Step 6): 0 findings
- Implementation drift check (Step 9): 0 findings, all 13 ACs + 2 amendments covered
- Code review (Step 11): 6 findings, all resolved
- BMAD party-mode review: unanimous ship from 4 agents (Architect, Developer, TEA, Tech Writer)
