### PR TITLE
docs(implement-feature): WF2 SKILL.md cleanup — numbering, loop-back source-of-truth, Step 8 headers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -357,6 +357,8 @@ design_loopback_count = 0
 tdd_loopback_used = false
 review_loopback_used = false
 global_loopback_total = 0
+
+**Source of truth:** once it exists, `claude_docs/.wf2-state/<issue>/loopback_counters.json` (written via `plan_lib.consume_loopback`) is canonical for all *successfully persisted* counts — it survives context compaction, fresh headless sessions, and worktrees. The in-context variables above are a convenience mirror: on resume, initialize them from the file when it is present, otherwise from the defaults above (a missing file means "no loop-backs consumed yet," not an error). Do not write the in-context values back over a more-advanced file. If a `consume_loopback` call increments the in-context counter but fails to persist, treat that as a blocker — reconcile or STOP rather than blindly trusting either side, since a stale file would silently restore spent budget.
 </loop-back-budget>
 
 <resumption-protocol>
@@ -492,18 +494,18 @@ This enables workflow resumption if context is lost.
 
 4. **Memory search (Layer 3 — proactive recall).** If a mempalace MCP server is available (`mcp__mempalace__*` tools loaded), call `mempalace_search` with the feature topic and `mempalace_kg_query` for entity-specific facts. Surface prior architectural decisions, known gotchas, and related implementations in this area. Reference findings explicitly when designing the implementation. If no mempalace MCP server is configured, skip silently.
 
-4. **Existing test/verification inventory:** Identify any existing tests, verification scripts, or validation mechanisms that cover the affected code. Note gaps.
+5. **Existing test/verification inventory:** Identify any existing tests, verification scripts, or validation mechanisms that cover the affected code. Note gaps.
 
-5. **Library and image research:** If the feature uses libraries in new ways, use Context7 MCP to fetch current documentation. For infrastructure projects, inspect Docker images that will be used — check for built-in migration files, supported database drivers, pre-installed packages (e.g., `psycopg2` in a Python image), and default configurations. This prevents designing around incorrect assumptions about image capabilities.
+6. **Library and image research:** If the feature uses libraries in new ways, use Context7 MCP to fetch current documentation. For infrastructure projects, inspect Docker images that will be used — check for built-in migration files, supported database drivers, pre-installed packages (e.g., `psycopg2` in a Python image), and default configurations. This prevents designing around incorrect assumptions about image capabilities.
 
-6. **Complexity classification:**
+7. **Complexity classification:**
    - `simple_change`: 1-3 files, no architecture change, no migration, no new deps
    - `standard_feature`: 4-15 files, contained scope, may need configuration changes
    - `complex_feature`: 15+ files, cross-service changes, multiple configuration changes, new deps
 
    This classification is AUTHORITATIVE — it overrides any complexity label from the GitHub issue.
 
-7. **Fast path eligibility:**
+8. **Fast path eligibility:**
    - If `simple_change`: `fast_path_eligible = true`
    - If `standard_feature` AND `is_wf1_created`: `fast_path_eligible = true`
    - Otherwise: `fast_path_eligible = false`
@@ -868,15 +870,16 @@ Promotion at the last task still triggers Step 8a (and any retroactive scan) bef
 ### Output
 For each high-risk task: an applied|deferred review log entry, committed status pointer updated, optional fix commits, session-note marker. The branch is not "ready" until the last `last_review_log_status` is `"applied"`.
 
-### Failure Modes
+### Step 8a Failure Modes
 - Reviewer cost spike on a plan with many high-risk tasks: confirmed expected behavior (P15 trades cost for early signal).
 - A Step 8a-deferred High finding is never re-presented at Step 11: this is what `plan_lib.assert_no_unresolved_high_deferrals` defends against in Step 11's exit check.
 
 ---
 
-### Continuing Step 8 (after the per-task review block above)
+### Step 8 Failure Modes (main task loop)
 
-### Failure Modes
+These apply to the main Step 8 implementation loop above (Step 8a, the per-task review sub-step, has its own failure modes listed under it).
+
 - Verification fails and cannot be fixed -> flag blocker to user
 - Design flaw discovered -> loop back to Step 3 if budget allows
 - For TDD: test passes before implementation (test not testing right thing) -> rewrite test

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.26.0"
+    assert plugin["version"] == "2.26.1"
 
 
 def test_descriptions_consistent_count():


### PR DESCRIPTION
## Summary

PR 1 of a careful, multi-PR cleanup of the WF2 `implement-feature` SKILL.md (surfaced during a skill-creator review). **Zero behavior change** — three concrete defects, no logic moved.

1. **Step 2 numbering** — the ordered list had two items numbered `4.`; renumbered to read 1→8.
2. **`<loop-back-budget>` source-of-truth** — the loop-back budget was tracked in *both* in-context variables and a persisted `loopback_counters.json` with no statement of which wins on resume. Added one paragraph making the file canonical for *successfully-persisted* counts, with explicit handling for the file-absent first-run (= defaults, not an error) and the persist-failure-after-increment race (= blocker, reconcile/STOP).
3. **Step 8 failure-mode headers** — removed an empty `### Continuing Step 8` stub and disambiguated the two identically-titled `### Failure Modes` blocks into `### Step 8a Failure Modes` and `### Step 8 Failure Modes (main task loop)`.

## Design Decisions

- **Scoped to non-structural fixes.** The headless-protocol extraction (to `references/`) and the WF2 latency/subagent optimization are deliberately split into later PRs to keep this one trivially reviewable.
- **Drift guards respected.** No `plan_lib` helper references, risk-criteria strings, or adversarial-review gate strings were moved out of their required `## Step N` sections.

## Verification

- Cross-model **adversarial review via Codex** on the diff: no Critical/High/Medium findings. Two Low findings on the loop-back wording (file-absent + crash-race) were incorporated before commit.
- Full suite: **653 passed, 3 skipped**.
- Version bumped `2.26.0` → `2.26.1` with the matching version-pin test updated.

## Quality Gate Summary
- Cleanup only; no new ACs. Behavior-preserving by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
