### PR TITLE
docs: add marketplace validation rules and update test count

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -503,6 +503,9 @@ See `docs/plans/2026-03-06-plugin-overhaul-design.md` for the full design.
 | Cross-project write denied       | File path is in a different project            | Switch first with `/rawgentic:switch <target>`, or ask user   |
 | Hooks fail after `cd` in Bash    | CWD drifted to project subdir, workspace file not found | Fixed in v2.5.3 — hooks now traverse up to 5 levels |
 | Hook errors after plugin update  | Session still references old cache path        | Exit session, reinstall plugin, start new session              |
+| Marketplace "Sync Failed" (no detail) | Stale server cache or rate limit            | Remove plugin from org marketplace, wait 60s, re-add          |
+| Marketplace `failed_content` with "Duplicate skill name" | Two `SKILL.md` files under `skills/` declare the same `name:` | Rename dev snapshots to `SKILL.snapshot.md` (validator only finds `SKILL.md`) |
+| Marketplace version conflict     | `marketplace.json` plugin entry has a `version` field that differs from `plugin.json` | Remove `version` from plugin entry; use `metadata.version` at top level instead |
 
 ---
 
@@ -542,11 +545,13 @@ pytest tests/ -v
 pytest tests/hooks/test_wal_guard.py -v
 ```
 
-**306 tests** across 13 test modules covering all hooks. See [docs/testing.md](docs/testing.md) for full details.
+**385 tests** across 13 test modules covering all hooks. See [docs/testing.md](docs/testing.md) for full details.
 
 **CI:** GitHub Actions runs `pytest tests/ -v` on all PRs to `main` (`.github/workflows/ci.yml`). SDLC workflows also run tests automatically when `.rawgentic.json` has a `testing` section configured.
 
 Skills are tested via the `/skill-creator` eval pipeline (14/15 skills have evals.json).
+
+**Workspace directories:** Some skills have a corresponding `*-workspace/` directory (e.g., `skills/setup-workspace/`) used for internal skill iteration and evaluation. These contain `evals/`, `iteration-N/`, and `skill-snapshot/` subdirectories. They are **excluded from marketplace installs** via the `skills` whitelist in `marketplace.json`. If you add a new workspace directory, never name a file `SKILL.md` inside it — the marketplace validator scans for that filename recursively and will reject duplicates.
 
 ---
 

--- a/docs/skill-development.md
+++ b/docs/skill-development.md
@@ -81,9 +81,12 @@ pass rate vs 72% without (+28% delta).
    frontmatter fields (`name`, `description`, `argument-hint`) and the full
    prompt body. The `name` field must use the `rawgentic:<name>` prefix.
 
-2. **Registration is automatic.** Claude Code discovers `SKILL.md` files under
-   `skills/` at plugin install time. No edits to `plugin.json` or any
-   registry file are needed.
+2. **Add to the marketplace skills whitelist.** Edit
+   `.claude-plugin/marketplace.json` and add `"./skills/<name>"` to the
+   `skills` array in the plugin entry. The marketplace uses this list to
+   control which skills are available for org installs. **Skills not in this
+   list are invisible to the marketplace but still discoverable by local
+   installs.**
 
 3. **Reinstall the plugin** after adding the file (see the update workflow in
    the workspace `CLAUDE.md`). Existing sessions will not pick up new skills
@@ -95,3 +98,28 @@ pass rate vs 72% without (+28% delta).
    evaluation harness will populate `with_skill/` and `without_skill/`
    subdirectories. This is recommended for SDLC workflow skills but not
    required for workspace-management skills like `setup` or `switch`.
+
+## Marketplace Manifest Validation
+
+When the plugin is installed via a Claude org marketplace (syncing from a
+private GitHub repo), the marketplace validator applies strict rules:
+
+1. **No duplicate skill names.** The validator walks ALL `skills/**/SKILL.md`
+   files recursively, regardless of the `skills` whitelist. Two files declaring
+   the same `name:` in frontmatter cause `sync_status: failed_content`. Names
+   are compared after normalization (stripping colons and hyphens), so
+   `rawgentic:setup` and `rawgentic-setup` would collide.
+
+2. **Workspace directories must not contain `SKILL.md`.** Dev snapshots in
+   `*-workspace/skill-snapshot/` should use a different filename like
+   `SKILL.snapshot.md`. The validator only searches for files named exactly
+   `SKILL.md`.
+
+3. **No version field on plugin entries.** If `marketplace.json` includes a
+   `version` on the plugin entry and it differs from `plugin.json`, the
+   validator rejects the install. Keep version only in `plugin.json` (the
+   single source-of-truth) and optionally in `metadata.version` at the
+   marketplace top level.
+
+4. **Use `strict: true`.** Required for org marketplace installs. Without it,
+   validation errors may be silently swallowed, producing confusing failures.


### PR DESCRIPTION
## Summary

- Update README test count from 306 to 385 (actual per `pytest --co`)
- Add 3 marketplace troubleshooting entries for the install issues discovered in #62/#64/#65
- Document `*-workspace` directories as dev scaffolding with the `SKILL.md` naming constraint
- Add "Marketplace Manifest Validation" section to `docs/skill-development.md` covering:
  - Duplicate name detection (validator walks all `SKILL.md` files recursively, ignoring whitelist)
  - Workspace directory rules (rename snapshots to `SKILL.snapshot.md`)
  - Version field placement (never on plugin entry, only in `plugin.json` + `metadata.version`)
  - `strict: true` requirement for org marketplace installs
- Update "Adding a New Skill" checklist to include marketplace whitelist step

## Test plan

- [x] No code changes — docs only + version bump
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)