### PR TITLE
feat(implement-feature): headless-interaction CLI replaces fragile inline python3 -c (WF2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Multiple projects can be active simultaneously. Use `/rawgentic:switch` to bind 
 **Key Features:**
 - Config-driven: TDD mode when tests configured, Implement-Verify mode when not
 - 4-agent code review (general, security, performance, test coverage)
+- Parallelized analysis (Step 2) and review (Step 4) phases for lower latency
 - Global loopback budget of 3 across all retry loops
 - Learning config: updates `.rawgentic.json` when new patterns discovered
 </details>

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -523,6 +523,20 @@ removed when the session resumes.
 - `parse_metadata()` — extracts JSON from hidden comment blocks
 - `format_suspend_state()` / `write_suspend_state()` / `read_suspend_state()`
 
+It also exposes a CLI so workflow skills drive the QUESTION-suspend protocol
+from Bash without reconstructing fragile inline `python3 -c` snippets:
+- `new-id` — print a fresh question_id (uuid4)
+- `format-comment` — render the structured comment body to stdout
+- `write-suspend` — write the suspend state file (atomic, fail-closed on empty
+  `--question-id`/`--comment-url`, non-positive `--issue`, or an out-of-range
+  `--step`)
+
+The skill runs these as one atomic `set -euo pipefail` block so the generated
+`$QID` and captured `$COMMENT_URL` flow consistently into the comment and the
+suspend file. (The resume side keeps using `read_suspend_state()` /
+`parse_metadata()` directly; those gain CLI subcommands when the resume protocol
+is wired to use them.)
+
 ### Security Notes
 
 - `session_id` is excluded from public GitHub comments (kept only in the

--- a/hooks/headless_interaction.py
+++ b/hooks/headless_interaction.py
@@ -8,9 +8,12 @@ Provides testable functions for:
 
 Used by workflow skills (via Bash tool) and tested via pytest.
 """
+import argparse
 import json
 import os
 import re
+import sys
+import uuid
 from datetime import datetime, timezone
 
 
@@ -191,3 +194,150 @@ def read_suspend_state(path: str) -> dict | None:
             return json.load(f)
     except (FileNotFoundError, json.JSONDecodeError, ValueError, OSError):
         return None
+
+
+# --- CLI ---
+#
+# The workflow skill (SKILL.md) drives the headless QUESTION-suspend protocol
+# from Bash. Doing that via `python3 -c "..."` forces Claude to reconstruct a
+# multi-line Python snippet (with nested quotes and string interpolation) on
+# every suspend — fragile and a frequent source of escaping bugs. This CLI gives
+# each step a stable flag-based contract so the skill calls a command instead of
+# rebuilding code.
+
+# A WF step is an integer in 1.._MAX_WF_STEP optionally followed by one
+# lowercase sub-step letter (e.g. "8a"). Validating at the CLI boundary stops a
+# malformed step ("", "0", "-1", whitespace, "abc") OR a well-formed but
+# unroutable step ("17", "99") from silently producing a suspend file that the
+# resume path can't dispatch. The numeric bound is the ASCII-only [0-9] class +
+# an int comparison, so leading zeros ("08") and unicode digits are also rejected.
+# Keep _MAX_WF_STEP in sync if WF2 gains steps.
+_MAX_WF_STEP = 16
+# No ``$`` anchor: it matches before a trailing newline, so ``re.match`` would
+# accept "5\n". Used with ``fullmatch`` (whole string must match) the trailing
+# "\n" is left unconsumed and correctly rejected.
+_STEP_RE = re.compile(r"([1-9][0-9]*)([a-z]?)")
+
+
+def _parse_step(step: str) -> int | str:
+    """Validate and coerce a WF step token. A bare number (``"5"``) becomes an
+    int so it matches int step values used in resume routing; a sub-step
+    (``"8a"``) stays a string. Anything malformed or out of range raises
+    ``ValueError``."""
+    m = _STEP_RE.fullmatch(step)
+    if not m or int(m.group(1)) > _MAX_WF_STEP:
+        raise ValueError(
+            f"invalid --step {step!r} (expected 1-{_MAX_WF_STEP}, "
+            f"optionally with a sub-step letter like '8a')"
+        )
+    # No sub-step letter → a pure integer step; otherwise keep the string form.
+    return int(m.group(1)) if not m.group(2) else step
+
+
+def main(argv=None) -> int:
+    """CLI entry point for headless interaction helpers.
+
+    Subcommands (the QUESTION-suspend path the workflow skill drives from Bash):
+      new-id          print a fresh question_id (uuid4)
+      format-comment  render the structured GitHub comment body to stdout
+      write-suspend   write the suspend state file (atomic)
+
+    (The resume side — reading suspend state and parsing a reply — is handled by
+    the read_suspend_state / parse_metadata library functions; those gain CLI
+    subcommands when the resume protocol is wired to use them.)
+
+    Exit codes:
+      0  success
+      1  invalid input (empty/malformed identifier or step) OR a fail-closed
+         write error — surfaced as non-zero so a caller never mistakes a failed
+         or unmatchable write for success
+    """
+    parser = argparse.ArgumentParser(prog="headless_interaction")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("new-id", help="print a fresh question_id (uuid4)")
+
+    p_fmt = sub.add_parser("format-comment", help="render the comment body")
+    p_fmt.add_argument("--step", required=True)
+    p_fmt.add_argument("--title", required=True)
+    p_fmt.add_argument("--context", required=True)
+    p_fmt.add_argument("--question", required=True)
+    p_fmt.add_argument("--option", action="append", help="repeatable")
+    p_fmt.add_argument("--type", required=True, dest="type")
+    p_fmt.add_argument("--question-id", required=True, dest="question_id")
+
+    p_sus = sub.add_parser("write-suspend", help="write the suspend state file")
+    p_sus.add_argument("--path", required=True)
+    p_sus.add_argument("--issue", required=True, type=int)
+    p_sus.add_argument("--step", required=True)
+    p_sus.add_argument("--question-id", required=True, dest="question_id")
+    p_sus.add_argument("--comment-url", required=True, dest="comment_url")
+    p_sus.add_argument("--session-id", default="N/A", dest="session_id")
+    p_sus.add_argument("--clarification-round", default=0, type=int,
+                       dest="clarification_round")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "new-id":
+        print(uuid.uuid4())
+        return 0
+
+    if args.cmd == "format-comment":
+        if not args.question_id.strip():
+            print("--question-id must be a non-empty value", file=sys.stderr)
+            return 1
+        try:
+            step = _parse_step(args.step)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        comment = format_comment(
+            step=step,
+            title=args.title,
+            context=args.context,
+            question=args.question,
+            options=args.option or [],
+            metadata={"question_id": args.question_id, "step": step, "type": args.type},
+        )
+        print(comment)
+        return 0
+
+    if args.cmd == "write-suspend":
+        # argparse required=True only proves the flag was PRESENT — an empty
+        # value (e.g. a lost/empty shell variable upstream) would otherwise
+        # write a suspend file that can never be matched to a real comment.
+        # Fail closed so an upstream shell failure can't masquerade as success.
+        for flag, value in (("--question-id", args.question_id),
+                            ("--comment-url", args.comment_url)):
+            if not value.strip():
+                print(f"{flag} must be a non-empty value", file=sys.stderr)
+                return 1
+        if args.issue <= 0:
+            print("--issue must be a positive integer", file=sys.stderr)
+            return 1
+        try:
+            step = _parse_step(args.step)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        state = format_suspend_state(
+            session_id=args.session_id,
+            issue=args.issue,
+            step=step,
+            question_id=args.question_id,
+            comment_url=args.comment_url,
+            clarification_round=args.clarification_round,
+        )
+        try:
+            write_suspend_state(args.path, state)
+        except OSError as exc:
+            print(f"failed to write suspend state: {exc}", file=sys.stderr)
+            return 1
+        print(args.path)
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -194,63 +194,56 @@ ERROR interactions (post error comment, exit WITHOUT ai-waiting label):
 
 **QUESTION protocol (post → label → suspend → exit):**
 
-1. Generate a structured comment using `hooks/headless_interaction.py`:
+1. Run the post-label-suspend sequence as **ONE atomic Bash block**. This is
+   mandatory: `$QID`, `$COMMENT_BODY`, and `$COMMENT_URL` are generated/captured
+   at runtime and shell variables do NOT persist across separate Bash tool
+   calls — splitting these into multiple blocks would post with an empty body or
+   write a suspend file with an empty question_id/comment_url. `set -euo
+   pipefail` plus the explicit URL guard make the whole sequence fail closed.
+   The CLI replaces inline `python3 -c` (a stable flag contract avoids the
+   quoting/escaping bugs of reconstructing a snippet on every suspend).
    ```bash
-   python3 -c "
-   import sys; sys.path.insert(0, 'hooks')
-   from headless_interaction import format_comment, format_suspend_state, write_suspend_state
-   comment = format_comment(
-       step=STEP_NUMBER,
-       title='QUESTION_TITLE',
-       context='WHAT_THE_WORKFLOW_IS_DOING',
-       question='THE_DECISION_NEEDED',
-       options=['(a) Option 1', '(b) Option 2'],
-       metadata={'question_id': 'GENERATED_UUID', 'step': STEP_NUMBER, 'type': 'INTERACTION_TYPE'}
-   )
-   print(comment)
-   "
-   ```
+   set -euo pipefail
 
-2. Post the comment to the GitHub issue:
-   ```bash
-   gh issue comment ISSUE_NUMBER --repo ${capabilities.repo} --body "COMMENT_BODY"
-   ```
+   # Generate a question_id + the structured comment body.
+   QID=$(python3 hooks/headless_interaction.py new-id)
+   COMMENT_BODY=$(python3 hooks/headless_interaction.py format-comment \
+     --step STEP_NUMBER \
+     --title "QUESTION_TITLE" \
+     --context "WHAT_THE_WORKFLOW_IS_DOING" \
+     --question "THE_DECISION_NEEDED" \
+     --option "(a) Option 1" --option "(b) Option 2" \
+     --type "INTERACTION_TYPE" \
+     --question-id "$QID")
 
-3. Add the waiting label:
-   ```bash
-   gh issue edit ISSUE_NUMBER --repo ${capabilities.repo} --add-label "rawgentic:ai-waiting"
-   ```
-   Create the label first if it doesn't exist:
-   ```bash
+   # Post the comment; capture the URL. Fail closed if gh returns no URL.
+   COMMENT_URL=$(gh issue comment ISSUE_NUMBER --repo ${capabilities.repo} --body "$COMMENT_BODY")
+   [[ -n "$COMMENT_URL" ]] || { echo "no comment URL returned by gh" >&2; exit 1; }
+
+   # Add the waiting label (create it first if missing).
    gh label create "rawgentic:ai-waiting" --repo ${capabilities.repo} \
      --description "Rawgentic headless: waiting for user reply" --color "FBCA04" 2>/dev/null || true
-   ```
+   gh issue edit ISSUE_NUMBER --repo ${capabilities.repo} --add-label "rawgentic:ai-waiting"
 
-4. Write the suspend state file:
-   ```bash
-   python3 -c "
-   import sys; sys.path.insert(0, 'hooks')
-   from headless_interaction import format_suspend_state, write_suspend_state
-   state = format_suspend_state(
-       session_id='N/A',
-       issue=ISSUE_NUMBER,
-       step=STEP_NUMBER,
-       question_id='GENERATED_UUID',
-       comment_url='COMMENT_URL',
-       clarification_round=0
-   )
-   write_suspend_state('claude_docs/headless_suspend.json', state)
-   "
-   ```
+   # Write the suspend state, reusing the SAME $QID and $COMMENT_URL. write-suspend
+   # rejects empty --question-id/--comment-url, so a lost variable fails closed
+   # rather than writing an unmatchable suspend file.
+   python3 hooks/headless_interaction.py write-suspend \
+     --path claude_docs/headless_suspend.json \
+     --issue ISSUE_NUMBER \
+     --step STEP_NUMBER \
+     --question-id "$QID" \
+     --comment-url "$COMMENT_URL"
 
-5. Write a SUSPEND WAL entry:
-   ```bash
+   # Write the SUSPEND WAL entry.
    bash hooks/wal-suspend
    ```
+   On a clarification re-ask, also pass `--clarification-round N` to
+   `write-suspend` (defaults to `0`); `--session-id` defaults to `N/A`.
 
-6. Write a rich checkpoint to session notes (see <headless-checkpoint>).
+2. Write a rich checkpoint to session notes (see <headless-checkpoint>).
 
-7. **EXIT the workflow cleanly.** Do NOT continue to the next step. The orchestrator
+3. **EXIT the workflow cleanly.** Do NOT continue to the next step. The orchestrator
    will re-invoke the skill in a fresh session after the user replies.
 
 **ERROR protocol (post error → exit WITHOUT label):**
@@ -1021,6 +1014,19 @@ Code review result with filtered findings and fixes applied. Committed `.rawgent
    ```bash
    git add CLAUDE.md && git commit -m "docs: update CLAUDE.md with implementation insights (#<issue_number>)"
    ```
+
+2a. **Update README + docs (mandatory decision, not optional):** Before pushing,
+   explicitly decide whether this feature changed anything user-facing — new
+   commands/flags, changed behavior, new files, or new config. If so, update
+   `README.md` and the relevant `docs/` file(s) and commit them so they ship in
+   this PR:
+   ```bash
+   git add README.md docs/ && git commit -m "docs: update README/docs for #<issue_number>"
+   ```
+   If there is genuinely no user-facing change (pure internal refactor, or
+   groundwork that does nothing visible yet), state that explicitly in the PR
+   body's Summary rather than silently skipping. Stale or omitted docs are a
+   recurring miss — make the call deliberately every time.
 
 3. **Final push:**
    ```bash

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.28.0"
+    assert plugin["version"] == "2.29.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_headless.py
+++ b/tests/hooks/test_headless.py
@@ -8,6 +8,7 @@ Covers:
 """
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -688,6 +689,322 @@ class TestWalSuspend:
 # =========================================================================
 # Canary test — SKILL.md count with <config-loading>
 # =========================================================================
+
+HEADLESS_CLI = HOOKS_DIR / "headless_interaction.py"
+
+
+def _run_cli(*args, stdin=None, timeout=10):
+    """Invoke headless_interaction.py as a CLI subprocess.
+
+    Exercises the real `__main__` path (argparse, exit codes, stdout/stderr)
+    exactly as the SKILL.md Bash blocks invoke it — calling main() in-process
+    would skip the integration seam we're trying to de-risk.
+    """
+    import subprocess
+    result = subprocess.run(
+        ["python3", str(HEADLESS_CLI), *args],
+        input=stdin, capture_output=True, text=True, timeout=timeout,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+class TestHeadlessCLI:
+    """The CLI wrapper that replaces the fragile inline `python3 -c` blocks in
+    SKILL.md (PR 4). Each subcommand maps to an existing tested function; these
+    tests pin the command-line contract the workflow depends on."""
+
+    # --- new-id ---
+
+    def test_new_id_prints_uuid(self):
+        import uuid
+        out, err, rc = _run_cli("new-id")
+        assert rc == 0
+        # Must be a parseable UUID (round-trips through uuid.UUID)
+        parsed = uuid.UUID(out.strip())
+        assert str(parsed) == out.strip()
+
+    def test_new_id_is_unique_across_calls(self):
+        out1, _, _ = _run_cli("new-id")
+        out2, _, _ = _run_cli("new-id")
+        assert out1.strip() != out2.strip()
+
+    # --- format-comment ---
+
+    def test_format_comment_renders_and_roundtrips_metadata(self):
+        from headless_interaction import parse_metadata
+        out, err, rc = _run_cli(
+            "format-comment",
+            "--step", "5",
+            "--title", "Risk ratio halt",
+            "--context", "ratio exceeded threshold",
+            "--question", "How to proceed?",
+            "--option", "(a) decompose",
+            "--option", "(b) override",
+            "--type", "risk_ratio",
+            "--question-id", "abc-123",
+        )
+        assert rc == 0, err
+        assert "Risk ratio halt" in out
+        # parens are markdown-escaped by format_comment; assert on word portions
+        assert "decompose" in out
+        assert "override" in out
+        meta = parse_metadata(out)
+        assert meta == {"question_id": "abc-123", "step": 5, "type": "risk_ratio"}
+
+    def test_format_comment_numeric_step_is_int_in_metadata(self):
+        """A numeric --step must land in metadata as an int (resume routing
+        compares step values); only non-numeric sub-steps stay strings."""
+        from headless_interaction import parse_metadata
+        out, _, rc = _run_cli(
+            "format-comment", "--step", "5", "--title", "t",
+            "--context", "c", "--question", "q",
+            "--type", "x", "--question-id", "id1",
+        )
+        assert rc == 0
+        assert parse_metadata(out)["step"] == 5
+
+    def test_format_comment_substep_8a_stays_string(self):
+        from headless_interaction import parse_metadata
+        out, _, rc = _run_cli(
+            "format-comment", "--step", "8a", "--title", "t",
+            "--context", "c", "--question", "q",
+            "--type", "x", "--question-id", "id1",
+        )
+        assert rc == 0
+        assert "Step 8a" in out
+        assert parse_metadata(out)["step"] == "8a"
+
+    def test_format_comment_no_options_ok(self):
+        out, _, rc = _run_cli(
+            "format-comment", "--step", "14", "--title", "Deploy",
+            "--context", "c", "--question", "Confirm?",
+            "--type", "deploy_confirm", "--question-id", "id1",
+        )
+        assert rc == 0
+        assert "Deploy" in out
+
+    # --- write-suspend ---
+
+    def test_write_suspend_creates_file_with_fields(self, tmp_path):
+        from headless_interaction import read_suspend_state
+        path = tmp_path / "headless_suspend.json"
+        out, err, rc = _run_cli(
+            "write-suspend",
+            "--path", str(path),
+            "--issue", "42",
+            "--step", "5",
+            "--question-id", "abc-123",
+            "--comment-url", "https://example.com/c/1",
+        )
+        assert rc == 0, err
+        state = read_suspend_state(str(path))
+        assert state["issue"] == 42
+        assert state["step"] == 5
+        assert state["question_id"] == "abc-123"
+        assert state["comment_url"] == "https://example.com/c/1"
+        # defaults
+        assert state["session_id"] == "N/A"
+        assert state["clarification_round"] == 0
+        assert "suspended_at" in state
+
+    def test_write_suspend_honors_optional_flags(self, tmp_path):
+        from headless_interaction import read_suspend_state
+        path = tmp_path / "s.json"
+        _, err, rc = _run_cli(
+            "write-suspend", "--path", str(path), "--issue", "7",
+            "--step", "8a", "--question-id", "q", "--comment-url", "u",
+            "--session-id", "sess-1", "--clarification-round", "2",
+        )
+        assert rc == 0, err
+        state = read_suspend_state(str(path))
+        assert state["session_id"] == "sess-1"
+        assert state["clarification_round"] == 2
+        assert state["step"] == "8a"
+
+    def test_write_suspend_unwritable_path_fails_closed(self, tmp_path):
+        """A write failure must exit non-zero, not print a traceback a caller
+        could misread as success (mirrors adversarial_review_lib fail-closed)."""
+        bad = tmp_path / "no_such_dir" / "s.json"
+        _, _, rc = _run_cli(
+            "write-suspend", "--path", str(bad), "--issue", "1",
+            "--step", "5", "--question-id", "q", "--comment-url", "u",
+        )
+        assert rc != 0
+
+    def test_write_suspend_rejects_empty_question_id(self, tmp_path):
+        """argparse required=True only proves presence; an empty value (lost
+        shell var upstream) must fail closed, not write an unmatchable file."""
+        path = tmp_path / "s.json"
+        _, _, rc = _run_cli("write-suspend", "--path", str(path), "--issue", "1",
+                            "--step", "5", "--question-id", "", "--comment-url", "u")
+        assert rc != 0
+        assert not path.exists()
+
+    def test_write_suspend_rejects_blank_comment_url(self, tmp_path):
+        path = tmp_path / "s.json"
+        _, _, rc = _run_cli("write-suspend", "--path", str(path), "--issue", "1",
+                            "--step", "5", "--question-id", "q", "--comment-url", "   ")
+        assert rc != 0
+        assert not path.exists()
+
+    def test_write_suspend_rejects_nonpositive_issue(self, tmp_path):
+        path = tmp_path / "s.json"
+        _, _, rc = _run_cli("write-suspend", "--path", str(path), "--issue", "0",
+                            "--step", "5", "--question-id", "q", "--comment-url", "u")
+        assert rc != 0
+        assert not path.exists()
+
+    def test_format_comment_rejects_empty_question_id(self):
+        _, _, rc = _run_cli("format-comment", "--step", "5", "--title", "t",
+                            "--context", "c", "--question", "q", "--type", "x",
+                            "--question-id", "")
+        assert rc != 0
+
+    def test_question_id_invariant_comment_matches_suspend(self, tmp_path):
+        """The comment metadata and the suspend state must carry the SAME
+        question_id — the resume path matches the user's reply to the suspend by
+        this id, so a mismatch silently loses the reply."""
+        from headless_interaction import parse_metadata, read_suspend_state
+        qid = _run_cli("new-id")[0].strip()
+        comment = _run_cli("format-comment", "--step", "5", "--title", "t",
+                           "--context", "c", "--question", "q", "--type", "x",
+                           "--question-id", qid)[0]
+        path = tmp_path / "s.json"
+        _run_cli("write-suspend", "--path", str(path), "--issue", "5",
+                 "--step", "5", "--question-id", qid,
+                 "--comment-url", "https://example.com/c/1")
+        meta_qid = parse_metadata(comment)["question_id"]
+        state_qid = read_suspend_state(str(path))["question_id"]
+        assert meta_qid == state_qid == qid
+
+    # --- step validation (rejects malformed steps that would be unroutable) ---
+
+    @pytest.mark.parametrize("bad_step",
+                             ["", "0", "-1", " ", "5 ", "abc", "17", "99", "08",
+                              "16aa", "8ab", "5\n", "8a\n"])
+    def test_format_comment_rejects_invalid_step(self, bad_step):
+        """Rejects malformed steps AND well-formed-but-unroutable ones (>16,
+        leading zeros, multi-letter sub-steps, trailing-newline via $ anchor)."""
+        _, _, rc = _run_cli("format-comment", "--step", bad_step, "--title", "t",
+                            "--context", "c", "--question", "q", "--type", "x",
+                            "--question-id", "id1")
+        assert rc != 0
+
+    @pytest.mark.parametrize("bad_step", ["", "0", "-1", " ", "abc"])
+    def test_write_suspend_rejects_invalid_step(self, tmp_path, bad_step):
+        path = tmp_path / "s.json"
+        _, _, rc = _run_cli("write-suspend", "--path", str(path), "--issue", "1",
+                            "--step", bad_step, "--question-id", "q",
+                            "--comment-url", "u")
+        assert rc != 0
+        assert not path.exists()
+
+    @pytest.mark.parametrize("ok_step", ["5", "16", "8a", "11"])
+    def test_format_comment_accepts_valid_step(self, ok_step):
+        _, _, rc = _run_cli("format-comment", "--step", ok_step, "--title", "t",
+                            "--context", "c", "--question", "q", "--type", "x",
+                            "--question-id", "id1")
+        assert rc == 0
+
+
+class TestHeadlessCLISkillWiring:
+    """Drift guard (PR 4): the WF2 skill must drive the headless QUESTION-suspend
+    protocol through the CLI subcommands, not a reconstructed `python3 -c` block.
+
+    Catches two regressions:
+    - a subcommand is renamed in the CLI but the SKILL.md still calls the old name
+    - someone re-introduces the fragile inline-Python pattern this PR removed
+    """
+
+    SKILL_MD = Path(__file__).resolve().parent.parent.parent / "skills" / "implement-feature" / "SKILL.md"
+    WIRED_SUBCOMMANDS = ["new-id", "format-comment", "write-suspend"]
+
+    @pytest.mark.parametrize("subcommand", WIRED_SUBCOMMANDS)
+    def test_skill_invokes_cli_subcommand(self, subcommand):
+        content = self.SKILL_MD.read_text()
+        needle = f"headless_interaction.py {subcommand}"
+        assert needle in content, (
+            f"SKILL.md should invoke `{needle}` but doesn't. If you renamed the "
+            f"subcommand, update SKILL.md and this guard."
+        )
+
+    def test_skill_has_no_inline_python_headless_block(self):
+        """The inline `from headless_interaction import ...` (python3 -c) pattern
+        is the fragile footgun PR 4 replaced — it must not creep back."""
+        content = self.SKILL_MD.read_text()
+        assert "from headless_interaction import" not in content, (
+            "SKILL.md re-introduced the inline-Python headless block; use the "
+            "headless_interaction.py CLI subcommands instead."
+        )
+
+    def _headless_block(self):
+        content = self.SKILL_MD.read_text()
+        start = content.index("<headless-interaction>")
+        end = content.index("</headless-interaction>")
+        return content[start:end]
+
+    def _question_protocol_commands(self):
+        """Return the QUESTION-protocol bash block as logical command lines:
+        comment lines dropped, backslash-continuations joined. This lets a guard
+        assert against the ACTUAL command invocations rather than raw substring
+        counts that prose/comments could satisfy spuriously."""
+        block = self._headless_block()
+        fences = re.findall(r"```bash\n(.*?)```", block, re.DOTALL)
+        candidates = [f for f in fences if "format-comment" in f]
+        assert len(candidates) == 1, (
+            "expected exactly one QUESTION-protocol bash block containing format-comment"
+        )
+        raw = candidates[0]
+        lines = [ln for ln in raw.splitlines() if not ln.lstrip().startswith("#")]
+        logical, buf = [], ""
+        for ln in lines:
+            if ln.rstrip().endswith("\\"):
+                buf += ln.rstrip()[:-1] + " "
+            else:
+                buf += ln
+                logical.append(buf)
+                buf = ""
+        if buf:
+            logical.append(buf)
+        return logical
+
+    def test_question_protocol_is_atomic_and_fail_closed(self):
+        """PR4 review finding: the post/label/suspend sequence must be ONE atomic
+        bash block — shell variables ($QID/$COMMENT_BODY/$COMMENT_URL) do not
+        persist across separate Bash tool calls, so splitting them would post an
+        empty body or write a suspend file with empty identifiers. It must also
+        fail closed on a missing comment URL. Pin both so they can't regress."""
+        block = self._headless_block()
+        assert "set -euo pipefail" in block, (
+            "QUESTION protocol must run as one atomic, fail-fast bash block"
+        )
+        assert '[[ -n "$COMMENT_URL" ]]' in block, (
+            "QUESTION protocol must guard against an empty comment URL before suspend"
+        )
+
+    def test_skill_reuses_one_question_id_and_url(self):
+        """PR4 review finding: the question_id invariant only holds if the SAME
+        shell variable feeds both commands. Assert against the actual command
+        spans (not raw block counts) that `format-comment` and `write-suspend`
+        each bind `--question-id "$QID"`, and that `write-suspend` reuses the
+        captured `$COMMENT_URL` — a CLI-level round-trip test can't catch a
+        SKILL.md regression that swaps the variable."""
+        commands = self._question_protocol_commands()
+        assert any('QID=$(python3 hooks/headless_interaction.py new-id)' in c
+                   for c in commands), "QUESTION protocol must generate one $QID"
+        fmt = [c for c in commands if "format-comment" in c]
+        sus = [c for c in commands if "write-suspend" in c]
+        assert len(fmt) == 1 and '--question-id "$QID"' in fmt[0], (
+            'the format-comment command must pass --question-id "$QID"'
+        )
+        assert len(sus) == 1, "expected exactly one write-suspend command"
+        assert '--question-id "$QID"' in sus[0], (
+            'the write-suspend command must pass the SAME --question-id "$QID"'
+        )
+        assert '--comment-url "$COMMENT_URL"' in sus[0], (
+            "the write-suspend command must reuse the captured $COMMENT_URL"
+        )
+
 
 class TestSkillCountCanary:
     """Canary: assert the number of SKILL.md files with <config-loading> matches expected."""


### PR DESCRIPTION
## Summary

Replaces the two fragile multi-line `python3 -c "from headless_interaction import ..."` blocks in the WF2 (`implement-feature`) headless **QUESTION-suspend** protocol with a stable argparse CLI. Reconstructing inline Python with nested quotes and string interpolation on every suspend was a recurring escaping footgun; a flag-based contract removes that interpretation variance and the LLM round-trips.

This is **PR 4** of the WF2 latency/reliability series (script extraction), scoped to the headless CLI slice. Resume step-detection and capabilities derivation are deferred to follow-up PRs.

## What changed

- **`hooks/headless_interaction.py`** — adds `main(argv)` + `__main__` with three subcommands (`new-id`, `format-comment`, `write-suspend`). Strict `_parse_step` (1–16 plus single-letter sub-steps like `8a`, via `fullmatch` to avoid the `$`-newline match). **Fail-closed** on empty `--question-id`/`--comment-url`, non-positive `--issue`, malformed/out-of-range `--step`, and write errors.
- **`skills/implement-feature/SKILL.md`** — the QUESTION protocol is now **one atomic `set -euo pipefail` Bash block** (shell variables do not persist across separate Bash tool calls, so the previous multi-block draft would have lost `$QID`/`$COMMENT_URL`), with a non-empty `COMMENT_URL` guard. Also adds a **mandatory README/docs decision step to Step 12** (create-PR phase).
- **`tests/hooks/test_headless.py`** — CLI behavior, step validation, the question_id-consistency invariant, and **drift guards**: subcommands stay wired, the inline-Python pattern can't return, the protocol stays atomic, and `format-comment`/`write-suspend` bind the same `$QID`.
- **`README.md`** — documents nothing new for the CLI (internal mechanism; contract unchanged) but adds the previously-missing #84 "parallelized phases" WF2 bullet.
- **`docs/config-reference.md`** — documents the new headless CLI.
- **`.claude-plugin/plugin.json`** — 2.28.0 → 2.29.0 (+ version pin test).

## Verification

- Full suite: **714 passed, 3 skipped**.
- TDD throughout (each fix's test verified RED by reverting the fix).
- **Cross-model adversarial review (Codex) iterated 5 rounds to CONVERGED.** It caught a real regression (cross-block shell variables), fail-open empty flags, speculative unwired CLI surface (removed), a step-range gap, and the `$`-anchor trailing-newline gotcha.

## Quality Gate Summary
- Adversarial review (Codex, cross-model): 5 rounds → CONVERGED
- Drift guards: CLI↔SKILL.md wiring, atomic-block, single-`$QID`, no-inline-python
- Fail-closed: empty identifiers, bad issue/step, write errors