### PR TITLE
docs: refresh BMAD refs for v6.6.0 + fix wal_guard test isolation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.22.4",
+  "version": "2.22.5",
   "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -559,6 +559,8 @@ Skills are tested via the `/skill-creator` eval pipeline (14/15 skills have eval
 
 If you also use the [BMAD Method](https://github.com/bmad-method/bmad-method), the two plugins overlap in implementation, code review, testing, and documentation. Without explicit routing, Claude may pick the wrong skill.
 
+**Compatibility:** Tested against **BMAD v6.6.0** (core/bmm 6.6.0, TEA 1.15.1). Rawgentic references the `bmad-dev-story` skill, `bmad-party-mode` skill, the `bmad-tea` agent + `bmad-testarch-*` workflows, and the `tech-writer` (Paige) agent — all in informational text only, never invoked directly. Loose coupling has held across BMAD upgrades 6.2 → 6.3 → 6.6; if upstream renames any of these, rawgentic continues to function but its help messages may show stale names.
+
 **Automatic detection:** When you run `/rawgentic:setup` or `/rawgentic:switch`, rawgentic checks for a `_bmad/` directory in your workspace root. If found, it asks you to choose your preferred tool (rawgentic or BMAD) for each overlapping task — per project. Preferences are stored in `.rawgentic_workspace.json` and enforced automatically. See [`docs/config-reference.md`](docs/config-reference.md#bmad-integration) for details.
 
 **Manual routing (legacy):** A CLAUDE.md routing snippet is also available at [`templates/CLAUDE-bmad-routing.md`](templates/CLAUDE-bmad-routing.md). The automated detection above replaces this approach.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -265,7 +265,7 @@ and defer to BMAD equivalents on a per-project basis.
 |-----------------|-----------------|
 | `implement-feature` | `bmad-dev-story` |
 | `fix-bug` | `bmad-dev-story` |
-| `create-tests` | BMAD TEA module (`bmad-tea-*`) |
+| `create-tests` | BMAD TEA module (`bmad-tea` agent / `bmad-testarch-*` workflows) |
 | `update-docs` | BMAD tech-writer agent |
 
 Skills not in this table (create-issue, refactor, security-audit, incident, update-deps,

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -39,7 +39,7 @@ Before executing any workflow steps, load the project configuration:
    - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
      - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
        "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
      - Otherwise, tell user:
        "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:

--- a/skills/create-tests/SKILL.md
+++ b/skills/create-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rawgentic:create-tests
-description: Create or improve a project's test suite using the WF12 14-step workflow with brainstorming-driven test strategy, context7 framework docs lookup, test harness generation, coverage gap analysis, and verified test execution. Invoke with /create-tests optionally followed by a specific file or module path. DO NOT use this skill if the user has BMAD's TEA module installed — use the TEA test workflows (bmad-tea-*) instead. Only trigger when the user explicitly invokes /create-tests or /rawgentic:create-tests, or is working in a rawgentic-only project without BMAD.
+description: Create or improve a project's test suite using the WF12 14-step workflow with brainstorming-driven test strategy, context7 framework docs lookup, test harness generation, coverage gap analysis, and verified test execution. Invoke with /create-tests optionally followed by a specific file or module path. DO NOT use this skill if the user has BMAD's TEA module installed — use the TEA test workflows (bmad-testarch-*) instead. Only trigger when the user explicitly invokes /create-tests or /rawgentic:create-tests, or is working in a rawgentic-only project without BMAD.
 argument-hint: Optional file/module path (e.g., "src/auth/") or omit for whole project
 ---
 
@@ -41,7 +41,7 @@ Before executing any workflow steps, load the project configuration:
    - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
      - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
        "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
      - Otherwise, tell user:
        "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:

--- a/skills/fix-bug/SKILL.md
+++ b/skills/fix-bug/SKILL.md
@@ -72,7 +72,7 @@ Before executing any workflow steps, load the project configuration:
      **[Headless cleanup]:** Before stopping, check if `claude_docs/headless_suspend.json` exists. If it does, delete it, remove `rawgentic:ai-waiting` label from the issue (read issue number from suspend file), and add `rawgentic:ai-error` with a comment: "This skill was disabled after a headless session was suspended. The pending question can no longer be processed." Then **STOP.**
      - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
        "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
      - Otherwise, tell user:
        "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -79,7 +79,7 @@ Before executing any workflow steps, load the project configuration:
      **[Headless cleanup]:** Before stopping, check if `claude_docs/headless_suspend.json` exists. If it does, delete it, remove `rawgentic:ai-waiting` label from the issue (read issue number from suspend file), and add `rawgentic:ai-error` with a comment: "This skill was disabled after a headless session was suspended. The pending question can no longer be processed." Then **STOP.**
      - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
        "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
      - Otherwise, tell user:
        "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:

--- a/skills/incident/SKILL.md
+++ b/skills/incident/SKILL.md
@@ -52,7 +52,7 @@ Before executing any workflow steps, load the project configuration:
    - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
      - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
        "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
      - Otherwise, tell user:
        "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:

--- a/skills/optimize-perf/SKILL.md
+++ b/skills/optimize-perf/SKILL.md
@@ -44,7 +44,7 @@ Before executing any workflow steps, load the project configuration:
    - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
      - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
        "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
      - Otherwise, tell user:
        "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -42,7 +42,7 @@ Before executing any workflow steps, load the project configuration:
    - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
      - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
        "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
      - Otherwise, tell user:
        "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -48,7 +48,7 @@ Before executing any workflow steps, load the project configuration:
    - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
      - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
        "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
      - Otherwise, tell user:
        "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -122,7 +122,7 @@ BMAD detected (_bmad/ found). For [project-name], choose your preferred tool:
 
 1. Feature implementation:  (a) rawgentic:implement-feature  (b) bmad-dev-story      [default: b]
 2. Bug fixing:              (a) rawgentic:fix-bug            (b) bmad-dev-story      [default: b]
-3. Test creation:           (a) rawgentic:create-tests       (b) bmad-tea-*          [default: b]
+3. Test creation:           (a) rawgentic:create-tests       (b) bmad-testarch-*     [default: b]
 4. Documentation:           (a) rawgentic:update-docs        (b) BMAD tech-writer    [default: b]
 
 Accept all defaults? (y) Or enter numbers to change (e.g., "1,3" to pick rawgentic for those)

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -44,7 +44,7 @@ Before executing any workflow steps, load the project configuration:
    - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
      - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
        "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
      - Otherwise, tell user:
        "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -38,7 +38,7 @@ Before executing any workflow steps, load the project configuration:
    - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
      - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
        "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea-*, update-docs -> BMAD tech-writer.
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
      - Otherwise, tell user:
        "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
    - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:

--- a/tests/hooks/test_wal_guard.py
+++ b/tests/hooks/test_wal_guard.py
@@ -25,9 +25,16 @@ def _make_input(command: str) -> dict:
     return {"tool_input": {"command": command}}
 
 
-def _run_guard(command: str) -> str:
-    """Run wal-guard with *command* and return 'allow' or 'deny'."""
-    stdout, _stderr, _rc = run_hook(HOOK, _make_input(command))
+def _run_guard(command: str, cwd: Path | None = None) -> str:
+    """Run wal-guard with *command* and return 'allow' or 'deny'.
+
+    Pass *cwd* to isolate the subprocess from any ambient
+    .rawgentic_workspace.json above the test runner's working directory.
+    Without it, the hook's wal_find_workspace walks up from pytest's CWD
+    and may pick up an active project whose protectionLevel changes the
+    expected guard behavior.
+    """
+    stdout, _stderr, _rc = run_hook(HOOK, _make_input(command), cwd=cwd)
     parsed = parse_hook_output(stdout)
     if parsed is None:
         return "allow"
@@ -88,9 +95,11 @@ CASES = [
     CASES,
     ids=[c[0] for c in CASES],
 )
-def test_wal_guard_pattern(label: str, command: str, expected: str) -> None:
+def test_wal_guard_pattern(
+    label: str, command: str, expected: str, tmp_path: Path
+) -> None:
     """Wal-guard correctly allows or denies *command*."""
-    actual = _run_guard(command)
+    actual = _run_guard(command, cwd=tmp_path)
     assert actual == expected, f"[{label}] expected {expected}, got {actual}"
 
 
@@ -321,13 +330,13 @@ class TestTmpAllowlist:
 class TestNoWorkspaceBackwardCompat:
     """Missing workspace config = strict behavior (backward compat)."""
 
-    def test_no_workspace_blocks_ssh_prod(self):
+    def test_no_workspace_blocks_ssh_prod(self, tmp_path):
         """Without a workspace, wal-guard still blocks prod commands (strict default)."""
-        actual = _run_guard("ssh user@prod-host")
+        actual = _run_guard("ssh user@prod-host", cwd=tmp_path)
         assert actual == "deny"
 
-    def test_no_workspace_allows_safe_commands(self):
-        actual = _run_guard("echo hello")
+    def test_no_workspace_allows_safe_commands(self, tmp_path):
+        actual = _run_guard("echo hello", cwd=tmp_path)
         assert actual == "allow"
 
 


### PR DESCRIPTION
## Summary

- BMAD workspace upgraded 6.3.0 → 6.6.0. TEA module's `bmad-tea-*` workflows were renamed to `bmad-testarch-*` over an 8-minor-version jump (1.7.2 → 1.15.1).
- Update the informational mapping strings in 11 SKILL.md files + config-reference.md overlap table to **`bmad-tea` agent / `bmad-testarch-*` workflows** — naming both halves so future renames of either side don't fully invalidate the message.
- Fix a long-standing test isolation bug in `tests/hooks/test_wal_guard.py`: parametrized cases and `TestNoWorkspaceBackwardCompat` inherited pytest's CWD. When developing inside the workspace with rawgentic bound active (sandbox protectionLevel), `wal_find_workspace` would walk up, find the workspace, and skip all guard checks — flipping all 11 deny-expecting tests to allow. Pass `cwd=tmp_path` to isolate.
- Bump version 2.22.4 → 2.22.5.

## Why "agent / workflows" wording

TEA structure is `bmad-tea` (Murat — agent) + `bmad-testarch-*` (9 workflows). Pinning the help message to either alone is fragile across upstream module churn; naming both gives each rename only half the surface area to invalidate.

## Why the test isolation fix lives here

The wal_guard failures surface only when running pytest from inside the workspace with rawgentic bound active — which is what `/rawgentic:switch rawgentic` does. They're invisible in CI (fresh clone, no workspace). Discovered while running the BMAD pre-PR test gate; bundled here so the gate stays meaningful.

## Test plan

- [x] All 385 tests pass locally (`pytest tests/ -v`)
- [x] `grep -rn 'bmad-tea-\*' skills/ docs/ README.md` returns no matches
- [x] All 10 mapping lines in skills/*/SKILL.md identical (`grep -h Mapping: skills/*/SKILL.md | sort -u` returns 1 line)
- [x] CI verified post-merge (BMAD module text only — no behavioral skill changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)