### PR TITLE
fix(hooks): unquote command paths so ${CLAUDE_PLUGIN_ROOT} expands

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.22.5",
+  "version": "2.22.6",
   "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/docs/plans/2026-03-06-wal-session-notes-design.md
+++ b/docs/plans/2026-03-06-wal-session-notes-design.md
@@ -226,7 +226,7 @@ All common functions: jq resolution, input parsing, WAL path setup, phase append
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/session-start'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start",
             "timeout": 10
           }
         ]
@@ -238,7 +238,7 @@ All common functions: jq resolution, input parsing, WAL path setup, phase append
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-guard'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-guard",
             "timeout": 5
           }
         ]
@@ -248,7 +248,7 @@ All common functions: jq resolution, input parsing, WAL path setup, phase append
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-pre'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-pre",
             "timeout": 5
           }
         ]
@@ -260,7 +260,7 @@ All common functions: jq resolution, input parsing, WAL path setup, phase append
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-post'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-post",
             "timeout": 5
           }
         ]
@@ -272,7 +272,7 @@ All common functions: jq resolution, input parsing, WAL path setup, phase append
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-post-fail'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-post-fail",
             "timeout": 5
           }
         ]
@@ -283,7 +283,7 @@ All common functions: jq resolution, input parsing, WAL path setup, phase append
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-context'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-context",
             "timeout": 5
           }
         ]
@@ -294,7 +294,7 @@ All common functions: jq resolution, input parsing, WAL path setup, phase append
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-stop'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-stop",
             "timeout": 10
           }
         ]

--- a/docs/plans/2026-03-06-wal-session-notes-implementation.md
+++ b/docs/plans/2026-03-06-wal-session-notes-implementation.md
@@ -54,7 +54,7 @@ Update `hooks/hooks.json` to add UserPromptSubmit and Stop entries pointing to t
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/session-start'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start",
             "async": false
           }
         ]
@@ -65,7 +65,7 @@ Update `hooks/hooks.json` to add UserPromptSubmit and Stop entries pointing to t
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/test-payload-dump'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/test-payload-dump",
             "timeout": 5
           }
         ]
@@ -76,7 +76,7 @@ Update `hooks/hooks.json` to add UserPromptSubmit and Stop entries pointing to t
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/test-payload-dump'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/test-payload-dump",
             "timeout": 5
           }
         ]
@@ -859,7 +859,7 @@ Replace `hooks/hooks.json` with the full registration:
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/session-start'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start",
             "timeout": 10
           }
         ]
@@ -871,7 +871,7 @@ Replace `hooks/hooks.json` with the full registration:
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-guard'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-guard",
             "timeout": 5
           }
         ]
@@ -881,7 +881,7 @@ Replace `hooks/hooks.json` with the full registration:
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-pre'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-pre",
             "timeout": 5
           }
         ]
@@ -893,7 +893,7 @@ Replace `hooks/hooks.json` with the full registration:
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-post'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-post",
             "timeout": 5
           }
         ]
@@ -905,7 +905,7 @@ Replace `hooks/hooks.json` with the full registration:
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-post-fail'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-post-fail",
             "timeout": 5
           }
         ]
@@ -916,7 +916,7 @@ Replace `hooks/hooks.json` with the full registration:
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-context'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-context",
             "timeout": 3
           }
         ]
@@ -927,7 +927,7 @@ Replace `hooks/hooks.json` with the full registration:
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-stop'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-stop",
             "timeout": 10
           }
         ]

--- a/docs/plans/2026-03-07-multi-project-sessions-design.md
+++ b/docs/plans/2026-03-07-multi-project-sessions-design.md
@@ -205,7 +205,7 @@ New entry for `wal-bind-guard`:
   "hooks": [
     {
       "type": "command",
-      "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-bind-guard'",
+      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-bind-guard",
       "timeout": 3
     }
   ]

--- a/docs/plans/2026-03-07-multi-project-sessions-implementation.md
+++ b/docs/plans/2026-03-07-multi-project-sessions-implementation.md
@@ -817,7 +817,7 @@ Add a new entry to the `PreToolUse` array, BEFORE the wal-pre entry (so binding 
   "hooks": [
     {
       "type": "command",
-      "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-bind-guard'",
+      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-bind-guard",
       "timeout": 3
     }
   ]

--- a/docs/plans/2026-03-07-security-guard-design.md
+++ b/docs/plans/2026-03-07-security-guard-design.md
@@ -252,7 +252,7 @@ Add to rawgentic's existing PreToolUse hooks:
   "hooks": [
     {
       "type": "command",
-      "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/security-guard.py'",
+      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/security-guard.py",
       "timeout": 5
     }
   ]
@@ -267,7 +267,7 @@ Add to SessionStart hooks:
   "hooks": [
     {
       "type": "command",
-      "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/security-guard-check.sh'",
+      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/security-guard-check.sh",
       "timeout": 3
     }
   ]

--- a/docs/plans/2026-03-07-security-guard-implementation.md
+++ b/docs/plans/2026-03-07-security-guard-implementation.md
@@ -1042,7 +1042,7 @@ Add to the `PreToolUse` array (after the wal-pre entry):
   "hooks": [
     {
       "type": "command",
-      "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/security-guard.py'",
+      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/security-guard.py",
       "timeout": 5
     }
   ]
@@ -1059,7 +1059,7 @@ Add to the `SessionStart` array (after the existing session-start entry). Uses `
   "hooks": [
     {
       "type": "command",
-      "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/security-guard-check.sh'",
+      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/security-guard-check.sh",
       "timeout": 3
     }
   ]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/session-start'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start",
             "timeout": 10
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/security-guard-check.sh'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/security-guard-check.sh",
             "timeout": 3
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-guard'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-guard",
             "timeout": 5
           }
         ]
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-bind-guard'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-bind-guard",
             "timeout": 3
           }
         ]
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-pre'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-pre",
             "timeout": 5
           }
         ]
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/security-guard.py'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/security-guard.py",
             "timeout": 5
           }
         ]
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-post'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-post",
             "timeout": 5
           }
         ]
@@ -82,7 +82,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-post-fail'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-post-fail",
             "timeout": 5
           }
         ]
@@ -93,7 +93,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-context'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-context",
             "timeout": 3
           }
         ]
@@ -104,7 +104,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/wal-stop'",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-stop",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary

A recent Claude Code update changed how env-vars are expanded in hook command strings. The plugin's `hooks/hooks.json` wrapped each command path in literal single quotes:

```json
"command": "'${CLAUDE_PLUGIN_ROOT}/hooks/session-start'"
```

When Claude Code now hands this string to `/bin/sh -c`, the shell strips the outer single quotes and, because `${...}` inside single-quoted text is not expanded, `sh` tries to exec a file literally named `${CLAUDE_PLUGIN_ROOT}/hooks/...` — producing a `not found` error for every hook.

This PR removes the wrapping single quotes from all 10 command entries so `${CLAUDE_PLUGIN_ROOT}` expands correctly under the new behavior. It also sweeps the same pattern out of 6 historical `docs/plans/` design documents so the embedded snippets are copy-pasteable.

Bumps `2.22.5 → 2.22.6` per pre-PR checklist.

## Test plan

- [x] `pytest tests/ -v` — **385 passed**
- [x] Manually reproduced the bug with the broken quoting (exit 127, `not found`)
- [x] Manually verified the fix (`SessionStart` hook returns valid JSON, exit 0)
- [ ] Reviewer: install `2.22.6` and confirm hooks fire on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)