### PR TITLE
feat(skills): add interview skill for pre-build requirements discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "rawgentic",
-      "description": "11 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
+      "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
       "source": "./",
       "strict": true,
       "skills": [
@@ -22,6 +22,7 @@
         "./skills/fix-bug",
         "./skills/implement-feature",
         "./skills/incident",
+        "./skills/interview",
         "./skills/new-project",
         "./skills/optimize-perf",
         "./skills/refactor",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rawgentic",
-  "version": "2.25.0",
-  "description": "11 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code: project registration, setup, session binding, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
+  "version": "2.26.0",
+  "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",
     "url": "https://github.com/3D-Stories"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rawgentic
 
-**11 SDLC workflow skills + 4 workspace management + 1 security skill + hooks for Claude Code**
+**11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-purple)](https://docs.anthropic.com/en/docs/claude-code)
@@ -11,10 +11,10 @@
 
 Claude Code is powerful but unstructured. Complex tasks — building features, fixing bugs, running security audits — need consistent quality gates, test-driven development, and deployment verification. Without guardrails, it's easy to skip code review, forget to run CI, or merge without testing.
 
-**Rawgentic** provides 16 skills organized in three layers:
+**Rawgentic** provides 17 skills organized in three layers:
 
 - **Workspace management** (4 skills) — Project registration, configuration, session binding, and guard exception management
-- **SDLC workflows** (10 skills) — Multi-step guided processes with quality gates, code review, CI verification, and deployment
+- **SDLC workflows** (11 skills) — Multi-step guided processes with quality gates, code review, CI verification, and deployment, plus a lightweight `interview` skill for pre-build requirements discovery
 - **Security & infrastructure** (1 skill + hooks) — Security pattern syncing, dangerous pattern blocking, per-project WAL logging, session binding enforcement, and cross-project file guards
 
 All workflow skills share a **config-loading protocol** that reads project configuration from `.rawgentic.json` — no hardcoded constants, no CLAUDE.md templates, no filesystem probing.
@@ -107,6 +107,12 @@ Multiple projects can be active simultaneously. Use `/rawgentic:switch` to bind 
 | `/rawgentic:setup`          | Auto-detect tech stack, optional critique for complex projects, generate `.rawgentic.json` |
 | `/rawgentic:switch`         | Bind this session to a project, list projects, or deactivate. Checks for config staleness and prompts for missing `defaultProtectionLevel`. |
 | `/rawgentic:add-exception`  | Interactively add guard exceptions to `.rawgentic.json` when a WAL or security guard blocks a legitimate operation. |
+
+### Planning
+
+| Skill                  | Purpose                                              |
+| ---------------------- | ---------------------------------------------------- |
+| `/rawgentic:interview` | Interview-style requirements discovery **before** building. Identifies the core problem, who it is and isn't for, and key implementation decisions, then summarizes an implementation spec for confirmation (and offers to save it). Lightweight — no config-loading or quality gates; complements deeper design exploration. |
 
 ### SDLC Workflows
 
@@ -584,7 +590,7 @@ pytest tests/hooks/test_wal_guard.py -v
 
 **CI:** GitHub Actions runs `pytest tests/ -v` on all PRs to `main` (`.github/workflows/ci.yml`). SDLC workflows also run tests automatically when `.rawgentic.json` has a `testing` section configured.
 
-Skills are tested via the `/skill-creator` eval pipeline (15/16 skills have evals.json).
+Skills are tested via the `/skill-creator` eval pipeline (15/17 skills have evals.json; the lightweight `add-exception` and `interview` skills have none).
 
 **Workspace directories:** Some skills have a corresponding `*-workspace/` directory (e.g., `skills/setup-workspace/`) used for internal skill iteration and evaluation. These contain `evals/`, `iteration-N/`, and `skill-snapshot/` subdirectories. They are **excluded from marketplace installs** via the `skills` whitelist in `marketplace.json`. If you add a new workspace directory, never name a file `SKILL.md` inside it — the marketplace validator scans for that filename recursively and will reject duplicates.
 

--- a/docs/skill-development.md
+++ b/docs/skill-development.md
@@ -25,6 +25,17 @@ invokes `/rawgentic:<name>`. This typically includes role definitions,
 constants, numbered workflow steps, quality gates, and config-loading
 instructions.
 
+> **Config-driven workflows vs. lightweight skills.** The 11 SDLC workflow
+> skills are *config-driven*: each opens with a `<config-loading>` block,
+> reads `.rawgentic.json`, and runs numbered quality-gated steps. Not every
+> skill needs that machinery. Lightweight skills such as `add-exception`
+> (workspace management) and `interview` (a pre-build requirements-discovery
+> skill) are a `<role>` plus a short prompt body — no `<config-loading>`, no
+> plan_lib counters, no eval workspace. Keep new skills lightweight unless they
+> genuinely need the full workflow protocol. The `<config-loading>` canary in
+> `tests/hooks/test_headless.py` expects exactly 11 skills to carry that block,
+> so adding it to a skill is a deliberate choice that must bump the canary.
+
 ### Invocation
 
 Users invoke a skill with `/rawgentic:<name>` followed by optional arguments.

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: rawgentic:interview
+description: Interview the user about what they want to build BEFORE any code is written. Use at the very start of a new feature, app, component, or behavior change — especially when the requirements are vague or unstated — to identify the core problem, who it is and isn't for, and the key implementation decisions, then summarize an implementation spec for confirmation. Invoke with /rawgentic:interview, or proactively when the user says "let's build", "I want to make", or "can you add" something whose requirements aren't yet pinned down. Complements (does not replace) deeper design exploration like brainstorming.
+argument-hint: optional — what you want to build (e.g., "a habit-tracking app")
+---
+
+<role>
+You are the rawgentic build interviewer. Before any code is written, you interview the user to surface the real problem, the intended (and explicitly out-of-scope) audience, and the key decisions that shape implementation. You finish by reflecting an implementation spec back for confirmation. You do NOT write code in this skill.
+</role>
+
+# Interview — `/rawgentic:interview`
+
+Before we start building, interview me about what we're trying to build.
+Work with me to identify the core problem we're solving, who it is and isn't for.
+As part of the interview, let's work through any key decisions together to help inform the implementation strategy.
+Then summarize it back to me as an implementation spec before we write any code.
+
+## After the spec is confirmed
+
+Once you've summarized the implementation spec back to me and I've confirmed it:
+
+- **Offer to save the spec to a file** so later work can reference it. Propose a path under the active project's `docs/` (for example `docs/specs/<slug>.md`), and write it only if I agree.
+- Do not start implementing from this skill. If I want to proceed, point me to `/rawgentic:create-issue` to turn the spec into a tracked issue, or `/rawgentic:implement-feature` to build it.

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.25.0"
+    assert plugin["version"] == "2.26.0"
 
 
 def test_descriptions_consistent_count():
@@ -52,9 +52,9 @@ def test_readme_count_strings_updated():
     readme = (REPO_ROOT / "README.md").read_text()
     assert "11 SDLC workflow skills" in readme
     assert "10 SDLC workflow skills" not in readme
-    assert "provides 16 skills" in readme
+    assert "provides 17 skills" in readme
     assert "All 11 workflow skills share" in readme
-    assert "15/16 skills have evals.json" in readme
+    assert "15/17 skills have evals.json" in readme
 
 
 def test_marketplace_skill_dirs_all_exist():

--- a/tests/test_interview_skill.py
+++ b/tests/test_interview_skill.py
@@ -1,0 +1,69 @@
+"""Drift guards for the `interview` skill (lightweight planning skill).
+
+`interview` is NOT a config-driven SDLC workflow — it deliberately has no
+`<config-loading>` block — so it must NOT be counted among the 11 config-driven
+workflow skills, and it must NOT trip the config-loading canary in
+`tests/hooks/test_headless.py`.
+
+It registers in the marketplace whitelist (alphabetical placement) and is
+accounted for as a separate "planning skill" in the count strings.
+"""
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+SKILL = SKILLS_DIR / "interview" / "SKILL.md"
+
+
+def test_skill_dir_and_frontmatter_exist():
+    assert SKILL.exists(), "skills/interview/SKILL.md missing"
+    text = SKILL.read_text()
+    assert "name: rawgentic:interview" in text
+    assert "description:" in text
+    assert "argument-hint:" in text
+
+
+def test_skill_is_lightweight_no_config_loading():
+    """interview must stay lightweight — no <config-loading>, so the 11-count canary holds."""
+    text = SKILL.read_text()
+    assert "<config-loading>" not in text
+
+
+def test_skill_contains_verbatim_core_prompt():
+    text = SKILL.read_text()
+    assert "interview me about what we're trying to build" in text
+    assert "who it is and isn't for" in text
+    assert "work through any key decisions together" in text
+    assert "summarize it back to me as an implementation spec" in text
+
+
+def test_skill_offers_to_write_spec_file():
+    """User decision: after summarizing, offer to persist the spec to a file."""
+    text = SKILL.read_text().lower()
+    assert "offer to save" in text or "offer to write" in text
+    assert "docs/" in text
+
+
+def test_marketplace_registers_skill_alphabetically():
+    mp = json.loads((REPO_ROOT / ".claude-plugin" / "marketplace.json").read_text())
+    skills = mp["plugins"][0]["skills"]
+    assert "./skills/interview" in skills
+    # alphabetical placement: incident < interview < new-project
+    assert skills.index("./skills/interview") == skills.index("./skills/incident") + 1
+
+
+def test_descriptions_account_for_interview_as_planning_skill():
+    plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
+    mp = json.loads((REPO_ROOT / ".claude-plugin" / "marketplace.json").read_text())
+    for desc in (plugin["description"], mp["plugins"][0]["description"]):
+        # interview is a separate planning skill, NOT a 12th SDLC workflow
+        assert "11 SDLC workflow skills" in desc
+        assert "planning skill" in desc
+
+
+def test_no_eval_workspace_skill_md():
+    """If an interview-workspace dir ever appears, it must not contain a SKILL.md
+    (the marketplace validator rejects duplicate SKILL.md names)."""
+    ws = SKILLS_DIR / "interview-workspace"
+    assert not (ws / "SKILL.md").exists()


### PR DESCRIPTION
## Summary

Adds `/rawgentic:interview` — a lightweight planning skill that interviews the user **before any code is written**. It works through the core problem, who it is and isn't for, and the key implementation decisions, then summarizes an implementation spec for confirmation and offers to save it.

The skill's body uses the requested prompt verbatim, wrapped only with a `<role>` and a short "after the spec is confirmed" section that (per the requested behavior) offers to persist the spec under the active project's `docs/` and points to `/rawgentic:create-issue` or `/rawgentic:implement-feature` for next steps.

## Design decision: lightweight, not a 12th workflow

`interview` is intentionally **not** a config-driven SDLC workflow — no `<config-loading>` block, no `plan_lib` counters, no eval workspace (modeled on `add-exception`). This keeps the `<config-loading>` canary at exactly 11 and counts `interview` as a separate **planning skill** rather than a 12th workflow. Its `description` is written to auto-trigger before build work, while noting it complements (does not replace) deeper design exploration.

## Changes

- **New skill:** `skills/interview/SKILL.md`
- **Registration:** `./skills/interview` added to `marketplace.json` (alphabetical, after `incident`)
- **Version:** `2.25.0` → `2.26.0` (minor — new feature)
- **Descriptions:** plugin.json + marketplace.json now say `… + 1 planning skill + …` and list "requirements interviewing"
- **README:** total 16 → **17 skills**, fixed stale "10 skills" → 11 in the layer breakdown, new **Planning** subsection, evals note `15/17`
- **Docs:** `docs/skill-development.md` documents the config-driven-vs-lightweight distinction
- **Tests:** new `tests/test_interview_skill.py` drift guards; version/count snapshots in `test_adversarial_review_registration.py` updated

## Testing

`pytest tests/ -v` — **653 passed, 3 skipped** locally (the project's full suite / CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)