### PR TITLE
feat(hooks): session notes size handler (#56)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ Rawgentic includes hooks that run automatically on Claude Code events:
 | `wal-context` | UserPromptSubmit | Injects session context (project, recent WAL activity) |
 | `wal-bind-guard` | PreToolUse | Blocks tool use if session unbound with multiple active projects; blocks cross-project file writes |
 | `wal-guard` | PreToolUse | Blocks dangerous production commands with per-project protection levels (sandbox/standard/strict) |
-| `session-start` | SessionStart | WAL recovery, JSONL archival + enrichment, archive context injection, project reconciliation, security pattern staleness check, resume context |
+| `session-start` | SessionStart | WAL recovery, JSONL archival + enrichment, **notes size handler**, archive context injection, project reconciliation, security pattern staleness check, resume context |
+| `notes-size-handler` | (called by session-start) | Trims session notes exceeding 800 lines to keep last 200; optionally ingests to memorypalace before trimming |
 | `security-guard` | PreToolUse | Blocks writing dangerous patterns (credentials, secrets, eval) to files |
 | `security-guard-check` | SessionStart | Warns if the official security-guidance plugin conflicts |
 
@@ -477,7 +478,7 @@ See `docs/plans/2026-03-06-plugin-overhaul-design.md` for the full design.
 2. **Ambiguity Circuit Breaker** — STOP and ask user when findings conflict
 3. **Finding Auto-Application** — Apply ALL quality gate findings automatically
 4. **Workflow Resumption** — Checkpoint artifacts for mid-workflow recovery
-5. **Session Notes** — Continuous documentation in `claude_docs/session_notes/<project>.md` (auto-created by setup/new-project, auto-registered by WAL hooks). Archived to JSONL with Haiku-extracted insights when >600 lines.
+5. **Session Notes** — Continuous documentation in `claude_docs/session_notes/<project>.md` (auto-created by setup/new-project, auto-registered by WAL hooks). Archived to JSONL with Haiku-extracted insights when >600 lines on startup. During active sessions, the size handler trims notes exceeding 800 lines to the most recent 200 on each context compaction.
 6. **Commit Convention** — `<type>(scope): <description>` matching branch prefix
 7. **Branch from default** — All branches from `origin/<defaultBranch>` (read from config)
 8. **Squash merge** — All PRs use `gh pr merge --squash`

--- a/docs/wal-guide.md
+++ b/docs/wal-guide.md
@@ -101,6 +101,25 @@ runs WAL recovery:
 4. **Report** -- incomplete INTENT entries (no DONE/FAIL) are injected into the
    session context as a recovery notice (up to 20 shown).
 
+## Session Notes Size Handler (`hooks/notes-size-handler.py`)
+
+During long-running sessions, session notes files can grow unbounded because the
+JSONL archival (600-line threshold) only runs on startup. The size handler
+provides a mid-session safety net:
+
+- **Threshold:** 800 lines
+- **Action:** Trim to the most recent 200 lines
+- **Triggers:** session-start on startup events (fallback after archival) and on
+  compact events (primary mid-session path)
+- **Optional ingestion:** Before trimming, the handler attempts to POST the full
+  notes content to the memorypalace server at `localhost:PORT/ingest` (default
+  port 9077, 2s timeout). If the server is unreachable, trimming proceeds
+  without error.
+
+The handler uses `fcntl.flock()` for concurrent safety, atomic writes via
+`tempfile` + `os.replace()`, and validates project names against
+`^[a-zA-Z0-9_-]+$`.
+
 ## WAL Guard (`hooks/wal-guard`)
 
 The WAL Guard is a separate PreToolUse hook (matcher: Bash) that blocks dangerous

--- a/hooks/notes-size-handler.py
+++ b/hooks/notes-size-handler.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Session notes size handler — trims oversized notes files.
+
+Usage: notes-size-handler.py <notes_file> [--session-id ID] [--port PORT]
+
+When a session notes file exceeds THRESHOLD lines (800):
+1. Optionally POST full content to memorypalace /ingest (best-effort)
+2. Trim to keep the most recent KEEP_LINES (200) lines
+3. Write result atomically (tempfile + os.replace)
+
+Called by: session-start Section 2a (on startup and compact events)
+
+Always exits 0 on non-fatal errors. Outputs JSON result to stdout.
+"""
+
+import argparse
+import fcntl
+import json
+import os
+import re
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+THRESHOLD = 800
+KEEP_LINES = 200
+
+# Must match archive-notes.py validation
+PROJECT_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def count_lines(path: Path) -> int:
+    """Count lines in a file without reading entire content into memory."""
+    with open(path) as f:
+        return sum(1 for _ in f)
+
+
+def try_ingest(content: str, project: str, session_id: str, port: int) -> bool:
+    """Best-effort POST to memorypalace /ingest. Returns True on success."""
+    try:
+        payload = json.dumps({
+            "project": project,
+            "session_id": session_id,
+            "notes": content,
+            "source": "size-handler",
+        }).encode("utf-8")
+        req = Request(
+            f"http://localhost:{port}/ingest",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urlopen(req, timeout=2)
+        return True
+    except (URLError, OSError, ValueError):
+        return False
+
+
+def trim_notes(
+    path: Path,
+    session_id: str = "unknown",
+    port: int = 9077,
+) -> dict:
+    """Check and trim a notes file if it exceeds THRESHOLD.
+
+    Uses fcntl.flock for exclusive access during read+write to prevent
+    data loss from concurrent appends by active sessions.
+    """
+    if not path.exists():
+        return {"trimmed": False, "reason": "file_not_found"}
+
+    # Validate project name from filename stem
+    project = path.stem
+    if not PROJECT_NAME_RE.match(project):
+        return {"trimmed": False, "reason": "invalid_project_name"}
+
+    line_count = count_lines(path)
+    if line_count <= THRESHOLD:
+        return {"trimmed": False, "line_count": line_count}
+
+    # Acquire exclusive lock before reading (hold through write)
+    fd = os.open(str(path), os.O_RDWR)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        with os.fdopen(os.dup(fd), "r") as f:
+            content = f.read()
+
+        lines = content.split("\n")
+        # Re-check line count under lock (may have changed)
+        # Use count("\n") for consistency with count_lines() / wc -l
+        line_count = content.count("\n")
+        if line_count <= THRESHOLD:
+            return {"trimmed": False, "line_count": line_count}
+
+        # Try memorypalace ingestion (best-effort, before trim)
+        ingested = try_ingest(content, project, session_id, port)
+
+        # Keep last KEEP_LINES
+        kept = lines[-KEEP_LINES:]
+
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        header = (
+            f"# Session Notes -- {project}\n"
+            f"\n"
+            f"<!-- Trimmed from {line_count} lines at {ts} -->\n"
+            f"\n"
+        )
+        new_content = header + "\n".join(kept)
+        if not new_content.endswith("\n"):
+            new_content += "\n"
+
+        # Atomic write: tempfile in same directory + os.replace
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=str(path.parent), suffix=".tmp"
+        )
+        try:
+            with os.fdopen(tmp_fd, "w") as f:
+                f.write(new_content)
+            os.replace(tmp_path, str(path))
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+        return {
+            "trimmed": True,
+            "line_count": line_count,
+            "kept_lines": KEEP_LINES,
+            "ingested": ingested,
+            "project": project,
+        }
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Trim oversized session notes")
+    parser.add_argument("notes_file", help="Path to the session notes .md file")
+    parser.add_argument("--session-id", default="unknown", help="Current session ID")
+    parser.add_argument("--port", type=int, default=9077, help="Memorypalace server port")
+    args = parser.parse_args()
+
+    try:
+        result = trim_notes(
+            Path(args.notes_file),
+            session_id=args.session_id,
+            port=args.port,
+        )
+        print(json.dumps(result))
+    except Exception:
+        # Guarantee exit 0 on all non-fatal errors
+        print(json.dumps({"trimmed": False, "reason": "error"}))
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/notes-size-handler.py
+++ b/hooks/notes-size-handler.py
@@ -55,7 +55,7 @@ def try_ingest(content: str, project: str, session_id: str, port: int) -> bool:
         )
         urlopen(req, timeout=2)
         return True
-    except (URLError, OSError, ValueError):
+    except Exception:
         return False
 
 
@@ -85,13 +85,13 @@ def trim_notes(
     fd = os.open(str(path), os.O_RDWR)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
+        # dup() so the with-block close doesn't release the original fd's lock
         with os.fdopen(os.dup(fd), "r") as f:
             content = f.read()
 
-        lines = content.split("\n")
+        lines = content.splitlines()
         # Re-check line count under lock (may have changed)
-        # Use count("\n") for consistency with count_lines() / wc -l
-        line_count = content.count("\n")
+        line_count = len(lines)
         if line_count <= THRESHOLD:
             return {"trimmed": False, "line_count": line_count}
 

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -468,7 +468,7 @@ _do_size_handler() {
     for notes_file in "$NOTES_DIR"/*.md; do
         [ -f "$notes_file" ] || continue
         python3 "$SCRIPT_DIR/notes-size-handler.py" "$notes_file" \
-            --session-id "$SESSION_ID" 2>/dev/null || continue
+            --session-id "$SESSION_ID" >/dev/null 2>&1 || continue
     done
 }
 _do_size_handler 2>/dev/null || true

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -449,6 +449,31 @@ print(count)
 _do_archival 2>/dev/null || true
 
 # =========================================================================
+# SECTION 2a: Notes Size Handler (startup + compact events)
+# =========================================================================
+# Trims session notes exceeding 800 lines to keep the most recent 200.
+# Runs on compact (mid-session) as the primary safety net, and on startup
+# as a fallback after archival. On startup, Section 2 archival (600-line
+# threshold) typically resets files first, so this rarely triggers.
+#
+# DESIGN ASSUMPTION: Section 2 and 2a run sequentially in single-threaded
+# bash. Do NOT parallelize these sections without adding file locking
+# coordination between archive-notes.py and notes-size-handler.py.
+_do_size_handler() {
+    [ "$EVENT_TYPE" = "startup" ] || [ "$EVENT_TYPE" = "compact" ] || return 0
+
+    NOTES_DIR="$CLAUDE_DOCS/session_notes"
+    [ -d "$NOTES_DIR" ] || return 0
+
+    for notes_file in "$NOTES_DIR"/*.md; do
+        [ -f "$notes_file" ] || continue
+        python3 "$SCRIPT_DIR/notes-size-handler.py" "$notes_file" \
+            --session-id "$SESSION_ID" 2>/dev/null || continue
+    done
+}
+_do_size_handler 2>/dev/null || true
+
+# =========================================================================
 # SECTION 2b: Archive Context Injection (startup/resume, bound sessions)
 # =========================================================================
 _do_archive_context() {

--- a/tests/hooks/test_notes_size_handler.py
+++ b/tests/hooks/test_notes_size_handler.py
@@ -1,0 +1,294 @@
+"""Tests for notes-size-handler.py — session notes size handler.
+
+Tests the standalone Python script that trims oversized session notes files
+and optionally ingests content to the memorypalace server before trimming.
+Uses subprocess invocation to match the hook testing pattern.
+"""
+import json
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from tests.hooks.conftest import HOOKS_DIR
+
+HANDLER_SCRIPT = HOOKS_DIR / "notes-size-handler.py"
+
+
+def _run_handler(
+    notes_file: Path,
+    *,
+    session_id: str = "test-session",
+    port: int | None = None,
+    timeout: int = 10,
+) -> tuple[str, str, int]:
+    """Run notes-size-handler.py as a subprocess."""
+    cmd = ["python3", str(HANDLER_SCRIPT), str(notes_file), "--session-id", session_id]
+    if port is not None:
+        cmd.extend(["--port", str(port)])
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def _make_notes(path: Path, project: str, num_lines: int) -> Path:
+    """Create a notes file with the given number of lines."""
+    notes_file = path / f"{project}.md"
+    header = f"# Session Notes -- {project}\n"
+    content = header + "".join(f"line {i}\n" for i in range(1, num_lines))
+    notes_file.write_text(content)
+    return notes_file
+
+
+class TestNoOp:
+    """Tests for cases where no trimming should occur."""
+
+    def test_under_threshold_no_trim(self, tmp_path):
+        """Notes under 800 lines should not be trimmed."""
+        notes_file = _make_notes(tmp_path, "testproj", 500)
+        original = notes_file.read_text()
+
+        stdout, stderr, rc = _run_handler(notes_file)
+        assert rc == 0
+
+        result = json.loads(stdout.strip())
+        assert result["trimmed"] is False
+
+        # File unchanged
+        assert notes_file.read_text() == original
+
+    def test_exactly_800_lines_no_trim(self, tmp_path):
+        """Exactly 800 lines should NOT trigger trim (threshold is >800)."""
+        notes_file = _make_notes(tmp_path, "testproj", 800)
+        original = notes_file.read_text()
+
+        stdout, stderr, rc = _run_handler(notes_file)
+        assert rc == 0
+
+        result = json.loads(stdout.strip())
+        assert result["trimmed"] is False
+        assert notes_file.read_text() == original
+
+    def test_nonexistent_file_exits_zero(self, tmp_path):
+        """Missing file should exit 0 with trimmed=false."""
+        fake_file = tmp_path / "nonexistent.md"
+
+        stdout, stderr, rc = _run_handler(fake_file)
+        assert rc == 0
+
+        result = json.loads(stdout.strip())
+        assert result["trimmed"] is False
+
+    def test_empty_file_no_trim(self, tmp_path):
+        """Empty file should not be trimmed."""
+        notes_file = tmp_path / "testproj.md"
+        notes_file.write_text("")
+
+        stdout, stderr, rc = _run_handler(notes_file)
+        assert rc == 0
+
+        result = json.loads(stdout.strip())
+        assert result["trimmed"] is False
+
+
+class TestTrimming:
+    """Tests for the trimming behavior."""
+
+    def test_trim_keeps_last_200_lines(self, tmp_path):
+        """Notes exceeding 800 lines should keep the last 200 lines."""
+        notes_file = _make_notes(tmp_path, "testproj", 1000)
+
+        stdout, stderr, rc = _run_handler(notes_file)
+        assert rc == 0
+
+        result = json.loads(stdout.strip())
+        assert result["trimmed"] is True
+        assert result["line_count"] == 1000
+        assert result["kept_lines"] == 200
+        assert result["project"] == "testproj"
+
+        # Verify content: last 200 lines preserved
+        content = notes_file.read_text()
+        lines = content.split("\n")
+        # Should contain the header and trim marker, then the last 200 original lines
+        assert "# Session Notes -- testproj" in content
+        assert "Trimmed from 1000 lines" in content
+        # The last line of original was "line 999"
+        assert "line 999" in content
+        # The first lines (like "line 1") should be gone
+        assert "line 1\n" not in content
+
+    def test_trim_at_801_lines(self, tmp_path):
+        """801 lines (just over threshold) should trigger trim."""
+        notes_file = _make_notes(tmp_path, "testproj", 801)
+
+        stdout, stderr, rc = _run_handler(notes_file)
+        assert rc == 0
+
+        result = json.loads(stdout.strip())
+        assert result["trimmed"] is True
+        assert result["line_count"] == 801
+
+    def test_trim_header_format(self, tmp_path):
+        """Trimmed file should have proper header with project name and timestamp."""
+        notes_file = _make_notes(tmp_path, "myproject", 900)
+
+        stdout, _, _ = _run_handler(notes_file)
+        result = json.loads(stdout.strip())
+        assert result["trimmed"] is True
+
+        content = notes_file.read_text()
+        assert content.startswith("# Session Notes -- myproject\n")
+        assert "<!-- Trimmed from 900 lines at " in content
+        # Timestamp should be ISO format
+        assert "T" in content.split("Trimmed from")[1]
+
+    def test_atomic_write_no_partial(self, tmp_path):
+        """Verify the original file is intact if we read it immediately."""
+        notes_file = _make_notes(tmp_path, "testproj", 1000)
+
+        _run_handler(notes_file)
+
+        # File should be valid (not empty, not partial)
+        content = notes_file.read_text()
+        assert len(content) > 0
+        assert content.startswith("# Session Notes")
+        # No .tmp files left behind
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert len(tmp_files) == 0
+
+
+class TestValidation:
+    """Tests for path and project name validation."""
+
+    def test_invalid_project_name_rejected(self, tmp_path):
+        """Filenames with invalid characters should be rejected."""
+        bad_file = tmp_path / "../../etc/passwd.md"
+        # Create a valid file with a traversal-style name
+        bad_dir = tmp_path / ".." / ".." / "etc"
+        bad_dir.mkdir(parents=True, exist_ok=True)
+        bad_file_resolved = bad_dir / "passwd.md"
+        bad_file_resolved.write_text("x\n" * 900)
+
+        stdout, stderr, rc = _run_handler(bad_file_resolved)
+        # Should exit 0 but not trim (invalid project name or path)
+        assert rc == 0
+
+    def test_valid_project_names_accepted(self, tmp_path):
+        """Standard project names should be accepted."""
+        for name in ["testproj", "my-project", "project_123", "CamelCase"]:
+            notes_file = _make_notes(tmp_path, name, 900)
+            stdout, _, rc = _run_handler(notes_file)
+            assert rc == 0
+            result = json.loads(stdout.strip())
+            assert result["trimmed"] is True, f"Failed for project name: {name}"
+
+
+class TestMemorypalaceIngestion:
+    """Tests for the optional memorypalace server POST."""
+
+    def test_no_server_trims_anyway(self, tmp_path):
+        """When memorypalace is unreachable, trim proceeds without error."""
+        notes_file = _make_notes(tmp_path, "testproj", 900)
+
+        # Port 1 is almost certainly not listening
+        stdout, stderr, rc = _run_handler(notes_file, port=1)
+        assert rc == 0
+
+        result = json.loads(stdout.strip())
+        assert result["trimmed"] is True
+        assert result["ingested"] is False
+
+    def test_server_receives_content(self, tmp_path):
+        """When memorypalace is reachable, full content is POSTed before trim."""
+        received = {}
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                received["body"] = json.loads(body)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"ok": true}')
+
+            def log_message(self, *args):
+                pass  # suppress logging
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.handle_request, daemon=True)
+        thread.start()
+
+        try:
+            notes_file = _make_notes(tmp_path, "testproj", 900)
+            original_content = notes_file.read_text()
+
+            stdout, _, rc = _run_handler(notes_file, port=port, session_id="sess-123")
+            assert rc == 0
+
+            result = json.loads(stdout.strip())
+            assert result["trimmed"] is True
+            assert result["ingested"] is True
+
+            # Verify the POST payload
+            assert "body" in received
+            assert received["body"]["project"] == "testproj"
+            assert received["body"]["session_id"] == "sess-123"
+            assert received["body"]["source"] == "size-handler"
+            # Full content was sent (not trimmed content)
+            assert "line 1" in received["body"]["notes"]
+            assert "line 899" in received["body"]["notes"]
+        finally:
+            server.server_close()
+            thread.join(timeout=3)
+
+    def test_no_server_call_under_threshold(self, tmp_path):
+        """Under threshold, no HTTP call should be made."""
+        received = {"called": False}
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                received["called"] = True
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'{}')
+
+            def log_message(self, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.handle_request, daemon=True)
+        thread.start()
+
+        try:
+            notes_file = _make_notes(tmp_path, "testproj", 500)
+            _run_handler(notes_file, port=port)
+            assert received["called"] is False
+        finally:
+            server.server_close()
+            thread.join(timeout=3)
+
+
+class TestExitBehavior:
+    """Tests that the script always exits 0 on non-fatal errors."""
+
+    def test_permission_error_exits_zero(self, tmp_path):
+        """If the file can't be read, exit 0 gracefully."""
+        notes_file = tmp_path / "testproj.md"
+        notes_file.write_text("x\n" * 900)
+        notes_file.chmod(0o000)
+
+        try:
+            stdout, stderr, rc = _run_handler(notes_file)
+            assert rc == 0
+        finally:
+            notes_file.chmod(0o644)

--- a/tests/hooks/test_session_start.py
+++ b/tests/hooks/test_session_start.py
@@ -441,3 +441,82 @@ class TestClaudeDocsMigration:
         assert not (fake_home / "claude_docs").exists()
         ws_data = json.loads(ws.workspace_json.read_text())
         assert "claudeDocsPath" not in ws_data
+
+
+class TestSizeHandler:
+    """Tests for Section 2a: session notes size handler integration."""
+
+    def test_trims_oversized_notes_on_startup(self, make_workspace):
+        """Notes exceeding 800 lines should be trimmed on startup."""
+        large_content = "# Notes\n" + "".join(f"line {i}\n" for i in range(1, 850))
+        ws = make_workspace(
+            session_notes={"testproj": large_content},
+            registry_entries=[{"session_id": "test-sess", "project": "testproj",
+                               "project_path": "./projects/testproj"}],
+        )
+
+        _run_session_start(ws.root, event_type="startup")
+
+        notes_file = ws.notes_dir / "testproj.md"
+        content = notes_file.read_text()
+        lines = content.strip().split("\n")
+        # After archival resets + size handler: archival fires first at 600+,
+        # resetting to ~1 line, so size handler won't trigger.
+        # But if archival fails or is bypassed, size handler catches it.
+        # For this test, notes are 850 lines > 600, archival runs first.
+        # After archival: file is reset to 1-line header.
+        assert len(lines) < 600
+
+    def test_trims_oversized_notes_on_compact(self, make_workspace):
+        """Notes exceeding 800 lines should be trimmed on compact events."""
+        # 850 lines — above the 800-line threshold
+        large_content = "# Notes\n" + "".join(f"line {i}\n" for i in range(1, 900))
+        ws = make_workspace(
+            session_notes={"testproj": large_content},
+            registry_entries=[{"session_id": "test-sess", "project": "testproj",
+                               "project_path": "./projects/testproj"}],
+        )
+
+        _run_session_start(ws.root, event_type="compact")
+
+        notes_file = ws.notes_dir / "testproj.md"
+        content = notes_file.read_text()
+        # On compact: archival does NOT run, so size handler handles it
+        # Should be trimmed to ~200 lines + header
+        lines = content.strip().split("\n")
+        assert len(lines) <= 210  # 200 kept + header + trim marker
+        assert "Trimmed from" in content
+        assert "line 899" in content  # last line preserved
+        assert "line 1\n" not in content  # early lines removed
+
+    def test_no_trim_on_compact_under_threshold(self, make_workspace):
+        """Notes under 800 lines should not be trimmed on compact."""
+        small_content = "# Notes\n" + "".join(f"line {i}\n" for i in range(1, 500))
+        ws = make_workspace(
+            session_notes={"testproj": small_content},
+            registry_entries=[{"session_id": "test-sess", "project": "testproj",
+                               "project_path": "./projects/testproj"}],
+        )
+
+        _run_session_start(ws.root, event_type="compact")
+
+        notes_file = ws.notes_dir / "testproj.md"
+        content = notes_file.read_text()
+        # Unchanged
+        assert content == small_content
+
+    def test_no_trim_on_resume(self, make_workspace):
+        """Size handler should NOT run on resume events."""
+        large_content = "# Notes\n" + "".join(f"line {i}\n" for i in range(1, 900))
+        ws = make_workspace(
+            session_notes={"testproj": large_content},
+            registry_entries=[{"session_id": "test-sess", "project": "testproj",
+                               "project_path": "./projects/testproj"}],
+        )
+
+        _run_session_start(ws.root, event_type="resume")
+
+        notes_file = ws.notes_dir / "testproj.md"
+        content = notes_file.read_text()
+        # Should be untrimmed (resume doesn't trigger size handler)
+        assert content == large_content


### PR DESCRIPTION
## Summary

Implements Story 1.2: session notes size handler that prevents notes files from growing unbounded during long-running sessions.

- **New:** `hooks/notes-size-handler.py` — trims session notes exceeding 800 lines to keep the most recent 200
- **Modified:** `hooks/session-start` — Section 2a calls size handler on startup and compact events
- **Optional memorypalace ingestion:** POSTs full notes to `localhost:9077/ingest` before trimming (best-effort, 2s timeout)

Closes #56

## Design Decisions

- **Python** (not bash) for consistency with `archive-notes.py`, testability, and atomic writes
- **`fcntl.flock(LOCK_EX)`** on the notes file prevents concurrent write data loss
- **`splitlines()`** for line counting (avoids `split("\n")` off-by-one from trailing empty strings)
- **Broad exception catch** in `try_ingest()` ensures trimming always proceeds regardless of HTTP error type
- **`>/dev/null 2>&1`** for subprocess call prevents stdout pollution of hook JSON output
- **Complementary to existing archival:** archival (600 lines, startup only) handles session boundaries; size handler (800 lines, startup + compact) handles mid-session growth

## Verification

- 14 unit tests for `notes-size-handler.py` (threshold, trimming, validation, HTTP, errors)
- 4 integration tests in `test_session_start.py` (startup, compact, under-threshold, resume)
- 304 total tests pass (excluding pre-existing wal-guard + headless failures)

## Quality Gate Summary

- Design critique (Step 4): 3-judge, 2H/5M/2L — all resolved (flock, path validation, server probe)
- Code review (Step 11): 3-agent, 1H/2M — fixed (splitlines, broad catch, dup comment)