### PR TITLE
feat(implement-feature): validated parallel_group + disjointness validator (WF2 opt-C, PR 3a)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -849,7 +849,12 @@ while keeping the cross-cutting PR-wide review intact.
 
 - **WF2 Step 5:** every task in the plan carries
   `riskLevel: high|standard` per the format contract enforced by
-  `hooks/plan_lib.parse_tasks` (fail-closed on missing field).
+  `hooks/plan_lib.parse_tasks` (fail-closed on missing field). Tasks may
+  also carry optional `parallel_group` + `files`; `validate_parallel_groups`
+  proves same-group tasks are file-disjoint so an un-provable group degrades
+  to sequential execution (never a collision). Isolated *concurrent* execution
+  of eligible groups via detached worktrees is tracked separately (the
+  worktree statement in Principle 1 remains aspirational until then).
 - **WF2 Step 8a:** for each high-risk task's commit, dispatch 2 inline
   reviewer roles (code-level + silent-failure hunt) via the Agent tool.
   Severity-banded confidence filter (Critical ≥0.50, High ≥0.65,

--- a/hooks/plan_lib.py
+++ b/hooks/plan_lib.py
@@ -35,6 +35,12 @@ class Task:
     title: str
     risk_level: Literal["high", "standard"]
     reason: str | None  # parenthesized reason for high-risk; None for standard
+    # Optional, purely additive (PR 3a / optimization C). A task may declare a
+    # `parallel_group` and the `files` it touches so validate_parallel_groups can
+    # prove same-group tasks are file-disjoint. Absent -> not parallel-eligible.
+    # tuple (not list) to stay hashable under frozen=True.
+    parallel_group: str | None = None
+    files: tuple[str, ...] = ()
 
 
 # --- Env-var loading with clamping and freeze-at-import ---
@@ -102,7 +108,17 @@ _RISKLEVEL_RE = re.compile(
     r"^\s*[-*]\s*riskLevel\s*:\s*(high|standard)(?:\s*\(([^)]+)\))?\s*$",
     re.IGNORECASE,
 )
+# Optional parallel-execution annotations (PR 3a). Both purely additive — their
+# absence never changes the riskLevel fail-closed contract or the pre-P15 migration.
+_PARALLEL_GROUP_RE = re.compile(r"^\s*[-*]\s*parallel_group\s*:\s*(\S+)\s*$", re.IGNORECASE)
+_FILES_RE = re.compile(r"^\s*[-*]\s*files\s*:\s*(.+?)\s*$", re.IGNORECASE)
 _ANY_HEADING_RE = re.compile(r"^#{1,6}\s+")
+
+
+def _split_files(raw: str) -> tuple[str, ...]:
+    """Split a `- files:` line value on commas/whitespace into a tuple."""
+    parts = [p.strip() for p in re.split(r"[,\s]+", raw) if p.strip()]
+    return tuple(parts)
 
 
 def parse_tasks(plan_markdown: str) -> list[Task]:
@@ -123,7 +139,7 @@ def parse_tasks(plan_markdown: str) -> list[Task]:
     bug, not a migration.
     """
     lines = plan_markdown.splitlines()
-    raw_tasks: list[tuple[str, str, str | None, str | None]] = []
+    raw_tasks: list[tuple[str, str, str | None, str | None, str | None, tuple[str, ...]]] = []
     i = 0
     while i < len(lines):
         m = _TASK_HEADER_RE.match(lines[i])
@@ -134,6 +150,8 @@ def parse_tasks(plan_markdown: str) -> list[Task]:
         # Scan body until next ### heading or EOF
         risk_level: str | None = None
         reason: str | None = None
+        parallel_group: str | None = None
+        files: tuple[str, ...] = ()
         body_start = i + 1
         j = body_start
         while j < len(lines):
@@ -143,11 +161,17 @@ def parse_tasks(plan_markdown: str) -> list[Task]:
             if mm:
                 risk_level = mm.group(1).lower()
                 reason = mm.group(2).strip() if mm.group(2) else None
+            pg = _PARALLEL_GROUP_RE.match(lines[j])
+            if pg:
+                parallel_group = pg.group(1)
+            fm = _FILES_RE.match(lines[j])
+            if fm:
+                files = _split_files(fm.group(1))
             j += 1
-        raw_tasks.append((task_id, title, risk_level, reason))
+        raw_tasks.append((task_id, title, risk_level, reason, parallel_group, files))
         i = j
 
-    tagged_count = sum(1 for _, _, rl, _ in raw_tasks if rl is not None)
+    tagged_count = sum(1 for _, _, rl, _, _, _ in raw_tasks if rl is not None)
     if raw_tasks and tagged_count == 0:
         # Pre-P15 plan: default every task to standard and warn once.
         print(
@@ -157,18 +181,129 @@ def parse_tasks(plan_markdown: str) -> list[Task]:
             file=sys.stderr,
         )
         return [
-            Task(id=tid, title=t, risk_level="standard", reason=None)
-            for tid, t, _, _ in raw_tasks
+            Task(id=tid, title=t, risk_level="standard", reason=None,
+                 parallel_group=pg, files=fs)
+            for tid, t, _, _, pg, fs in raw_tasks
         ]
 
     out: list[Task] = []
-    for tid, t, rl, r in raw_tasks:
+    for tid, t, rl, r, pg, fs in raw_tasks:
         if rl is None:
             raise PlanFormatError(
                 f"Task {tid} ({t!r}) is missing required `riskLevel` line"
             )
-        out.append(Task(id=tid, title=t, risk_level=rl, reason=r))
+        out.append(Task(id=tid, title=t, risk_level=rl, reason=r,
+                        parallel_group=pg, files=fs))
     return out
+
+
+_GLOB_CHARS = frozenset("*?[]")
+
+
+def _classify_decl(path: str) -> tuple[str, str]:
+    """Classify a declared file path for disjointness proof.
+
+    Returns ``(kind, value)``. ``kind`` is ``"ok"`` with ``value`` set to a
+    canonical comparison key (normalized + case-folded), or one of
+    ``"glob"``/``"directory"``/``"absolute"`` (value = the raw path) when the
+    declaration cannot be statically proven disjoint. We case-fold so that on a
+    case-insensitive filesystem ``A.py`` and ``a.py`` are treated as the same
+    file — this can only ADD conflicts (lose the optimization), never miss a
+    real collision. Symlink/hardlink aliasing is out of scope for a pure static
+    check; the runtime touched-file gate (issue #85, PR 3b) is the real backstop.
+    """
+    if any(c in _GLOB_CHARS for c in path):
+        return ("glob", path)
+    if path.endswith("/"):
+        return ("directory", path)
+    if os.path.isabs(path):
+        return ("absolute", path)
+    norm = os.path.normpath(path)
+    # Reject anything that escapes the repo or denotes the root: `..`, `../x`
+    # (can re-enter and alias another declared file), and `.` (the root, an
+    # ancestor of every path — the prefix-based overlap check would miss it).
+    if norm == "." or norm == ".." or norm.startswith(".." + os.sep) or norm.startswith("../"):
+        return ("non-repo-relative", path)
+    return ("ok", norm.casefold())
+
+
+def validate_parallel_groups(tasks: list[Task]) -> tuple[bool, list[str]]:
+    """Prove that same-`parallel_group` tasks are statically file-disjoint.
+
+    Returns ``(all_eligible, conflicts)``. ``all_eligible`` is True iff every
+    parallel_group with >=2 members has every member declaring concrete,
+    repo-relative, non-glob, non-directory ``files`` AND no two members'
+    declared paths are equal or nested (one an ancestor directory of the
+    other). Ungrouped tasks (parallel_group is None) and singleton groups are
+    never flagged.
+
+    A conflict (overlap, missing files, glob, directory, or absolute path)
+    means the group is NOT parallel-eligible. The caller MUST run such a group
+    sequentially — so an un-provable group degrades to serial execution, never
+    to a concurrent collision. This is a STATIC pre-dispatch heuristic only;
+    the runtime touched-file gate (issue #85, PR 3b) is the real backstop once
+    isolated parallel execution exists.
+    """
+    groups: dict[str, list[Task]] = {}
+    for t in tasks:
+        if t.parallel_group is not None:
+            groups.setdefault(t.parallel_group, []).append(t)
+
+    conflicts: list[str] = []
+    for gid, members in groups.items():
+        if len(members) < 2:
+            continue  # nothing to parallelize / no overlap possible
+
+        # Phase 1 — every member must declare only provable concrete files.
+        # If ANY member's declaration is unprovable, the whole group is not
+        # eligible and we skip the overlap proof (avoids under-reporting).
+        group_valid = True
+        norm_sets: dict[str, set[str]] = {}
+        for t in members:
+            if not t.files:
+                conflicts.append(
+                    f"parallel_group {gid!r}: task {t.id} declares no files "
+                    f"-> cannot prove disjointness, not parallel-eligible"
+                )
+                group_valid = False
+                continue
+            normed: set[str] = set()
+            for f in t.files:
+                kind, value = _classify_decl(f)
+                if kind != "ok":
+                    label = {"absolute": "absolute path",
+                             "non-repo-relative": "non-repo-relative path"}.get(kind, kind)
+                    conflicts.append(
+                        f"parallel_group {gid!r}: task {t.id} declares {label} {f!r} "
+                        f"-> cannot prove disjointness, not parallel-eligible"
+                    )
+                    group_valid = False
+                else:
+                    normed.add(value)
+            norm_sets[t.id] = normed
+        if not group_valid:
+            continue
+
+        # Phase 2 — pairwise overlap among fully-valid members. Two paths
+        # collide if equal OR one is an ancestor directory of the other.
+        ids = list(norm_sets.keys())
+        for a in range(len(ids)):
+            for b in range(a + 1, len(ids)):
+                for fa in sorted(norm_sets[ids[a]]):
+                    for fb in sorted(norm_sets[ids[b]]):
+                        if fa == fb:
+                            conflicts.append(
+                                f"parallel_group {gid!r}: tasks {ids[a]} and {ids[b]} both "
+                                f"touch {fa} -> overlap, not parallel-eligible"
+                            )
+                        elif fb.startswith(fa + "/") or fa.startswith(fb + "/"):
+                            conflicts.append(
+                                f"parallel_group {gid!r}: tasks {ids[a]} and {ids[b]} declare "
+                                f"nested paths {fa} / {fb} -> cannot prove disjointness, "
+                                f"not parallel-eligible"
+                            )
+
+    return (len(conflicts) == 0, conflicts)
 
 
 # --- Risk-ratio calibration ---

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -673,7 +673,11 @@ Amended design document.
    - VERIFY: Run a verification command (health check, syntax check, dry-run, or manual inspection)
    - Document what "verified" means for this task
 
-3. **Task ordering:** Make dependencies explicit. Mark parallel-eligible tasks with the same `parallel_group`.
+3. **Task ordering:** Make dependencies explicit. Parallel-eligible tasks share a `parallel_group` AND each declares the files it touches via a `- files: <comma-separated paths>` line, so disjointness can be proven mechanically:
+   - `- parallel_group: <group-id>` — tasks with the same id are candidates to run concurrently.
+   - `- files: <comma-separated paths>` — the exact files the task creates/modifies (concrete paths only; globs and directories cannot be proven disjoint).
+
+   After decomposition, call `plan_lib.validate_parallel_groups(tasks)`; it returns `(all_eligible, conflicts)`. A group is parallel-eligible ONLY when every member declares concrete `files` and the members' file sets are pairwise disjoint. Any conflict (overlap, missing files, glob, or directory) means that group is **not** parallel-eligible and **runs sequentially** — an un-provable group degrades to serial execution, never to a concurrent collision. Log conflicts to session notes. (Isolated *concurrent* execution of eligible groups is added in a follow-up; today eligible groups still execute sequentially but are validated so the contract is ready.)
 
 3a. **Risk stratification (P15):** Tag every task with a `riskLevel: high|standard` field. Use **`high`** if ANY of the 8 criteria apply; otherwise `standard`. The 8 criteria (canonical list lives in `hooks/plan_lib.py::RISK_CRITERIA`):
 
@@ -690,6 +694,7 @@ Amended design document.
    - Each task begins with `### Task <id>: <title>` heading.
    - Each task body MUST contain a line `- riskLevel: high|standard`; high-risk tasks include a parenthesized reason: `- riskLevel: high (security surface)`.
    - Tasks lacking a `riskLevel` line **fail closed** (parse error → STOP). **[Headless: ERROR — add `rawgentic:ai-error` label, post comment explaining the plan format contract.]**
+   - OPTIONAL: `- parallel_group: <id>` and `- files: <comma-separated paths>` (see Task ordering above). These are purely additive — absent fields just mean the task is not parallel-eligible; they never affect the `riskLevel` fail-closed contract or the pre-P15 migration.
 
    **Calibration check** — after task decomposition, compute the high-risk ratio via `plan_lib.compute_risk_ratio(tasks)` and classify via `plan_lib.check_ratio_band(ratio, len(tasks))`. Handle the result:
 
@@ -820,7 +825,7 @@ Execute the implementation plan task by task.
    git push origin <branch_name>
    ```
 
-**Parallel task execution:** For independent tasks (same `parallel_group`), dispatch via parallel Agent tool calls.
+**Parallel task execution (validated, currently serial):** Use the parallel-eligibility result from Step 5's `plan_lib.validate_parallel_groups(tasks)` to know which groups *could* run concurrently. **Until isolated concurrent execution lands (issue #85), execute ALL tasks sequentially in plan order**, including parallel-eligible groups. Do NOT dispatch concurrent Agent calls that write to the working tree: with no worktree isolation, concurrent edits to the shared tree can collide and corrupt commits — sequential execution is the safe floor. **Staging backstop:** the "stage ONLY this task's files, never `git add -A`" rule above applies to every task; when a task additionally declares `files`, that rule becomes machine-checkable — assert the staged set is a subset of the declared `files` and STOP to reconcile if not. (A task in a parallel_group that declared no `files` is already non-eligible and runs sequentially under the same stage-only-this-task's-files rule.)
 
 **Mid-flight risk promotion (P15):** After implementing each task and staging its diff, re-evaluate the task against the 8 risk criteria via two paths:
 

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.27.0"
+    assert plugin["version"] == "2.28.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_parallel_groups.py
+++ b/tests/hooks/test_parallel_groups.py
@@ -1,0 +1,166 @@
+"""Tests for WF2 Step 8 parallel_group support (PR 3a, optimization C).
+
+Covers the two additive plan_lib pieces that make parallel_group a real,
+validated concept (execution stays serial until the worktree layer in #85):
+- parse_tasks captures optional `parallel_group` + `files` per task
+  (purely additive; the riskLevel fail-closed contract is unchanged)
+- validate_parallel_groups(tasks) -> (all_eligible, conflicts): proves
+  same-group tasks are file-disjoint, so a group can NEVER be parallelized
+  into a collision. Cannot-prove-disjointness (missing files, glob, dir,
+  overlap) degrades to NOT-eligible (caller runs it sequentially).
+"""
+import sys
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+import plan_lib  # noqa: E402
+
+
+# --- parse_tasks: optional parallel_group + files ---
+
+def test_parse_tasks_captures_parallel_group_and_files():
+    plan = """### Task 1: do thing
+- riskLevel: standard
+- parallel_group: g1
+- files: src/a.py, src/b.py
+"""
+    (task,) = plan_lib.parse_tasks(plan)
+    assert task.parallel_group == "g1"
+    assert task.files == ("src/a.py", "src/b.py")
+
+
+def test_parse_tasks_back_compat_no_parallel_fields():
+    plan = """### Task 1: do thing
+- riskLevel: high (security surface)
+"""
+    (task,) = plan_lib.parse_tasks(plan)
+    assert task.parallel_group is None
+    assert task.files == ()
+    # everything else unchanged
+    assert task.risk_level == "high"
+    assert task.reason == "security surface"
+
+
+def test_parse_tasks_risklevel_contract_unchanged_with_parallel_fields():
+    """Partial annotation still fail-closes even when the untagged task carries
+    parallel_group/files — the additive fields must not weaken the contract.
+    (A *fully* untagged plan is the pre-P15 migration, not a partial bug.)"""
+    plan = """### Task 1: tagged
+- riskLevel: standard
+
+### Task 2: untagged but has parallel fields
+- parallel_group: g1
+- files: a.py
+"""
+    import pytest
+    with pytest.raises(plan_lib.PlanFormatError):
+        plan_lib.parse_tasks(plan)
+
+
+# --- validate_parallel_groups ---
+
+def _t(id_, group=None, files=()):
+    return plan_lib.Task(id=id_, title=f"task {id_}", risk_level="standard",
+                         reason=None, parallel_group=group, files=tuple(files))
+
+
+def test_validate_parallel_groups_disjoint_ok():
+    tasks = [_t("1", "g1", ["a.py"]), _t("2", "g1", ["b.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is True
+    assert conflicts == []
+
+
+def test_validate_parallel_groups_overlap_fails():
+    tasks = [_t("1", "g1", ["a.py", "shared.py"]), _t("2", "g1", ["shared.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is False
+    assert any("shared.py" in c for c in conflicts)
+
+
+def test_validate_parallel_groups_missing_files_not_eligible():
+    tasks = [_t("1", "g1", ["a.py"]), _t("2", "g1", [])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is False
+    assert any("2" in c for c in conflicts)
+
+
+def test_validate_parallel_groups_ignores_ungrouped():
+    """Ungrouped tasks (parallel_group=None) are never compared, even if their
+    declared files collide — they run sequentially anyway."""
+    tasks = [_t("1", None, ["same.py"]), _t("2", None, ["same.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is True
+    assert conflicts == []
+
+
+def test_validate_parallel_groups_normalizes_paths():
+    """`./a.py` and `a.py` are the same file — overlap must still be caught."""
+    tasks = [_t("1", "g1", ["./a.py"]), _t("2", "g1", ["a.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is False
+    assert any("a.py" in c for c in conflicts)
+
+
+def test_validate_parallel_groups_rejects_glob():
+    """A glob declaration can't be proven disjoint statically -> not eligible."""
+    tasks = [_t("1", "g1", ["src/*.py"]), _t("2", "g1", ["other.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is False
+    assert any("glob" in c.lower() for c in conflicts)
+
+
+def test_validate_parallel_groups_rejects_directory():
+    """A directory declaration (trailing slash) can't be proven disjoint -> not eligible."""
+    tasks = [_t("1", "g1", ["src/"]), _t("2", "g1", ["other.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is False
+    assert any("director" in c.lower() for c in conflicts)
+
+
+def test_validate_parallel_groups_rejects_absolute_path():
+    """An absolute path can't be proven disjoint from a repo-relative one -> not eligible."""
+    tasks = [_t("1", "g1", ["/etc/thing.py"]), _t("2", "g1", ["thing.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is False
+    assert any("absolute" in c.lower() for c in conflicts)
+
+
+def test_validate_parallel_groups_case_insensitive_overlap():
+    """Same file via case variants must be flagged (safe under a case-insensitive FS)."""
+    tasks = [_t("1", "g1", ["A.py"]), _t("2", "g1", ["a.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is False
+    assert any("a.py" in c.lower() for c in conflicts)
+
+
+def test_validate_parallel_groups_directory_containment_overlap():
+    """A bare directory token containing another task's file is an overlap."""
+    tasks = [_t("1", "g1", ["src"]), _t("2", "g1", ["src/a.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is False
+    assert any("src" in c for c in conflicts)
+
+
+def test_validate_parallel_groups_rejects_parent_escape():
+    """`../x` can re-enter the repo and alias another declared file -> reject as unprovable."""
+    tasks = [_t("1", "g1", ["../other/a.py"]), _t("2", "g1", ["a.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is False
+    assert any("repo-relative" in c.lower() for c in conflicts)
+
+
+def test_validate_parallel_groups_rejects_dot_root():
+    """`.` (or anything normalizing to it) is the repo root — ancestor of everything -> reject."""
+    tasks = [_t("1", "g1", ["."]), _t("2", "g1", ["src/a.py"])]
+    ok, conflicts = plan_lib.validate_parallel_groups(tasks)
+    assert ok is False
+
+
+def test_validate_parallel_groups_singleton_and_empty_ok():
+    """No parallel groups, or a one-member group, is trivially fine."""
+    assert plan_lib.validate_parallel_groups([]) == (True, [])
+    assert plan_lib.validate_parallel_groups([_t("1", "g1", ["a.py"])]) == (True, [])
+    assert plan_lib.validate_parallel_groups([_t("1"), _t("2")]) == (True, [])

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -46,6 +46,7 @@ EXPECTED_REFERENCES = {
     "parse_tasks": ["5"],
     "compute_risk_ratio": ["5"],
     "check_ratio_band": ["5"],
+    "validate_parallel_groups": ["5"],  # PR 3a: parallel_group disjointness validator
     "should_promote": ["8"],
     "format_promotion_note": ["8"],
     "scan_prior_commits_for_trigger": ["8"],


### PR DESCRIPTION
## Summary

**PR 3a of optimization "C" (parallel Step 8).** Lands the *validated* `parallel_group` concept and **closes today's actual footgun** — without yet adding concurrent execution. The worktree compute layer (the speedup) is tracked separately in **#85**, to be done after the script-extraction work.

The design came from a 15-agent design workflow (constraint readers → 3 independent architectures → judge panel → synthesis → 4 adversarial skeptics). The panel proved the only safe spine is *orchestrator-serial commit on one branch* (worktree-per-task-with-branches is dead — it breaks `assert_review_coverage`'s SHA-equality / `scan_prior_commits_for_trigger`'s numstat). It also showed the latency win and all 19 of its risks live in the worktree layer, while the **correctness gap is closed by this MVP alone**.

## What this PR does

**`plan_lib`**
- `Task` gains optional, additive `parallel_group` + `files` (tuple, frozen-safe); `parse_tasks` captures them. Purely additive — the `riskLevel` fail-closed contract and the pre-P15 all-untagged migration are **unchanged**.
- New pure helper `validate_parallel_groups(tasks) -> (all_eligible, conflicts)` statically proves same-group tasks are file-disjoint. **Fail-closed** (degrades to sequential, never a collision) on: overlap, missing files, glob, directory, absolute path, nested/ancestor paths, case-variant aliasing, and parent-escape/root (`.`/`..`/`../`).

**`SKILL.md`**
- Step 5: machine-readable `parallel_group`/`files` contract; wires `plan_lib.validate_parallel_groups(tasks)` (drift-guard mapped to Step 5).
- Step 8: **replaces the unsafe "dispatch via parallel Agent calls" instruction** (no isolation → concurrent edits could collide) with validated-but-**serial** execution + a machine-checkable staging backstop (staged set ⊆ declared `files`).
- `docs/principles.md`: documents the validator; clarifies the worktree statement in Principle 1 stays aspirational until #85.

## Why split (3a now, 3b in #85)

The MVP keeps execution serial → P15 / review-state / retroactive scan / resumption are touched **zero times**, and it closes the collision gap permanently. The worktree speedup carries 1 Critical + 9 High adversarial findings (all in that layer) and a win that's eroded by the mandatory post-integration union re-test — better judged on its own, ideally after the PR 5 A/B-measurement method.

## Verification

- **TDD throughout** (RED→GREEN per behavior); 16 new tests covering the parser additions, the preserved `riskLevel` contract, and every validator fail-closed case.
- **3 rounds of cross-model (Codex) adversarial review** → CONVERGED: no declared-string false-negative remains, no Critical/High. Each round found real false-negatives (absolute/case, nested directory, parent-escape, `.` root) that were fixed before this PR.
- Full suite: **672 passed, 3 skipped**. Version `2.27.0` → `2.28.0` + pin test.

## Quality Gate Summary
- Additive + behavior-preserving for existing plans (no parallel fields ⇒ identical parse + serial execution as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
