### PR TITLE
feat(wf1,wf4,skills): adversarial-review in WF1/WF4 + evals + fix OpenAI strict schema (#79, #80)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Multiple projects can be active simultaneously. Use `/rawgentic:switch` to bind 
 **Key Features:**
 - Different-model second opinion (complements same-model reflexion critique)
 - Report-only — writes `docs/reviews/<slug>-<date>.md`, never edits the artifact
-- Optionally wired into WF2 (design/plan gates) and WF3 (default-off) per-project
+- Optionally wired into WF2 (design/plan gates), WF3, WF1 (issue spec), and WF4 (refactor design) per-project (all opt-in; WF3/WF1/WF4 default-off)
 - Warn-only egress with secret scanning; fail-closed on any Codex error
 - Requires the Codex CLI installed + authenticated. See [Data Handling](#cross-model-review-data-handling-codex).
 </details>
@@ -480,7 +480,7 @@ See `docs/plans/2026-03-06-plugin-overhaul-design.md` for the full design.
 | WF2 Feature Implementation | Full critique      | `/reflexion:critique` | After design                 |
 | WF3 Bug Fix                | Reflect only       | `/reflexion:reflect`  | After RCA                    |
 | WF4 Refactoring            | Category-based     | Full or Reflect       | Full for extract/restructure |
-| WF5 Adversarial Review     | Cross-model        | Codex CLI             | Standalone; opt-in in WF2/WF3 |
+| WF5 Adversarial Review     | Cross-model        | Codex CLI             | Standalone; opt-in in WF1–WF4 |
 | WF7 Documentation          | Reflect only       | `/reflexion:reflect`  | After draft                  |
 | WF8 Dependency Update      | None (audit-based) | `npm audit` + tests   | Automated                    |
 | WF9 Security Audit         | Full (on audit)    | `/reflexion:critique` | Critique the findings        |
@@ -490,14 +490,14 @@ See `docs/plans/2026-03-06-plugin-overhaul-design.md` for the full design.
 
 ### Cross-Model Review Data Handling (Codex)
 
-WF5 Adversarial Review (`/rawgentic:adversarial-review`) and its opt-in WF2/WF3
+WF5 Adversarial Review (`/rawgentic:adversarial-review`) and its opt-in WF1/WF2/WF3/WF4
 hooks send the **text of the reviewed artifact to OpenAI** via the Codex CLI for an
 independent, different-model critique. This is **warn-only**: a one-time egress
 notice is printed before each invocation, and the engine scans the artifact for
 obvious secrets (API keys, passwords, tokens, private keys), naming any detected
 categories. Set `RAWGENTIC_ADV_REVIEW_BLOCK_SECRETS=1` to block egress when secrets
 are found. Findings reports are written locally to `<project>/docs/reviews/` and are
-never uploaded. The feature is **default-disabled** per project; existing WF2/WF3
+never uploaded. The feature is **default-disabled** per project; existing WF1/WF2/WF3/WF4
 runs are unchanged unless explicitly opted in via `adversarialReview` in
 `.rawgentic_workspace.json`. Requires the Codex CLI installed
 (`curl -fsSL https://codex.openai.com/install.sh | bash`) and authenticated
@@ -584,7 +584,7 @@ pytest tests/hooks/test_wal_guard.py -v
 
 **CI:** GitHub Actions runs `pytest tests/ -v` on all PRs to `main` (`.github/workflows/ci.yml`). SDLC workflows also run tests automatically when `.rawgentic.json` has a `testing` section configured.
 
-Skills are tested via the `/skill-creator` eval pipeline (14/16 skills have evals.json).
+Skills are tested via the `/skill-creator` eval pipeline (15/16 skills have evals.json).
 
 **Workspace directories:** Some skills have a corresponding `*-workspace/` directory (e.g., `skills/setup-workspace/`) used for internal skill iteration and evaluation. These contain `evals/`, `iteration-N/`, and `skill-snapshot/` subdirectories. They are **excluded from marketplace installs** via the `skills` whitelist in `marketplace.json`. If you add a new workspace directory, never name a file `SKILL.md` inside it — the marketplace validator scans for that filename recursively and will reject duplicates.
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -295,7 +295,8 @@ the project repo. Shape:
 "adversarialReview": { "enabled": true, "workflows": ["implement-feature", "fix-bug"] }
 ```
 
-`workflows` uses bare skill names. When enabled and the running skill is listed:
+`workflows` uses bare skill names (`implement-feature`, `fix-bug`, `create-issue`,
+`refactor`). When enabled and the running skill is listed:
 
 - **WF2** (`implement-feature`): after the normal design critique (Step 4) and plan
   reflect (Step 6), if `fast_path_eligible == false`, it additionally invokes
@@ -305,6 +306,19 @@ the project repo. Shape:
 - **WF3** (`fix-bug`): default-OFF even when WF2 is on (must be explicitly listed).
   When enabled, Step 4 adds a cross-model review on top of the lightweight reflect,
   accepting the documented latency tradeoff.
+- **WF1** (`create-issue`): runs at Step 4 over the draft issue spec, merging into the
+  existing ambiguity circuit breaker. Expected to stay OFF for most projects — WF1
+  already runs a full same-model 3-judge critique at Step 3, so the cross-model pass is
+  additive/redundant. WF1 has no `plan_lib` loop-back; findings flow through the Step 4
+  circuit breaker only.
+- **WF4** (`refactor`): runs at Step 4 over the refactoring design, **only on the
+  Extract/Restructure full-critique path** (Rename/Simplify skips it). Loop-back uses
+  WF4's own textual `LOOPBACK_BUDGET`, not `plan_lib`.
+
+In every embedded workflow the review is **non-blocking / fail-closed**: any Codex
+failure (including a missing/unauthenticated CLI, even in headless mode) is logged and
+skipped, never blocking the host workflow. Only the standalone WF5 skill ERRORs on an
+unmet prerequisite.
 
 Loading is **fail-closed**: a missing file, malformed JSON, missing field, or bad value
 resolves to disabled — a workflow never crashes and never silently enables. Bool shorthand

--- a/hooks/adversarial_review_lib.py
+++ b/hooks/adversarial_review_lib.py
@@ -309,11 +309,17 @@ def prereq_status(headless: bool = False) -> tuple[bool, str]:
 # Findings schema + validation + normalization
 # ============================================================================
 
+# OpenAI strict structured-output (used by `codex exec --output-schema`) requires
+# that EVERY key in `properties` also appear in `required`, recursively, with
+# additionalProperties:false. Optional fields are therefore declared required but
+# NULLABLE. (#80: the prior schema omitted summary/ambiguity_flag/ambiguity_reason/
+# location from `required`, which OpenAI rejects with HTTP 400, silently breaking
+# every cross-model review.)
 FINDINGS_SCHEMA: Final[dict] = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": False,
-    "required": ["findings"],
+    "required": ["summary", "findings"],
     "properties": {
         "summary": {"type": "string"},
         "findings": {
@@ -321,15 +327,19 @@ FINDINGS_SCHEMA: Final[dict] = {
             "items": {
                 "type": "object",
                 "additionalProperties": False,
-                "required": ["severity", "category", "description", "recommendation"],
+                "required": [
+                    "severity", "category", "description", "recommendation",
+                    "ambiguity_flag", "ambiguity_reason", "location",
+                ],
                 "properties": {
                     "severity": {"enum": list(SEVERITIES)},
                     "category": {"type": "string"},
                     "description": {"type": "string"},
                     "recommendation": {"type": "string"},
-                    "ambiguity_flag": {"type": "boolean"},
-                    "ambiguity_reason": {"type": "string"},
-                    "location": {"type": "string"},
+                    # Optional in spirit → required-but-nullable for strict mode.
+                    "ambiguity_flag": {"type": ["boolean", "null"]},
+                    "ambiguity_reason": {"type": ["string", "null"]},
+                    "location": {"type": ["string", "null"]},
                 },
             },
         },
@@ -355,8 +365,10 @@ def validate_finding(d: object) -> tuple[bool, list[str]]:
         val = d.get(field)
         if not isinstance(val, str) or not val.strip():
             errors.append(f"missing/empty {field}")
-    if "ambiguity_flag" in d and not isinstance(d["ambiguity_flag"], bool):
-        errors.append("ambiguity_flag must be boolean")
+    # Optional fields may be absent OR null (strict-mode schema sends them as null).
+    af = d.get("ambiguity_flag")
+    if af is not None and not isinstance(af, bool):
+        errors.append("ambiguity_flag must be boolean or null")
     return (not errors), errors
 
 
@@ -392,7 +404,8 @@ def normalize_findings(raw: object) -> list[dict]:
             continue
         # Dedupe on the FULL description — truncating the key would silently
         # collapse distinct findings that share an opening clause (#77 Step 8a F2).
-        key = (f["severity"], f.get("location", ""), f["description"])
+        # location may be null under the strict-mode schema (#80) — coerce to "".
+        key = (f["severity"], f.get("location") or "", f["description"])
         if key in seen:
             continue
         seen.add(key)
@@ -638,7 +651,7 @@ def render_report_md(findings: list[dict], meta: dict) -> str:
         lines.append("_No findings returned._")
     for i, f in enumerate(findings, 1):
         lines += [
-            f"### {i}. [{f['severity']}] {f['category']} — {f.get('location', 'n/a')}",
+            f"### {i}. [{f['severity']}] {f['category']} — {f.get('location') or 'n/a'}",
             "",
             f["description"],
             "",

--- a/hooks/adversarial_review_lib.py
+++ b/hooks/adversarial_review_lib.py
@@ -365,10 +365,17 @@ def validate_finding(d: object) -> tuple[bool, list[str]]:
         val = d.get(field)
         if not isinstance(val, str) or not val.strip():
             errors.append(f"missing/empty {field}")
-    # Optional fields may be absent OR null (strict-mode schema sends them as null).
+    # Optional fields are required-but-nullable in the strict-mode schema (#80):
+    # they may be null, but a non-null value must match the declared type.
     af = d.get("ambiguity_flag")
     if af is not None and not isinstance(af, bool):
         errors.append("ambiguity_flag must be boolean or null")
+    ar = d.get("ambiguity_reason")
+    if ar is not None and not isinstance(ar, str):
+        errors.append("ambiguity_reason must be string or null")
+    loc = d.get("location")
+    if loc is not None and not isinstance(loc, str):
+        errors.append("location must be string or null")
     return (not errors), errors
 
 
@@ -404,7 +411,8 @@ def normalize_findings(raw: object) -> list[dict]:
             continue
         # Dedupe on the FULL description — truncating the key would silently
         # collapse distinct findings that share an opening clause (#77 Step 8a F2).
-        # location may be null under the strict-mode schema (#80) — coerce to "".
+        # location may be null OR missing under the strict-mode schema (#80) —
+        # coerce both to "" so dedupe keys stay comparable strings.
         key = (f["severity"], f.get("location") or "", f["description"])
         if key in seen:
             continue

--- a/skills/adversarial-review-workspace/evals/evals.json
+++ b/skills/adversarial-review-workspace/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "rawgentic:adversarial-review",
+  "_note": "WF5 invokes the Codex CLI, which is unavailable/unauthenticated in the eval sandbox. These evals therefore exercise STRUCTURAL / fail-closed behavior only (prerequisite gate, path-traversal refusal, report-only intent) and never depend on live Codex output.",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Run /rawgentic:adversarial-review docs/design.md. The working directory is /tmp/rawgentic-advrev-test/no-codex, which is a configured rawgentic project (its .rawgentic_workspace.json marks it active+configured) containing docs/design.md with a short design. The `codex` CLI is NOT installed (not on PATH). Write a transcript of all steps to outputs/transcript.md.",
+      "expected_output": "Loads config, validates the artifact exists under the project, then the prerequisite gate detects Codex is not installed and STOPs with install instructions (curl install.sh) and login guidance. Does NOT fabricate any findings, does NOT write a findings report, and does NOT edit docs/design.md. Reports the review could not run."
+    },
+    {
+      "id": 2,
+      "prompt": "Run /rawgentic:adversarial-review ../../../etc/passwd. The working directory is /tmp/rawgentic-advrev-test/traversal, a configured rawgentic project. Write a transcript of all steps to outputs/transcript.md showing how the skill handles this path.",
+      "expected_output": "Refuses: the artifact path resolves outside the project root, so the skill rejects it (ArtifactError / 'artifact must live inside the active project') and STOPs without invoking Codex, without reading the file, and without writing any report."
+    },
+    {
+      "id": 3,
+      "prompt": "Run /rawgentic:adversarial-review docs/plan.md plan. The working directory is /tmp/rawgentic-advrev-test/report-only, a configured rawgentic project containing docs/plan.md. A fake `codex` on PATH returns a valid findings JSON. Save the original docs/plan.md content to outputs/plan-after.md after the run, and write a transcript to outputs/transcript.md.",
+      "expected_output": "Prints the one-time warn-only egress notice, invokes the engine, writes a severity-ranked report to <project>/docs/reviews/, presents a summary, and leaves docs/plan.md byte-for-byte UNCHANGED (report-only invariant). outputs/plan-after.md equals the original docs/plan.md content."
+    }
+  ]
+}

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -268,6 +268,16 @@ Prioritized findings list with severity tiers and ambiguity flags. This is NOT p
 
 This step implements the circuit breaker logic. It is prompt-level logic, not a separate tool.
 
+0. **Adversarial review sub-step (opt-in, cross-model — runs FIRST).** Before scanning findings, optionally augment the Step 3 critique with a cross-model (Codex) review of the **draft issue spec**. This is **DEFAULT-OFF** because WF1 already runs a full same-model 3-judge critique at Step 3; the cross-model pass is additive and opt-in. Gate it on project opt-in (check FIRST so a disabled project is a true no-op — no temp file, no subprocess):
+   ```bash
+   python3 hooks/adversarial_review_lib.py is-enabled \
+     --workspace .rawgentic_workspace.json --project <name> --skill create-issue
+   ```
+   The command exits `0` when enabled for `create-issue` and non-zero otherwise. If non-zero, **skip silently** — behavior is byte-for-byte unchanged. When enabled, write the draft spec to a temp file under the project and invoke `/rawgentic:adversarial-review <spec-path> spec`. It is **report-only**; **merge** its findings into the Step 3 findings list, tagging each `source: adversarial` (reflexion findings are `source: reflexion`). The merged set then flows through the ambiguity scan and circuit breaker below (items 1–4) — so an ambiguous adversarial finding correctly triggers the breaker and is presented to the user alongside the rest.
+   - **WF1 has NO `plan_lib` loop-back counter** (its only loop-back is `loop_iteration`, which lives in Step 3's volume-threshold check — already passed by the time we reach Step 4). Therefore the adversarial sub-step does **NOT** call `plan_lib.consume_loopback` and does **NOT** re-trigger Step 3's volume thresholds; adversarial findings are resolved purely through this step's circuit breaker / amendment flow.
+   - **Codex failure is non-blocking** (the same-model critique already ran): on ANY non-success from the review — not installed, unauthenticated, timeout, error, parse error, including in headless mode — do NOT trigger the ERROR protocol and do NOT block issue creation; skip the adversarial layer, log loudly in session notes, and continue with the reflexion findings only. (Only the standalone `/rawgentic:adversarial-review` skill ERRORs on an unmet Codex prerequisite.)
+   - Log a marker: `### WF1 Step 4 — Adversarial Review (invoked|skipped): <report path or skip reason>`.
+
 1. **Scan all findings for ambiguity:**
 
    ```

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -225,6 +225,16 @@ Refactoring design (internal): { approach, target_structure, migration_steps, be
 - Are all references updated? (Serena `find_referencing_symbols` cross-check)
 - Any behavioral side effects?
 
+**Adversarial review sub-step (opt-in, cross-model — Extract/Restructure only).** After the critique above, optionally run a cross-model (Codex) review of the refactoring design. **Default-off**; opt-in if you want an independent second opinion on the refactoring. Gate on BOTH:
+- the refactoring `category` (recorded in Step 2's Analysis) is `extract` or `restructure` — **skip silently for Rename/Simplify** (those use the lightweight path; cross-model review is not worth the latency there, mirroring how the cheap path is skipped), AND
+- the project opts in (check FIRST so a disabled project is a true no-op):
+  ```bash
+  python3 hooks/adversarial_review_lib.py is-enabled \
+    --workspace .rawgentic_workspace.json --project <name> --skill refactor
+  ```
+  exits `0` when enabled for `refactor`, non-zero otherwise. If non-zero (or category is rename/simplify), **skip silently** — behavior is byte-for-byte unchanged.
+When enabled, write the refactoring design to a temp file under the project and invoke `/rawgentic:adversarial-review <design-path> design`. It is **report-only**; **merge** its findings (tagged `source: adversarial`) with the reflexion critique findings and apply the circuit breaker over the **merged** set. If a Critical/High finding indicates the refactoring would change external behavior or is otherwise a genuine design flaw, loop back to Step 3 using WF4's **own textual `LOOPBACK_BUDGET`** (`Step_4_to_3`, max 2 for extract/restructure, within `global_cap` 3) — the same budget the reflexion critique loop-back already uses. **WF4 does NOT use `plan_lib` loop-back counters**, so do NOT call `plan_lib.consume_loopback`; just track the textual budget as Step 4 already does. **Codex failure is non-blocking**: on ANY non-success (incl. headless unmet-prerequisite) skip the adversarial layer, log loudly, and continue with the reflexion result; never ERROR or block WF4 (only the standalone `/rawgentic:adversarial-review` skill ERRORs on prereq). Log: `### WF4 Step 4 — Adversarial Review (invoked|skipped): <report path or skip reason>`.
+
 ### Output
 
 Amended design OR blocked state (circuit breaker).

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -208,13 +208,14 @@ Check the active project's entry in `.rawgentic_workspace.json` for the `headles
 This step runs on **every** setup invocation (including Sub-flow A re-runs).
 
 The `/rawgentic:adversarial-review` skill (WF5) runs a cross-model review of a
-text artifact via the Codex CLI. It can also be wired into the WF2 and WF3
-quality gates so they automatically run a cross-model second opinion on the
-design / implementation plan (WF2) or root-cause analysis (WF3). This is
-**opt-in and default-off** because it adds latency and sends artifact text to
-OpenAI (Codex). The setting lives in the active project's entry in
-`.rawgentic_workspace.json` (sibling to `headlessEnabled` / `critiqueMethod`),
-NOT in `.rawgentic.json` — it is workspace-scoped, not committed to the project repo.
+text artifact via the Codex CLI. It can also be wired into the WF1, WF2, WF3, and
+WF4 quality gates so they automatically run a cross-model second opinion on the
+issue spec (WF1), design / implementation plan (WF2), root-cause analysis (WF3),
+or refactoring design (WF4). This is **opt-in and default-off** because it adds
+latency and sends artifact text to OpenAI (Codex). The setting lives in the active
+project's entry in `.rawgentic_workspace.json` (sibling to `headlessEnabled` /
+`critiqueMethod`), NOT in `.rawgentic.json` — it is workspace-scoped, not committed
+to the project repo.
 
 Check the active project's entry for the `adversarialReview` field.
 
@@ -226,28 +227,37 @@ Check the active project's entry for the `adversarialReview` field.
   When enabled for a workflow, that workflow invokes /rawgentic:adversarial-review
   to get an independent (different-model) critique at its quality gate. The
   artifact text is sent to OpenAI (Codex). The standalone /rawgentic:adversarial-review
-  skill works regardless of this setting; this only controls the WF2/WF3 hooks.
+  skill works regardless of this setting; this only controls the embedded hooks.
 
-  Enable for which workflows? (none / wf2 / wf2+wf3) [default: none]
-    - wf2  = implement-feature: review the design (Step 4) and plan (Step 6)
-    - wf3  = fix-bug: review the root-cause analysis (Step 4)  [extra latency on bug fixes]
+  Enable for which workflows? Enter any combination of numbers (e.g. "1,2"),
+  "none", or "all" [default: none]:
+    1. implement-feature (WF2) — review the design (Step 4) and plan (Step 6)
+    2. fix-bug (WF3)          — review the root-cause analysis (Step 4)   [extra latency on bug fixes]
+    3. create-issue (WF1)     — review the issue spec (Step 4)            [redundant with WF1's own same-model critique]
+    4. refactor (WF4)         — review the refactoring design (Step 4, Extract/Restructure only)
   ```
 
-  Write the result to the project's entry. Use bare skill names in `workflows`:
-  - none      → `"adversarialReview": { "enabled": false, "workflows": [] }`
-  - wf2       → `"adversarialReview": { "enabled": true, "workflows": ["implement-feature"] }`
-  - wf2+wf3   → `"adversarialReview": { "enabled": true, "workflows": ["implement-feature", "fix-bug"] }`
+  Write the result to the project's entry using **bare skill names** in `workflows`
+  (map: 1→implement-feature, 2→fix-bug, 3→create-issue, 4→refactor). Examples:
+  - none        → `"adversarialReview": { "enabled": false, "workflows": [] }`
+  - "1"         → `"adversarialReview": { "enabled": true, "workflows": ["implement-feature"] }`
+  - "1,2"       → `"adversarialReview": { "enabled": true, "workflows": ["implement-feature", "fix-bug"] }`
+  - "all"       → `"adversarialReview": { "enabled": true, "workflows": ["implement-feature", "fix-bug", "create-issue", "refactor"] }`
 
-  Requires the Codex CLI to be installed and authenticated to actually run
+  Notes: WF1 (create-issue) is listed but expected to stay off for most projects —
+  it already runs a full same-model 3-judge critique, so the cross-model pass is
+  additive/redundant. WF4 (refactor) only fires on the Extract/Restructure path
+  (Rename/Simplify skips it). Requires the Codex CLI installed and authenticated
   (`curl -fsSL https://codex.openai.com/install.sh | bash` then `codex login`);
-  enabling the config without Codex present means the gate fails closed and is skipped.
+  enabling without Codex present means the gate fails closed and is skipped.
 
 - **If `adversarialReview` is already set** (re-configuration): show current
   status and allow changing:
 
   ```
-  Adversarial review (WF5): [DISABLED / enabled for: implement-feature, fix-bug]
-  Change? (none / wf2 / wf2+wf3) [default: keep current]
+  Adversarial review (WF5): [DISABLED / enabled for: <bare skill names>]
+  Change? Enter numbers (1=implement-feature, 2=fix-bug, 3=create-issue, 4=refactor),
+  "none", or "all" [default: keep current]
   ```
 
 ---

--- a/tests/hooks/test_adversarial_review_config.py
+++ b/tests/hooks/test_adversarial_review_config.py
@@ -139,3 +139,15 @@ def test_is_enabled_for_bool_shorthand_has_no_workflows(tmp_path):
 
 def test_is_enabled_for_missing_file_false(tmp_path):
     assert arl.is_enabled_for(str(tmp_path / "nope.json"), "p", "implement-feature") is False
+
+
+@pytest.mark.parametrize("skill", ["create-issue", "refactor", "implement-feature", "fix-bug"])
+def test_is_enabled_for_accepts_all_workflow_skill_names(tmp_path, skill):
+    """#79: is_enabled_for is skill-name-generic — WF1/WF4 need no engine change."""
+    ws = _write_ws(tmp_path, [{
+        "name": "p", "path": "./projects/p",
+        "adversarialReview": {"enabled": True, "workflows": [skill]},
+    }])
+    assert arl.is_enabled_for(str(ws), "p", skill) is True
+    # a different skill not in the list stays off
+    assert arl.is_enabled_for(str(ws), "p", "some-other-skill") is False

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.24.0"
+    assert plugin["version"] == "2.25.0"
 
 
 def test_descriptions_consistent_count():
@@ -54,7 +54,7 @@ def test_readme_count_strings_updated():
     assert "10 SDLC workflow skills" not in readme
     assert "provides 16 skills" in readme
     assert "All 11 workflow skills share" in readme
-    assert "14/16 skills have evals.json" in readme
+    assert "15/16 skills have evals.json" in readme
 
 
 def test_marketplace_skill_dirs_all_exist():
@@ -129,3 +129,75 @@ def test_setup_has_step_2d():
     text = (SKILLS_DIR / "setup" / "SKILL.md").read_text()
     assert "Step 2d" in text
     assert "adversarialReview" in text
+
+
+# --- WF1 / WF4 integration (issue #79) ---
+
+def test_wf1_invokes_in_step4_default_off():
+    text = (SKILLS_DIR / "create-issue" / "SKILL.md").read_text()
+    step4 = _section(text, "## Step 4:", "## Step 5:")
+    assert "adversarial-review" in step4.lower(), "WF1 Step 4 missing adversarial-review invocation"
+    assert "is-enabled" in step4, "WF1 Step 4 missing config gate (is-enabled)"
+    assert "create-issue" in step4, "WF1 hook must gate on the 'create-issue' skill name"
+    assert "default-off" in step4.lower() or "DEFAULT-OFF" in step4
+
+
+def test_wf1_uses_no_plan_lib_loopback():
+    """WF1 has no plan_lib loopback — its hook must NOT *invoke* consume_loopback.
+
+    (The prose may mention `consume_loopback` to say it is NOT used; we assert there
+    is no actual call, i.e. no `consume_loopback(` invocation.)
+    """
+    text = (SKILLS_DIR / "create-issue" / "SKILL.md").read_text()
+    step4 = _section(text, "## Step 4:", "## Step 5:")
+    assert "consume_loopback(" not in step4
+
+
+def test_wf4_invokes_in_step4_extract_restructure_only():
+    text = (SKILLS_DIR / "refactor" / "SKILL.md").read_text()
+    step4 = _section(text, "## Step 4:", "## Step 5:")
+    assert "adversarial-review" in step4.lower(), "WF4 Step 4 missing adversarial-review invocation"
+    assert "is-enabled" in step4, "WF4 Step 4 missing config gate (is-enabled)"
+    assert "refactor" in step4
+    # gated to the full-critique path only (extract/restructure), not rename/simplify
+    low = step4.lower()
+    assert "extract" in low and "restructure" in low
+
+
+def test_wf4_uses_textual_budget_not_plan_lib():
+    """WF4 manages loop-back via its own textual LOOPBACK_BUDGET, not plan_lib.
+
+    Assert no actual `consume_loopback(` invocation, and that the textual budget
+    is referenced.
+    """
+    text = (SKILLS_DIR / "refactor" / "SKILL.md").read_text()
+    step4 = _section(text, "## Step 4:", "## Step 5:")
+    assert "consume_loopback(" not in step4  # WF4 does not use plan_lib counters
+    assert "LOOPBACK_BUDGET" in step4
+
+
+def test_setup_offers_all_four_workflows():
+    text = (SKILLS_DIR / "setup" / "SKILL.md").read_text()
+    step2d = _section(text, "## Step 2d:", "## Step 3:")
+    for name in ("implement-feature", "fix-bug", "create-issue", "refactor"):
+        assert name in step2d, f"setup Step 2d must offer {name}"
+
+
+# --- adversarial-review evals workspace (issue #79) ---
+
+def test_adversarial_review_evals_exist_and_valid():
+    evals_path = SKILLS_DIR / "adversarial-review-workspace" / "evals" / "evals.json"
+    assert evals_path.exists(), "missing skills/adversarial-review-workspace/evals/evals.json"
+    data = json.loads(evals_path.read_text())
+    assert data["skill_name"] == "rawgentic:adversarial-review"
+    assert isinstance(data["evals"], list) and len(data["evals"]) >= 3
+    for ev in data["evals"]:
+        assert isinstance(ev.get("id"), int)
+        assert ev.get("prompt") and isinstance(ev["prompt"], str)
+        assert ev.get("expected_output") and isinstance(ev["expected_output"], str)
+
+
+def test_adversarial_review_workspace_has_no_skill_md():
+    """Workspace dirs are eval artifacts — must NOT contain a SKILL.md (validator rejects)."""
+    ws = SKILLS_DIR / "adversarial-review-workspace"
+    assert not (ws / "SKILL.md").exists()

--- a/tests/hooks/test_adversarial_review_schema.py
+++ b/tests/hooks/test_adversarial_review_schema.py
@@ -124,3 +124,57 @@ def test_schema_rejects_bad_severity_with_jsonschema():
     doc = {"findings": [_finding(severity="Nope")]}
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(doc, arl.FINDINGS_SCHEMA)
+
+
+# --- #80: OpenAI strict structured-output compliance ---
+
+def _assert_strict(node, path="root"):
+    """Recursively assert every object's `properties` keys all appear in `required`
+    and additionalProperties is False (OpenAI strict structured-output rule)."""
+    if isinstance(node, dict):
+        if node.get("type") == "object" and "properties" in node:
+            props = set(node["properties"].keys())
+            required = set(node.get("required", []))
+            missing = props - required
+            assert not missing, f"{path}: properties not in required: {missing}"
+            assert node.get("additionalProperties") is False, \
+                f"{path}: additionalProperties must be False for strict mode"
+        for k, v in node.items():
+            _assert_strict(v, f"{path}.{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            _assert_strict(v, f"{path}[{i}]")
+
+
+def test_findings_schema_is_openai_strict_compliant():
+    # Every key in properties must be in required, recursively (OpenAI strict mode).
+    _assert_strict(arl.FINDINGS_SCHEMA)
+
+
+def test_optional_finding_fields_are_nullable_in_schema():
+    item_props = arl.FINDINGS_SCHEMA["properties"]["findings"]["items"]["properties"]
+    for field in ("ambiguity_flag", "ambiguity_reason", "location"):
+        t = item_props[field]["type"]
+        assert "null" in t, f"{field} must allow null (strict mode requires it in `required`)"
+
+
+def test_validate_finding_accepts_null_optionals():
+    # Codex now returns ALL fields (optionals as null) under strict mode.
+    f = _finding(ambiguity_flag=None, ambiguity_reason=None, location=None)
+    ok, errs = arl.validate_finding(f)
+    assert ok, errs
+
+
+def test_normalize_handles_null_location():
+    f = _finding(location=None, ambiguity_flag=None)
+    out = arl.normalize_findings([f])
+    assert len(out) == 1
+
+
+def test_strict_schema_validates_full_findings_with_jsonschema():
+    jsonschema = pytest.importorskip("jsonschema")
+    doc = {"summary": "s", "findings": [
+        {"severity": "High", "category": "security", "description": "d",
+         "recommendation": "r", "ambiguity_flag": None, "ambiguity_reason": None, "location": None},
+    ]}
+    jsonschema.validate(doc, arl.FINDINGS_SCHEMA)  # must not raise

--- a/tests/hooks/test_adversarial_review_schema.py
+++ b/tests/hooks/test_adversarial_review_schema.py
@@ -165,6 +165,20 @@ def test_validate_finding_accepts_null_optionals():
     assert ok, errs
 
 
+@pytest.mark.parametrize("field,bad", [
+    ("location", 123),
+    ("location", []),
+    ("ambiguity_reason", 42),
+    ("ambiguity_reason", {"x": "y"}),
+])
+def test_validate_finding_rejects_wrong_type_optionals(field, bad):
+    # Step 11 High: optionals are required-but-nullable in the schema, so a
+    # non-null wrong TYPE must be rejected (not just null accepted).
+    f = _finding(**{field: bad})
+    ok, errs = arl.validate_finding(f)
+    assert not ok and any(field in e for e in errs)
+
+
 def test_normalize_handles_null_location():
     f = _finding(location=None, ambiguity_flag=None)
     out = arl.normalize_findings([f])


### PR DESCRIPTION
## Summary

Extends the WF5 cross-model adversarial review (shipped in #77) to the **WF1** and **WF4** quality gates, adds the skill's `evals.json`, and **rolls in the #80 fix** for OpenAI strict structured-output (the same engine WF1/WF4 use — it would otherwise silently break them).

Closes #79
Closes #80

## #79 — WF1/WF4 integration + evals

- **WF1 (`create-issue`) Step 4:** opt-in, **default-off** cross-model review of the draft issue spec; merges findings into the existing ambiguity circuit breaker. WF1 has **no `plan_lib` loop-back**, so the hook uses none.
- **WF4 (`refactor`) Step 4:** opt-in cross-model review of the refactoring design, **Extract/Restructure path only** (Rename/Simplify skips it); loop-back uses WF4's **own textual `LOOPBACK_BUDGET`**, not `plan_lib`.
- Both hooks: gate checked first (true no-op when disabled), **non-blocking / fail-closed** on any Codex failure (incl. headless) — never ERROR/block the host workflow. Only the standalone WF5 skill ERRORs on prereq.
- `/rawgentic:setup` Step 2d generalized to offer all four workflows.
- New `skills/adversarial-review-workspace/evals/evals.json` — 3 **structural / no-live-Codex** evals (prereq STOP, path-traversal refusal, report-only).
- No engine change for enablement (`is_enabled_for` is skill-name-generic). `v2.24.0 → 2.25.0`; evals count `14/16 → 15/16`.

## #80 — FINDINGS_SCHEMA rejected by OpenAI strict mode (silent WF5 breakage)

OpenAI strict structured-output (used by `codex exec --output-schema`) requires **every** `properties` key to be in `required`, recursively. The shipped schema omitted `summary`/`ambiguity_flag`/`ambiguity_reason`/`location`, so **every** review against OpenAI returned HTTP 400 — and since all callers treat Codex failure as non-blocking, they **silently skipped** the review. Fix:

- `FINDINGS_SCHEMA`: all properties in `required` at both levels; optionals nullable (`["<type>","null"]`); `summary` required.
- `validate_finding`: accepts null optionals **and** type-checks them (non-null wrong type rejected).
- `normalize_findings`/`render_report_md`: null-safe for `location`.
- **Regression test** asserts strict-compliance via schema introspection — **no live call** (closes the exact CI gap that let it ship).

## Verification

- **Tests:** `pytest tests/` → **646 passed, 3 skipped** (2 skips are bonus `jsonschema` checks). New: WF1/WF4 drift guards, `is_enabled_for` genericity, evals validity, strict-schema compliance, null-optional accept + wrong-type reject.
- **CI:** matches local.

## Quality Gate Summary

- **Step 4 — Design critique** (3-judge): 0 design flaws; caught a real error (WF4 uses its *own* textual budget, not `plan_lib`) before coding.
- **Step 11 — Pre-PR review** (3 agents + adversarial verify): 1 High (verified) — `validate_finding` didn't type-check the new nullable optionals — fixed + tests; 2 Low applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
