### PR TITLE
fix(plan_lib): address 4 deferred Low findings from PR #75 review (v2.23.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "10 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/hooks/plan_lib.py
+++ b/hooks/plan_lib.py
@@ -13,11 +13,13 @@ Provides testable helpers for:
 
 Used by skills/implement-feature/SKILL.md via `python3 -c` invocations.
 """
+import fcntl
 import json as _json
 import os
 import re
 import subprocess
 import sys
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Final, Literal
@@ -329,10 +331,20 @@ def should_promote(
     return False, None
 
 
-def format_promotion_note(task_id: str, criterion: str, rationale: str) -> str:
-    """Format a session-notes line documenting a mid-flight promotion."""
+def format_promotion_note(
+    task_id: str,
+    criterion: str,
+    rationale: str,
+    step: str = "8",
+) -> str:
+    """Format a session-notes line documenting a mid-flight promotion.
+
+    `step` defaults to "8" (the WF2 step where promotion fires today). If
+    P15 ever sprouts a Step 8b promotion or a different workflow reuses
+    the helper, callers can override.
+    """
     return (
-        f"### WF2 Step 8 — Promoted {task_id}: standard -> high "
+        f"### WF2 Step {step} — Promoted {task_id}: standard -> high "
         f"(criterion: {criterion}; rationale: {rationale})"
     )
 
@@ -661,8 +673,36 @@ def write_review_state(
     return path
 
 
+@contextmanager
+def _file_lock(path: str):
+    """Context manager: hold an exclusive flock on `path` (created if absent).
+
+    WF2 is single-writer-per-branch by design (one orchestrator session
+    drives a feature branch at a time), so this lock is a defense-in-depth
+    measure against accidental concurrent invocations rather than a
+    primary correctness mechanism.
+    """
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    # Open in append mode so the file is created if missing without
+    # truncating existing content; the lock is on the file descriptor.
+    fd = os.open(path + ".lock", os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
 def consume_loopback(path: str, source: str) -> tuple[bool, dict]:
     """Attempt to consume one loop-back from the named source.
+
+    Atomically (under a file lock): reads the current per-source counters,
+    checks per-source and global caps, and writes back the incremented
+    state. Two concurrent invocations cannot both see the same pre-state
+    and over-spend the budget.
 
     Returns (ok, state). Fails if:
     - Source exceeds its per-source cap
@@ -672,12 +712,13 @@ def consume_loopback(path: str, source: str) -> tuple[bool, dict]:
     """
     if source not in _LOOPBACK_SOURCES:
         raise ValueError(f"unknown loopback source: {source!r}")
-    state = _read_loopback_state(path)
-    if state[source] >= _LOOPBACK_SOURCE_MAX[source]:
-        return False, state
-    if state["total"] >= GLOBAL_LOOPBACK_BUDGET:
-        return False, state
-    state[source] += 1
-    state["total"] = sum(state[s] for s in _LOOPBACK_SOURCES)
-    _write_loopback_state(path, state)
+    with _file_lock(path):
+        state = _read_loopback_state(path)
+        if state[source] >= _LOOPBACK_SOURCE_MAX[source]:
+            return False, state
+        if state["total"] >= GLOBAL_LOOPBACK_BUDGET:
+            return False, state
+        state[source] += 1
+        state["total"] = sum(state[s] for s in _LOOPBACK_SOURCES)
+        _write_loopback_state(path, state)
     return True, state

--- a/tests/hooks/test_plan_lib.py
+++ b/tests/hooks/test_plan_lib.py
@@ -265,9 +265,12 @@ not a task
 # --- compute_risk_ratio + check_ratio_band ---
 
 def _t(id_, lvl, reason=None):
-    """Shortcut for Task fixtures."""
-    from plan_lib import Task
-    return Task(id=id_, title=f"task {id_}", risk_level=lvl, reason=reason)
+    """Shortcut for Task fixtures. Uses the currently-loaded plan_lib.Task
+    (rather than a top-level `from plan_lib import Task`) because individual
+    tests may reload the module via `_reload_plan_lib` and the Task class
+    identity changes across reloads."""
+    mod = sys.modules.get("plan_lib") or _reload_plan_lib()
+    return mod.Task(id=id_, title=f"task {id_}", risk_level=lvl, reason=reason)
 
 
 class TestRiskRatio:
@@ -454,6 +457,16 @@ class TestFormatPromotionNote:
         assert "security surface" in note
         assert "touches auth/" in note
         assert "standard" in note.lower() and "high" in note.lower()
+        # Default step is "8"
+        assert "Step 8" in note
+
+    def test_step_override(self):
+        mod = _reload_plan_lib()
+        note = mod.format_promotion_note(
+            "T2.3", "security surface", "touches auth/", step="8b"
+        )
+        assert "Step 8b" in note
+        assert "Step 8 " not in note  # not the default
 
 
 # --- review log + deferrals + assertions ---
@@ -684,6 +697,50 @@ class TestConsumeLoopback:
         path = tmp_path / "counters.json"
         with pytest.raises(ValueError):
             mod.consume_loopback(str(path), "bogus")
+
+    def test_concurrent_consume_does_not_overspend(self, tmp_path):
+        """Two processes attempting to consume from the same source at the
+        same time must not both succeed past the budget. Uses a real
+        multiprocessing pair to exercise the flock."""
+        import multiprocessing
+        mod = _reload_plan_lib()
+        path = tmp_path / "counters.json"
+        # Pre-spend design once (budget allows 2)
+        mod.consume_loopback(str(path), "design")
+
+        def _worker(q, p):
+            # Re-import in child process
+            import importlib
+            import sys as _sys
+            _sys.path.insert(0, str(HOOKS_DIR))
+            if "plan_lib" in _sys.modules:
+                child_mod = importlib.reload(_sys.modules["plan_lib"])
+            else:
+                import plan_lib as child_mod
+            ok, state = child_mod.consume_loopback(p, "design")
+            q.put((ok, state["design"]))
+
+        # Spawn 5 concurrent attempts; only ONE more should succeed
+        # (design cap is 2, we've already used 1).
+        q = multiprocessing.Queue()
+        procs = [
+            multiprocessing.Process(target=_worker, args=(q, str(path)))
+            for _ in range(5)
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=10)
+            assert not p.is_alive(), "worker hung — flock deadlock?"
+        results = [q.get_nowait() for _ in range(5)]
+        successes = [r for r in results if r[0]]
+        assert len(successes) == 1, (
+            f"expected exactly 1 successful consume past pre-spent budget, got "
+            f"{len(successes)}: {results}"
+        )
+        # Final state on disk
+        final = mod._read_loopback_state(str(path))
+        assert final["design"] == 2  # cap reached, no over-spend
 
 
 class TestReviewState:

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -60,17 +60,34 @@ EXPECTED_REFERENCES = {
 }
 
 
+# Match `helper_name`, `plan_lib.helper_name`, or `something.helper_name` inside
+# backticks. The backtick requirement (vs plain substring) filters out prose
+# mentions like "we call parse_tasks later" and forces actual invocation syntax.
+def _backticked_reference_re(helper: str) -> re.Pattern:
+    return re.compile(r"`[A-Za-z0-9_.]*\b" + re.escape(helper) + r"\b[^`]*`")
+
+
 @pytest.mark.parametrize("helper,steps", list(EXPECTED_REFERENCES.items()))
 def test_helper_referenced_in_expected_step(helper, steps):
-    """Each helper must appear in the section of one of its expected steps."""
+    """Each helper must appear in a backticked code reference in the section
+    of one of its expected steps.
+
+    The backtick requirement is the tightening from review finding R3 F4:
+    plain substring matching would accept prose mentions ("we call parse_tasks
+    later"), but the helper is only actually wired in if it appears as
+    invocation syntax (`plan_lib.parse_tasks(...)`)."""
     skill = _read_skill()
+    pattern = _backticked_reference_re(helper)
     for step in steps:
         section = _step_section(skill, step)
-        if helper in section:
+        if pattern.search(section):
             return
     pytest.fail(
-        f"Helper {helper!r} expected in Step section(s) {steps} of SKILL.md but not found. "
-        f"This is the WF2/plan_lib drift guard — either rename in SKILL.md or update this test."
+        f"Helper {helper!r} expected in Step section(s) {steps} of SKILL.md "
+        f"as a backticked code reference (e.g., `plan_lib.{helper}` or "
+        f"`{helper}(...)`) but not found. "
+        f"This is the WF2/plan_lib drift guard — either rename in SKILL.md, "
+        f"add the actual invocation, or update this test."
     )
 
 


### PR DESCRIPTION
Follow-up to #75 (P15 tiered code review). The four Low-severity findings deferred from the original PR's code review are addressed here. Each is small, contained, and surfaced a real (if minor) improvement on reflection.

## Changes

| # | Source | What | How |
|---|--------|------|-----|
| 1 | Reviewer 1 #5 | \`format_promotion_note\` hardcoded "WF2 Step 8" | Added \`step: str = \"8\"\` parameter; default preserves backward compat |
| 2 | Reviewer 1 #6 | \`_t\` test helper had \`from plan_lib import Task\` inside the function body | Use the currently-loaded \`plan_lib.Task\` via \`sys.modules\` (hoist-to-top would break reload-aware tests because the class identity changes across reloads) |
| 3 | Reviewer 2 #5 | \`consume_loopback\` non-atomic — 2 concurrent invocations could over-spend the budget | Wrapped read-check-write in \`fcntl.LOCK_EX\` flock via a new \`_file_lock\` context manager. Defense-in-depth: WF2 is single-writer-per-branch by design |
| 4 | Reviewer 3 F4 | Drift guard was presence-only (\`\"parse_tasks\" in skill_md\`) — would accept prose mentions | Tightened to require BACKTICKED occurrence (\`plan_lib.parse_tasks\` or \`parse_tasks(...)\` inside backticks). All 14 existing helpers already meet the tighter bar |

## Verification

- \`pytest tests/ -v\` — **522 / 522 passing** (was 520; +2 tests: \`test_step_override\` and \`test_concurrent_consume_does_not_overspend\`)
- The concurrency test spawns 5 \`multiprocessing.Process\` workers attempting to consume from a near-exhausted budget; asserts exactly 1 succeeds (the others bounce off the cap correctly)
- Drift guard tightening: re-ran all 14 helper-reference assertions, all still pass

## Files

```
.claude-plugin/plugin.json     # 2.23.0 → 2.23.1 (patch)
hooks/plan_lib.py              # +56 / -10  (file lock + step param)
tests/hooks/test_plan_lib.py   # +56 / -7   (concurrency test + step override + _t fix)
tests/test_skill_helpers.py    # +22 / -6   (backtick regex drift guard)
```

## Test plan

- [x] Local \`pytest tests/ -v\` — 522/522 passing
- [x] Concurrency test reliably reproduces under flock
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)