### PR TITLE
fix(marketplace): restructure manifest to fix Sync Failed install error

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,20 +1,19 @@
 {
   "name": "rawgentic",
-  "description": "12 SDLC workflow skills for Claude Code: workspace management, project setup, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, and incident response.",
   "owner": {
     "name": "3D-Stories",
     "url": "https://github.com/3D-Stories"
   },
+  "metadata": {
+    "description": "3D-Stories Claude Code plugins",
+    "version": "1.0.0"
+  },
   "plugins": [
     {
       "name": "rawgentic",
-      "description": "12 SDLC workflow skills for Claude Code: workspace management, project setup, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, and incident response.",
-      "version": "2.3.1",
+      "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
       "source": "./",
-      "author": {
-        "name": "3D-Stories",
-        "url": "https://github.com/3D-Stories"
-      }
+      "strict": true
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",


### PR DESCRIPTION
## Summary

- Restructure `.claude-plugin/marketplace.json` to match the proven pattern from `presentation-builder` (commit history shows they hit the same class of bug).
- Remove `version` from the marketplace plugin entry — drift source eliminated. `plugin.json` is now the single source-of-truth for the plugin's version (was: marketplace=`2.3.1` vs plugin=`2.22.0`, install rejected with "Sync Failed").
- Add `"strict": true` on the plugin entry — tells the marketplace validator to enforce manifest correctness.
- Move description/version into a top-level `metadata` block; drop redundant top-level `description` and plugin-entry `author` (covered by `metadata.description` and top-level `owner`).
- Bump `plugin.json` 2.22.0 → 2.22.1 (patch — per project conventions for fixes).

## Test plan

- [x] Manifest validates as JSON (`python3 -m json.tool < .claude-plugin/marketplace.json`).
- [ ] Install plugin in Claude org STARS marketplace — verify "Sync Failed" no longer appears.

## Notes

- `pytest tests/ -v` shows 11 pre-existing failures in `tests/hooks/test_wal_guard.py` (production-blocking patterns). These exist on `main` independent of this change — only `.claude-plugin/*.json` files modified here. Worth a separate issue/PR to address.
- After merge, pull `main` locally and the dual-push to STARS-private will sync the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)