### PR TITLE
fix(ci): add persist-credentials and repo guard to mirror workflow

### DIFF
--- a/.github/workflows/mirror-to-stars.yml
+++ b/.github/workflows/mirror-to-stars.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   mirror:
+    if: github.repository == '3D-Stories/rawgentic'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Two fixes: `persist-credentials: false` (prevents checkout from hijacking auth) and `if: github.repository` guard (prevents workflow running on the mirrored STARS-private side).