### PR TITLE
fix(hooks): migrate hooks.json to exec form with args: []

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.22.6",
+  "version": "2.22.7",
   "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -597,6 +597,18 @@ For major changes, please open an issue first to discuss the approach.
 
 ---
 
+## Changelog
+
+### v2.22.7 (2026-05-13)
+
+- **Hook commands use exec form.** `hooks/hooks.json` now declares `args: []` on every entry so Claude Code invokes hooks directly via `execv` instead of `/bin/sh -c "string"`. Permanently eliminates the shell-quoting class of bugs (per [Claude Code v2.1.139 hooks reference](https://code.claude.com/docs/en/hooks.md)). Backward compatible — `args` is ignored on older Claude Code versions.
+
+### v2.22.6 (2026-05-13)
+
+- **Fix `${CLAUDE_PLUGIN_ROOT}` not expanding in hook commands.** Each command in `hooks/hooks.json` was wrapped in literal single quotes (`"'${CLAUDE_PLUGIN_ROOT}/hooks/...'"`); a recent Claude Code update changed env-var expansion behavior, and `/bin/sh -c` then tried to exec a file literally named `${CLAUDE_PLUGIN_ROOT}/hooks/...`. Removed the wrapping quotes so the variable expands correctly. Also cleaned up the same pattern in 6 historical `docs/plans/` design documents.
+
+---
+
 ## License
 
 [MIT](LICENSE)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,6 +7,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start",
+            "args": [],
             "timeout": 10
           }
         ]
@@ -17,6 +18,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/security-guard-check.sh",
+            "args": [],
             "timeout": 3
           }
         ]
@@ -29,6 +31,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-guard",
+            "args": [],
             "timeout": 5
           }
         ]
@@ -39,6 +42,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-bind-guard",
+            "args": [],
             "timeout": 3
           }
         ]
@@ -49,6 +53,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-pre",
+            "args": [],
             "timeout": 5
           }
         ]
@@ -59,6 +64,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/security-guard.py",
+            "args": [],
             "timeout": 5
           }
         ]
@@ -71,6 +77,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-post",
+            "args": [],
             "timeout": 5
           }
         ]
@@ -83,6 +90,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-post-fail",
+            "args": [],
             "timeout": 5
           }
         ]
@@ -94,6 +102,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-context",
+            "args": [],
             "timeout": 3
           }
         ]
@@ -105,6 +114,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/wal-stop",
+            "args": [],
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary

Migrate `hooks/hooks.json` to the **exec-form** hook syntax that Claude Code v2.1.139+ introduced. Every command entry now declares `args: []` (or arguments, if it had any):

```json
{
  "type": "command",
  "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start",
  "args": []
}
```

When `args` is present, Claude Code invokes the hook directly via `execv` instead of `/bin/sh -c "string"`. This makes the plugin **permanently immune** to the shell-quoting class of bug fixed in #71 (2.22.6) — there is no shell to mis-parse the command in the first place.

`${CLAUDE_PLUGIN_ROOT}` still expands inside the `command` field — see the [Claude Code hooks reference](https://code.claude.com/docs/en/hooks.md).

**Backward compatible:** pre-2.1.139 Claude Code versions ignore the `args` field, so the existing `command` field works exactly as before.

## Changes

- 10 hook entries in `hooks/hooks.json` got `"args": []`
- Bumped `2.22.6 → 2.22.7`
- README gains a `## Changelog` section (didn't exist before) with 2.22.7 and 2.22.6 entries

## Test plan

- [x] `pytest tests/ -v` — **385 passed**
- [x] Hook file validated as JSON
- [ ] Reviewer: install 2.22.7 and confirm hooks still fire on session start (and don't fail on Claude Code 2.1.138 or earlier if you have one handy)

## Related

- #71 was the band-aid (unquote command paths). This is the durable fix.
- Companion PR in `3D-Stories/rawgentic-memorypalace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)