### PR TITLE
chore: remove dead archive-query blocks from skills (#57)

### DIFF
--- a/skills/fix-bug/SKILL.md
+++ b/skills/fix-bug/SKILL.md
@@ -294,15 +294,6 @@ Wait for user confirmation before proceeding to Step 2. **[Headless: AUTO-RESOLV
    - `complex_bug`: 10+ files, cross-service, unclear root cause → **prompt upgrade to WF2**
 5. **Related issues check:** `gh issue list --repo capabilities.repo --search "<keywords>" --limit 10`
 
-<archive-query>
-**Archive Context (optional):** If `claude_docs/session_notes/archive/` exists for this project:
-1. Derive 2-3 keywords from the bug report (error messages, affected component names)
-2. Run: `python3 hooks/query-archive.py claude_docs/session_notes/archive/ --keyword "<term>" --project "<project>" --limit 5 --format brief`
-3. Check for: prior bugs in the same area, recurring error patterns, previous fixes that may have regressed
-4. If results found, note relevant patterns in the bug analysis
-5. If no archive exists or query returns empty, skip silently — do not mention the absence
-</archive-query>
-
 ### Output
 
 Bug analysis (internal working artifact):

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -458,15 +458,6 @@ This enables workflow resumption if context is lost.
    - If `standard_feature` AND `is_wf1_created`: `fast_path_eligible = true`
    - Otherwise: `fast_path_eligible = false`
 
-<archive-query>
-**Archive Context (optional):** If `claude_docs/session_notes/archive/` exists for this project:
-1. Derive 2-3 keywords from the issue's affected components and scope
-2. Run: `python3 hooks/query-archive.py claude_docs/session_notes/archive/ --keyword "<term>" --project "<project>" --limit 5 --format brief`
-3. Check for: prior design decisions about affected components, architectural patterns, lessons learned
-4. If results found, incorporate relevant context into the codebase analysis
-5. If no archive exists or query returns empty, skip silently — do not mention the absence
-</archive-query>
-
 ### Output
 Codebase analysis with complexity classification, fast path eligibility, and (for infrastructure projects) live environment probe results. Do NOT present to user — feeds into Step 3.
 

--- a/skills/incident/SKILL.md
+++ b/skills/incident/SKILL.md
@@ -197,15 +197,6 @@ For each service in `config.services[]`:
 
 Log in session notes: `### WF11 Step 2: Rapid Diagnosis — DONE (fast-path|full)`
 
-<archive-query>
-**Archive Context (optional):** If `claude_docs/session_notes/archive/` exists for this project:
-1. Derive 2-3 keywords from the incident symptoms (service names, error codes, affected endpoints)
-2. Run: `python3 hooks/query-archive.py claude_docs/session_notes/archive/ --keyword "<term>" --project "<project>" --limit 5 --format brief`
-3. Check for: prior incidents with same service/symptoms, known failure modes, previous mitigation steps
-4. If results found, note relevant patterns in the diagnosis
-5. If no archive exists or query returns empty, skip silently — do not mention the absence
-</archive-query>
-
 ### Failure Modes
 
 - Can't SSH to server → check if server is down entirely (ping hosts from `config.infrastructure.hosts[]`, then check hosting console)

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -165,15 +165,6 @@ Wait for user confirmation before proceeding to Step 2.
 5. **Category classification:** Classify as Rename, Extract, Restructure, or Simplify.
 6. **Risk assessment:** Rate risk (low/medium/high) based on coupling and test coverage.
 
-<archive-query>
-**Archive Context (optional):** If `claude_docs/session_notes/archive/` exists for this project:
-1. Derive 2-3 keywords from the refactoring scope (component names, pattern names)
-2. Run: `python3 hooks/query-archive.py claude_docs/session_notes/archive/ --keyword "<term>" --project "<project>" --limit 5 --format brief`
-3. Check for: prior refactoring attempts in the same area, architectural decisions that constrain the refactoring, past issues encountered
-4. If results found, note relevant patterns in the scope analysis
-5. If no archive exists or query returns empty, skip silently — do not mention the absence
-</archive-query>
-
 ### Output
 
 Analysis (internal): { symbols, reference_graph, existing_tests, test_gaps, category, risk, coupling_score }
@@ -490,7 +481,7 @@ WF4 complete.
 ### Failure Modes
 
 - GitHub issue close fails → verify issue number and repo; may already be closed
-- Session notes file missing or archived → create new file or check for archived versions
+- Session notes file missing → create new file
 
 ---
 

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -405,7 +405,7 @@ WF8 complete.
 ### Failure Modes
 
 - GitHub issue close fails -> verify issue number and repo; may already be closed
-- Session notes file missing or archived -> create new file (archives are in JSONL format at claude_docs/session_notes/archive/)
+- Session notes file missing -> create new file
 
 ---
 

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -457,7 +457,7 @@ Completion summary. WF7 terminates.
 ### Failure Modes
 
 - GitHub issue close fails → verify issue number and repo; may already be closed
-- Session notes file missing or archived → create new file or check for archived versions
+- Session notes file missing → create new file
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #60 — removes dead `<archive-query>` blocks and stale archive references from 6 skill files after `query-archive.py` was deleted.

- Remove `<archive-query>` blocks from: implement-feature, fix-bug, refactor, incident
- Clean up "or archived" failure mode text in: update-docs, refactor, update-deps

Net: -36 lines of dead code across 6 skill markdown files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)