### PR TITLE
fix(marketplace): add skills whitelist to prevent duplicate-name validation error

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,24 @@
       "name": "rawgentic",
       "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
       "source": "./",
-      "strict": true
+      "strict": true,
+      "skills": [
+        "./skills/add-exception",
+        "./skills/create-issue",
+        "./skills/create-tests",
+        "./skills/fix-bug",
+        "./skills/implement-feature",
+        "./skills/incident",
+        "./skills/new-project",
+        "./skills/optimize-perf",
+        "./skills/refactor",
+        "./skills/security-audit",
+        "./skills/setup",
+        "./skills/switch",
+        "./skills/sync-security-patterns",
+        "./skills/update-deps",
+        "./skills/update-docs"
+      ]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",


### PR DESCRIPTION
## Summary

Marketplace install was failing with `sync_status: failed_content` after the v2.22.1 manifest restructure (#62). Server-reported error:

> Duplicate skill name 'rawgenticsetup' found in 'skills/setup-workspace/skill-snapshot' and 'skills/setup'

## Root cause

The strict marketplace validator walks `skills/` recursively. Both `skills/setup/SKILL.md` (production) and `skills/setup-workspace/skill-snapshot/SKILL.md` (a versioned dev snapshot used for internal skill iteration workflows) declare `name: rawgentic:setup`, normalizing to the same `rawgenticsetup` slug.

## Fix

Add an explicit `skills` array to the marketplace.json plugin entry, listing only the 15 production skills. The `*-workspace/` directories (with `evals/`, `iteration-1/`, `skill-snapshot/`) remain in the repo for development use but are excluded from the marketplace install.

This matches the pattern used successfully by `3D-Stories/presentation-builder` (which also uses `strict: true` and an explicit skills whitelist).

## Test plan

- [x] Manifest validates as JSON.
- [ ] Reinstall plugin in Claude org STARS marketplace from `STARSAirAmbulance/rawgentic-private` → `sync_status: synced` (was `failed_content`).
- [ ] Confirm all 15 production skills appear available after sync.

## Notes

- Bump plugin.json 2.22.1 → 2.22.2 (patch — fix).
- Pre-existing wal-guard test failures (#63) still apply; only `.claude-plugin/*.json` modified here.
- After merge, propagate to STARS-private with: \`git checkout main && git pull && git push origin main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)