### PR TITLE
feat(implement-feature): resume-side CLIs (detect-step / read-suspend / parse-reply) replace fragile prose (WF2 PR 4b)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -624,6 +624,8 @@ The rawgentic safety hooks (WAL guard, security guard, WAL logging) remain activ
 
 Workflow skills can run non-interactively for CI/orchestrator integration. Set `RAWGENTIC_HEADLESS=1` and use `claude --print` with `--permission-mode bypassPermissions`. When a skill needs user input, it posts a structured comment to the GitHub issue, adds the `rawgentic:ai-waiting` label, and exits cleanly. Resume with `claude --resume {session_id}` after the user replies. See [`docs/config-reference.md`](docs/config-reference.md#headless-mode) for the full orchestrator interface contract.
 
+The QUESTION-suspend and resume paths are driven from Bash via `hooks/headless_interaction.py` subcommands (`new-id`, `format-comment`, `write-suspend`, `read-suspend`, `parse-reply`) so the skill never reconstructs fragile inline `python3 -c` snippets, and the resumption step is chosen by `hooks/resume_lib.py detect-step` (the priority-ordered cascade lives in one tested place instead of being hand-applied in prose). Both fail closed on unusable inputs. See [`docs/config-reference.md`](docs/config-reference.md#python-helper) for the subcommand contracts.
+
 ---
 
 ## Contributing

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -523,19 +523,54 @@ removed when the session resumes.
 - `parse_metadata()` — extracts JSON from hidden comment blocks
 - `format_suspend_state()` / `write_suspend_state()` / `read_suspend_state()`
 
-It also exposes a CLI so workflow skills drive the QUESTION-suspend protocol
-from Bash without reconstructing fragile inline `python3 -c` snippets:
+It also exposes a CLI so workflow skills drive the headless protocol from Bash
+without reconstructing fragile inline `python3 -c` snippets.
+
+QUESTION-suspend side:
 - `new-id` — print a fresh question_id (uuid4)
 - `format-comment` — render the structured comment body to stdout
 - `write-suspend` — write the suspend state file (atomic, fail-closed on empty
   `--question-id`/`--comment-url`, non-positive `--issue`, or an out-of-range
   `--step`)
 
-The skill runs these as one atomic `set -euo pipefail` block so the generated
-`$QID` and captured `$COMMENT_URL` flow consistently into the comment and the
-suspend file. (The resume side keeps using `read_suspend_state()` /
-`parse_metadata()` directly; those gain CLI subcommands when the resume protocol
-is wired to use them.)
+Resume side:
+- `read-suspend` — read AND validate the suspend file in one step. Exit `0` with
+  the validated state JSON on stdout; exit `3` when the file is absent (benign
+  "no pending question"); exit `1` when the file parses but is unusable (empty
+  identifier, non-positive `issue`, missing `suspended_at`, bad `step`). The
+  distinct `3` vs `1` lets the caller proceed normally vs escalate.
+- `parse-reply` — extract an unambiguous option choice (e.g. `a`, `2`) from a
+  user's free-text reply. Exit `0` + the token when the whole reply IS a literal
+  option; exit `1` otherwise, so natural-language replies fall back to the
+  skill's own judgement / a clarification round rather than a wrong guess.
+
+The QUESTION-suspend commands run as one atomic `set -euo pipefail` block so the
+generated `$QID` and captured `$COMMENT_URL` flow consistently into the comment
+and the suspend file.
+
+### Resume Step Detection
+
+`hooks/resume_lib.py` encodes the WF2 resumption cascade — the priority-ordered
+rules that decide which of the 16 steps a fresh session resumes at. Applying that
+order by hand in prose is how a resume silently lands on the wrong step (redoing
+finished work, or skipping a quality gate), so the ordering lives in one tested
+function exposed as a CLI:
+
+- `detect-step` — print the step to resume at given the gathered facts. Takes
+  three composite-enum flags and two optional markers:
+  - `--pr-state {none,open,ready-to-merge,merged}` (`ready-to-merge` = CI green
+    OR project has no CI — the orchestrator collapses the "or no CI" rule while
+    gathering facts)
+  - `--branch-state {none,empty,changes,verified}`
+  - `--notes-state {none,issue-validated,design-doc}`
+  - `--markers-complete` / `--completion-gate-printed` (for the "all markers
+    present but the gate was never printed" case → prints `completion-gate`)
+
+  The orchestrator still *gathers* the facts (git/gh for the PR and branch,
+  session notes for design/issue/test status); `detect-step` just applies the
+  canonical precedence. An unrecognized state value exits non-zero (fail-closed)
+  rather than defaulting to Step 1, so a mistyped fact fails loudly instead of
+  restarting an in-flight workflow.
 
 ### Security Notes
 

--- a/hooks/headless_interaction.py
+++ b/hooks/headless_interaction.py
@@ -143,6 +143,35 @@ def parse_metadata(comment_body: str | None) -> dict | None:
         return None
 
 
+# --- User reply parsing (headless resume) ---
+
+# A confident, unambiguous option token: an optional "option" prefix, an optional
+# wrapping paren, a single letter OR a 1-99 number (NO leading zero, NO bare "0" —
+# options are 1-based, so "0"/"00"/"012" are not valid choices), and an optional
+# trailing ")" or ".". Used with ``fullmatch`` on the trimmed/lowercased reply so
+# the WHOLE reply must be just this token — a sentence ("go with the first one",
+# "I'll take a, thanks") does NOT match and is deferred to the skill's
+# natural-language judgement. No ``$`` anchor (it matches before a trailing
+# newline); the strip() handles surrounding whitespace/newlines instead.
+_REPLY_CHOICE_RE = re.compile(r"(?:option\s*:?\s*)?\(?([a-z]|[1-9][0-9]?)\)?[.)]?")
+
+
+def parse_reply_choice(reply: str | None) -> str | None:
+    """Extract an unambiguous option choice from a user's free-text reply.
+
+    Returns the normalized token (a lowercase letter like ``"a"`` or a number
+    like ``"2"``) only when the entire reply IS that token. Returns None for
+    empty input, natural language, or anything with more than one candidate — the
+    caller then falls back to prose interpretation / a clarification round.
+    Conservative by design: a wrong guess here would silently apply the wrong
+    decision, so "not sure" must mean "re-ask," never "pick something."
+    """
+    if not reply:
+        return None
+    m = _REPLY_CHOICE_RE.fullmatch(reply.strip().lower())
+    return m.group(1) if m else None
+
+
 # --- Suspend state management ---
 
 def format_suspend_state(
@@ -234,23 +263,64 @@ def _parse_step(step: str) -> int | str:
     return int(m.group(1)) if not m.group(2) else step
 
 
+def _validate_suspend_state(state) -> tuple[bool, str | None]:
+    """Check a loaded suspend state is not just JSON-valid but USABLE for resume.
+
+    Returns ``(True, None)`` or ``(False, reason)``. A file that parses but is
+    missing or has an empty/ill-typed identifier can never be matched to the
+    user's reply, so the resume path must treat it as a hard error rather than
+    silently behaving as "no pending question" (which would drop the user's
+    decision). This is the validation the original deferred CLI lacked.
+    """
+    if not isinstance(state, dict):
+        return False, "suspend state must be a JSON object"
+    for key in ("question_id", "comment_url", "suspended_at"):
+        val = state.get(key)
+        if not isinstance(val, str) or not val.strip():
+            return False, f"suspend state field {key!r} must be a non-empty string"
+    issue = state.get("issue")
+    # bool is an int subclass — exclude it explicitly so True/False can't pass.
+    if isinstance(issue, bool) or not isinstance(issue, int) or issue <= 0:
+        return False, "suspend state field 'issue' must be a positive integer"
+    if "step" not in state:
+        return False, "suspend state is missing 'step'"
+    try:
+        _parse_step(str(state["step"]))
+    except ValueError:
+        return False, f"suspend state field 'step' is invalid: {state['step']!r}"
+    # clarification_round may be absent in an old/hand-written file — that's not
+    # corruption, it defaults to 0; but if present it must be a sane count.
+    cr = state.get("clarification_round", 0)
+    if isinstance(cr, bool) or not isinstance(cr, int) or cr < 0:
+        return False, (
+            "suspend state field 'clarification_round' must be a "
+            "non-negative integer"
+        )
+    return True, None
+
+
 def main(argv=None) -> int:
     """CLI entry point for headless interaction helpers.
 
-    Subcommands (the QUESTION-suspend path the workflow skill drives from Bash):
-      new-id          print a fresh question_id (uuid4)
-      format-comment  render the structured GitHub comment body to stdout
-      write-suspend   write the suspend state file (atomic)
-
-    (The resume side — reading suspend state and parsing a reply — is handled by
-    the read_suspend_state / parse_metadata library functions; those gain CLI
-    subcommands when the resume protocol is wired to use them.)
+    Subcommands:
+      QUESTION-suspend path (drives the suspend side from Bash):
+        new-id          print a fresh question_id (uuid4)
+        format-comment  render the structured GitHub comment body to stdout
+        write-suspend   write the suspend state file (atomic)
+      Resume path (drives the resume side from Bash):
+        read-suspend    read + validate the suspend state file
+        parse-reply     extract an unambiguous option choice from a reply on stdin
+                        (optionally validated against --options)
 
     Exit codes:
       0  success
-      1  invalid input (empty/malformed identifier or step) OR a fail-closed
-         write error — surfaced as non-zero so a caller never mistakes a failed
-         or unmatchable write for success
+      1  invalid input (empty/malformed identifier or step), a fail-closed write
+         error, a suspend file that parses but is unusable, or a reply with no
+         unambiguous choice — surfaced as non-zero so a caller never mistakes a
+         failed/unmatchable result for success
+      3  read-suspend only: no suspend file present (benign "no pending question"
+         signal, kept distinct from the corrupt-file error so the caller can
+         proceed with normal resumption instead of escalating)
     """
     parser = argparse.ArgumentParser(prog="headless_interaction")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -275,6 +345,22 @@ def main(argv=None) -> int:
     p_sus.add_argument("--session-id", default="N/A", dest="session_id")
     p_sus.add_argument("--clarification-round", default=0, type=int,
                        dest="clarification_round")
+
+    p_read = sub.add_parser("read-suspend",
+                            help="read + validate the suspend state file")
+    p_read.add_argument("--path", required=True)
+
+    p_reply = sub.add_parser(
+        "parse-reply",
+        help="extract an unambiguous option choice from a user reply (read on "
+             "stdin so an arbitrary reply is never spliced into a command)",
+    )
+    p_reply.add_argument(
+        "--options", default=None,
+        help="comma-separated valid option tokens (e.g. 'a,b,c'); when given, the "
+             "matched choice MUST be one of them or the command fails closed, so "
+             "an out-of-range answer routes to clarification instead of resuming",
+    )
 
     args = parser.parse_args(argv)
 
@@ -334,6 +420,48 @@ def main(argv=None) -> int:
             print(f"failed to write suspend state: {exc}", file=sys.stderr)
             return 1
         print(args.path)
+        return 0
+
+    if args.cmd == "read-suspend":
+        if not os.path.exists(args.path):
+            # Missing file is benign — no pending question. A DISTINCT exit code
+            # (3) lets the caller proceed to normal resumption rather than
+            # escalating, while a parse/validation failure below stays exit 1.
+            print("no suspend file", file=sys.stderr)
+            return 3
+        state = read_suspend_state(args.path)
+        if state is None:
+            print("suspend file is unreadable or not valid JSON", file=sys.stderr)
+            return 1
+        ok, reason = _validate_suspend_state(state)
+        if not ok:
+            print(reason, file=sys.stderr)
+            return 1
+        # Materialize the clarification_round default so the printed JSON always
+        # carries it — a caller running `jq -r .clarification_round` must get 0,
+        # not the JSON null an absent key would yield.
+        state.setdefault("clarification_round", 0)
+        print(json.dumps(state, separators=(",", ":")))
+        return 0
+
+    if args.cmd == "parse-reply":
+        # Read the reply from stdin: an arbitrary GitHub comment (which may
+        # contain quotes, newlines, shell metacharacters) is never passed as a
+        # command-line literal the caller would have to escape.
+        choice = parse_reply_choice(sys.stdin.read())
+        if choice is None:
+            print("no unambiguous option choice in reply", file=sys.stderr)
+            return 1
+        if args.options is not None:
+            valid = {t.strip().lower() for t in args.options.split(",") if t.strip()}
+            if choice not in valid:
+                print(
+                    f"choice {choice!r} is not one of the offered options "
+                    f"{sorted(valid)}",
+                    file=sys.stderr,
+                )
+                return 1
+        print(choice)
         return 0
 
     return 1

--- a/hooks/resume_lib.py
+++ b/hooks/resume_lib.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""WF2 resumption step-detection for the implement-feature workflow skill.
+
+WF2 may span multiple Claude Code sessions (context compaction, fresh headless
+sessions, worktrees). On every resume the orchestrator must decide which of the
+16 steps to re-enter. That decision is a *priority-ordered cascade*: a merged PR
+resumes at post-deploy verification even if a stale design doc also exists; a
+branch with code changes resumes at the drift check even if the issue was
+validated earlier. Applying that ordering by hand in prose is exactly the kind
+of fragile interpretation that lets a resume silently land on the wrong step —
+redoing finished work, or skipping a quality gate.
+
+This module encodes the cascade once, as a tested pure function, and exposes it
+as a `detect-step` CLI. The orchestrator still *gathers* the facts (git/gh for
+PR + branch state, session notes for design/issue/test status — the inherently
+environmental and semantic parts); this function just applies the canonical
+precedence to those facts so the resume target cannot drift from the order the
+workflow intends.
+"""
+import argparse
+import sys
+
+
+# The three fact dimensions, each a small closed enum. Composite enums (rather
+# than a pile of booleans) make within-dimension contradictions inexpressible —
+# you cannot say "branch has changes but no branch exists" — and let argparse
+# `choices=` reject anything unrecognized at the CLI boundary, fail-closed.
+
+# PR dimension. Resume meaning, highest precedence first:
+#   merged          -> PR merged                                  -> Step 15
+#   ready-to-merge  -> PR open AND (CI green OR project has no CI) -> Step 14
+#   open            -> PR open AND CI not yet green                -> Step 13
+#   none            -> no PR for this branch                       -> (fall through)
+# The orchestrator collapses the prose rule "CI passed (or no CI)" into
+# `ready-to-merge` while gathering facts, so this function needs no CI flag.
+PR_STATES = ("none", "open", "ready-to-merge", "merged")
+
+# Branch dimension (consulted only when there is no PR):
+#   verified  -> branch has commits AND tests pass/verified -> Step 11
+#   changes   -> branch has commits, tests not yet verified -> Step 9
+#   empty     -> branch exists with no commits              -> Step 8
+#   none      -> no feature branch                          -> (fall through)
+BRANCH_STATES = ("none", "empty", "changes", "verified")
+
+# Session-notes dimension (consulted only when there is no PR and no branch):
+#   design-doc       -> a design document is recorded in notes -> Step 5
+#   issue-validated  -> issue validated, no design yet         -> Step 2
+#   none             -> neither                                -> Step 1
+NOTES_STATES = ("none", "issue-validated", "design-doc")
+
+# Sentinel returned for resumption rule 0: every step marker is present but the
+# completion gate was never printed. The workflow is effectively done — run the
+# gate and terminate rather than redo Step 15.
+COMPLETION_GATE = "completion-gate"
+
+
+def detect_resume_step(
+    pr_state: str,
+    branch_state: str,
+    notes_state: str,
+    *,
+    markers_complete: bool = False,
+    completion_gate_printed: bool = False,
+) -> int | str:
+    """Return the WF2 step to resume at given the gathered facts.
+
+    Returns an int step (1, 2, 5, 8, 9, 11, 13, 14, 15) or the ``COMPLETION_GATE``
+    sentinel. The mapping is total over all valid inputs: there is no input that
+    falls through to an undefined result. An *unrecognized* state raises
+    ``ValueError`` rather than defaulting to Step 1 — silently restarting an
+    in-flight workflow because a fact was mistyped would be worse than failing
+    loudly.
+    """
+    for name, value, valid in (
+        ("pr_state", pr_state, PR_STATES),
+        ("branch_state", branch_state, BRANCH_STATES),
+        ("notes_state", notes_state, NOTES_STATES),
+    ):
+        if value not in valid:
+            raise ValueError(
+                f"invalid {name} {value!r} (expected one of {list(valid)})"
+            )
+
+    # Rule 0 (precedence above everything except the headless check, which the
+    # skill runs first in prose): a fully-marked run that never printed its gate.
+    if markers_complete and not completion_gate_printed:
+        return COMPLETION_GATE
+
+    # PR cascade (rules 1-3) — a PR outranks branch/notes state.
+    if pr_state == "merged":
+        return 15
+    if pr_state == "ready-to-merge":
+        return 14
+    if pr_state == "open":
+        return 13
+
+    # Branch cascade (rules 4-6) — only reached when there is no PR.
+    if branch_state == "verified":
+        return 11
+    if branch_state == "changes":
+        return 9
+    if branch_state == "empty":
+        return 8
+
+    # Notes cascade (rules 7-8) — only reached when there is no PR and no branch.
+    if notes_state == "design-doc":
+        return 5
+    if notes_state == "issue-validated":
+        return 2
+
+    # Rule 9: nothing detected — start from the top.
+    return 1
+
+
+def main(argv=None) -> int:
+    """CLI entry point.
+
+    Subcommand:
+      detect-step  print the WF2 step to resume at (or `completion-gate`)
+
+    Exit codes:
+      0  success — the step (or sentinel) is printed to stdout
+      1  invalid fact combination (should be unreachable from the CLI because
+         argparse `choices=` validates the enums, but kept so the boundary is
+         fail-closed if the function ever rejects an input)
+      2  argparse usage error (unknown/invalid flag) — also fail-closed
+    """
+    parser = argparse.ArgumentParser(prog="resume_lib")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser(
+        "detect-step",
+        help="print the WF2 step to resume at given the gathered facts",
+    )
+    p.add_argument("--pr-state", required=True, choices=list(PR_STATES),
+                   dest="pr_state")
+    p.add_argument("--branch-state", required=True, choices=list(BRANCH_STATES),
+                   dest="branch_state")
+    p.add_argument("--notes-state", required=True, choices=list(NOTES_STATES),
+                   dest="notes_state")
+    # Explicit boolean VALUE flags (not store_true): the completion-gate rule is
+    # part of the deterministic invocation, so the skill's command always passes
+    # them rather than conditionally appending a bare flag in prose. `choices`
+    # rejects a typo'd value (fail-closed) instead of treating it as false.
+    p.add_argument("--markers-complete", choices=["true", "false"], default="false",
+                   dest="markers_complete",
+                   help="whether all WF2 step markers are present in session notes")
+    p.add_argument("--completion-gate-printed", choices=["true", "false"],
+                   default="false", dest="completion_gate_printed",
+                   help="whether the completion gate was already printed")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "detect-step":
+        try:
+            step = detect_resume_step(
+                args.pr_state, args.branch_state, args.notes_state,
+                markers_complete=(args.markers_complete == "true"),
+                completion_gate_printed=(args.completion_gate_printed == "true"),
+            )
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        print(step)
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -302,34 +302,67 @@ pending headless interaction:
 
 0. **Load project configuration** per `<config-loading>` to populate `capabilities.repo`.
    If config-loading fails, post error comment and exit.
-1. Check if `claude_docs/headless_suspend.json` exists.
-2. If missing → no pending question. Proceed with normal resumption protocol.
-3. If present → read the suspend state:
-   - Extract `question_id`, `comment_url`, `issue`, `step`, `clarification_round`
-4. Fetch the user's reply from GitHub issue comments:
+   Each numbered step below runs as its own Bash call with your judgement in
+   between, so shell variables do NOT persist across them. Read the values once
+   from `read-suspend` (step 1) and substitute them as **literals** into the
+   later commands (the `ISSUE`, `SUSPENDED_AT`, `OPTION_TOKENS` placeholders).
+   The user's reply itself is never substituted — it stays inside a quoted shell
+   variable within step 2's single block.
+
+1. Read and validate the suspend state in one fail-closed step with `read-suspend`
+   (it handles existence, JSON parse, AND field validation — a file that parses
+   but is unusable must not be mistaken for "no pending question"). On success it
+   prints the validated state JSON to stdout:
    ```bash
-   gh api repos/${capabilities.repo}/issues/ISSUE/comments \
-     --jq '[.[] | select(.created_at > "SUSPEND_TIMESTAMP")] | map(select(.user.login != "github-actions[bot]")) | last.body // empty'
+   python3 hooks/headless_interaction.py read-suspend \
+     --path claude_docs/headless_suspend.json
+   rc=$?; echo "read-suspend exit: $rc"; exit "$rc"
    ```
-   Use the `suspended_at` timestamp from the suspend file to find comments posted AFTER the bot's question.
-5. If no reply found → the user hasn't responded yet. Post a reminder comment if
-   `clarification_round < 2`, otherwise post an error. Exit.
-6. If reply found → parse the reply for the user's choice:
-   - Look for option letters/numbers ("a", "1", "option a", etc.)
-   - Look for natural language ("proceed", "approved", "go with the first one")
-   - If unparseable → increment `clarification_round`, post a clarification comment,
-     re-add `rawgentic:ai-waiting`, update suspend file (update ONLY `clarification_round` —
-     do NOT update `suspended_at`, as the next resume must still see comments posted after
-     the original question), exit.
-7. If reply parsed successfully:
+   (the block re-exits with read-suspend's code so the exit status — not just text — carries the result.)
+   - exit `3` → no suspend file: no pending question. Proceed with the normal `<resumption-protocol>`.
+   - exit `1` (or any non-zero other than 3) → the suspend file exists but is corrupt/unusable; a pending question was lost. STOP and escalate (post an error comment, add `rawgentic:ai-error`, exit). Do NOT silently restart as if nothing were pending.
+   - exit `0` → read these fields from the printed JSON and carry them as literals into the steps below: `question_id`, `comment_url`, `issue`, `step`, `suspended_at`, `clarification_round` (always present — defaults to 0).
+2. Fetch the user's reply AND attempt a deterministic literal parse in ONE block,
+   keeping the reply in a quoted shell variable so an arbitrary comment (quotes,
+   newlines, shell metacharacters) is never spliced into a command. Substitute
+   the literal `issue` and `suspended_at` from step 1 for `ISSUE`/`SUSPENDED_AT`,
+   and `OPTION_TOKENS` with the comma-separated letters/numbers you offered (e.g.
+   `a,b`) so an out-of-range answer fails closed to clarification:
+   ```bash
+   set -uo pipefail   # NOT -e: we branch on the parse outcome below
+   # Check the fetch itself: an auth/network/rate-limit failure returns non-zero
+   # with empty output, which must NOT be mistaken for "the user hasn't replied".
+   if ! REPLY=$(gh api repos/${capabilities.repo}/issues/ISSUE/comments \
+     --jq '[.[] | select(.created_at > "SUSPENDED_AT")] | map(select(.user.login != "github-actions[bot]")) | last.body // empty'); then
+     echo "FETCH_FAILED"
+   elif [[ -z "$REPLY" ]]; then
+     echo "NO_REPLY"
+   else
+     printf 'REPLY: %s\n' "$REPLY"
+     printf '%s' "$REPLY" \
+       | python3 hooks/headless_interaction.py parse-reply --options "OPTION_TOKENS" \
+       && echo "CHOICE_OK" || echo "CHOICE_DEFERRED"
+   fi
+   ```
+3. Act on the block's output:
+   - `FETCH_FAILED` → could not read the issue comments (auth/network/rate-limit). This is a transient infrastructure failure, NOT a missing reply: do not post a no-response reminder. STOP and escalate (or retry) so the pending question is preserved.
+   - `NO_REPLY` → the user hasn't responded yet. Post a reminder comment if `clarification_round < 2`, otherwise post an error. Exit.
+   - `CHOICE_OK` → the token printed on the line just above it is an unambiguous, in-range option (e.g. `a`, `2`). Use it.
+   - `CHOICE_DEFERRED` → no in-range literal choice. Interpret the `REPLY:` text
+     yourself ("proceed"/"approved"/"go with the first one" → the obvious option).
+     If you still cannot resolve it confidently → increment `clarification_round`,
+     post a clarification comment, re-add `rawgentic:ai-waiting`, update the suspend
+     file (update ONLY `clarification_round` — do NOT update `suspended_at`, as the
+     next resume must still see comments posted after the original question), exit.
+4. Once the choice is resolved:
    - Delete `claude_docs/headless_suspend.json`
-   - Remove `rawgentic:ai-waiting` label (and `rawgentic:ai-error` if stale from prior run):
+   - Remove `rawgentic:ai-waiting` label (and `rawgentic:ai-error` if stale from prior run), substituting the literal `issue`:
      ```bash
      gh issue edit ISSUE --repo ${capabilities.repo} --remove-label "rawgentic:ai-waiting" --remove-label "rawgentic:ai-error" 2>/dev/null || true
      ```
-   - Inject the user's choice into the workflow context
-   - Continue with the normal resumption protocol (the session notes checkpoint
-     tells us exactly where to resume and what the pending decision was)
+   - Inject the user's choice into the workflow context and resume at the `step`
+     read from the suspend state (the session notes checkpoint provides the rest
+     of the context for that step).
 </headless-resume>
 
 <termination-rule>
@@ -355,19 +388,38 @@ global_loopback_total = 0
 </loop-back-budget>
 
 <resumption-protocol>
-WF2 may span multiple Claude Code sessions. On resumption, detect the current step:
+WF2 may span multiple Claude Code sessions. On resumption, detect the current step.
 
--1. **Headless resume check (FIRST):** If in headless mode, execute `<headless-resume>` before any other check. If a pending question was answered, inject the reply and resume at the step indicated in the session notes checkpoint. If no reply yet, exit cleanly.
-0. All step markers present but completion-gate not printed? -> Run completion-gate, then terminate.
-1. PR exists and is merged? -> Resume at Step 15 (post-deploy verification)
-2. PR exists and CI passed (or no CI)? -> Resume at Step 14 (merge + deploy)
-3. PR exists? -> Resume at Step 13 (CI verification)
-4. Feature branch has code changes with passing tests (or verified)? -> Resume at Step 11 (code review)
-5. Feature branch has code changes? -> Resume at Step 9 (implementation drift check)
-6. Feature branch exists but is empty? -> Resume at Step 8 (implementation)
-7. Design document exists in session notes? -> Resume at Step 5 (create plan)
-8. Issue is validated in session notes? -> Resume at Step 2 (analyze codebase)
-9. None of the above? -> Start from Step 1
+**Headless resume check (FIRST):** If in headless mode, execute `<headless-resume>` before anything below. If a pending question was answered, inject the reply and resume at the step indicated in the session notes checkpoint. If no reply yet, exit cleanly.
+
+**Otherwise, do NOT hand-apply the priority cascade.** The resume target is a strict ordered precedence (a merged PR resumes at post-deploy even if a stale design doc also exists), and applying that order by hand is how a resume silently lands on the wrong step. Gather the facts below — git/gh for the PR and branch, session notes for the design/issue/test status — then let `hooks/resume_lib.py detect-step` apply the canonical order. The ordering lives in one tested place so it can't drift from this prose:
+
+```bash
+set -euo pipefail
+# Map your gathered facts to these three states (the value names ARE the rules):
+#   --pr-state     none | open | ready-to-merge | merged
+#     merged         = PR is merged
+#     ready-to-merge = PR open AND (CI green OR project has no CI)   [-> Step 14]
+#     open           = PR open AND CI not yet green                  [-> Step 13]
+#     none           = no PR for this branch
+#   --branch-state none | empty | changes | verified
+#     verified = branch has commits AND tests pass/verified in notes [-> Step 11]
+#     changes  = branch has commits, tests not yet verified          [-> Step 9]
+#     empty    = branch exists with no commits                       [-> Step 8]
+#     none     = no feature branch
+#   --notes-state none | issue-validated | design-doc
+#     design-doc      = a design document is recorded in notes       [-> Step 5]
+#     issue-validated = issue validated in notes, no design yet       [-> Step 2]
+#     none            = neither                                       [-> Step 1]
+# MARKERS_COMPLETE = true|false  (true iff ALL step markers are present in notes)
+# GATE_PRINTED     = true|false  (true iff the completion gate was already printed)
+STEP=$(python3 hooks/resume_lib.py detect-step \
+  --pr-state PR_STATE --branch-state BRANCH_STATE --notes-state NOTES_STATE \
+  --markers-complete MARKERS_COMPLETE --completion-gate-printed GATE_PRINTED)
+echo "Resuming at: $STEP"
+```
+
+Pass the marker booleans on every call (don't leave the completion-gate rule to prose) — `detect-step` prints either a step number (1, 2, 5, 8, 9, 11, 13, 14, 15) or `completion-gate` (all markers present but the gate was never printed — run the completion gate, then terminate). Resume at the printed step. An unrecognized `--*-state` or non-`true`/`false` marker value exits non-zero rather than defaulting to Step 1, so a mistyped fact fails loudly instead of restarting in-flight work.
 
 Before context compacts, document in session notes:
 - Current step number and sub-step

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.29.0"
+    assert plugin["version"] == "2.30.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_headless.py
+++ b/tests/hooks/test_headless.py
@@ -917,7 +917,8 @@ class TestHeadlessCLISkillWiring:
     """
 
     SKILL_MD = Path(__file__).resolve().parent.parent.parent / "skills" / "implement-feature" / "SKILL.md"
-    WIRED_SUBCOMMANDS = ["new-id", "format-comment", "write-suspend"]
+    WIRED_SUBCOMMANDS = ["new-id", "format-comment", "write-suspend",
+                         "read-suspend", "parse-reply"]
 
     @pytest.mark.parametrize("subcommand", WIRED_SUBCOMMANDS)
     def test_skill_invokes_cli_subcommand(self, subcommand):
@@ -1004,6 +1005,179 @@ class TestHeadlessCLISkillWiring:
         assert '--comment-url "$COMMENT_URL"' in sus[0], (
             "the write-suspend command must reuse the captured $COMMENT_URL"
         )
+
+
+class TestParseReplyChoice:
+    """parse_reply_choice extracts an option choice from a user's free-text reply
+    on the headless resume path. It is deliberately conservative: it accepts only
+    an UNAMBIGUOUS literal option token (the common case, e.g. "a" or "(2)") and
+    defers everything else (natural language, multiple tokens, garbage) to the
+    skill's prose judgement / clarification round. Fail-closed: when in doubt,
+    return None so the orchestrator re-asks rather than guessing."""
+
+    @pytest.mark.parametrize("reply,expected", [
+        ("a", "a"),
+        ("A", "a"),
+        ("(a)", "a"),
+        ("a)", "a"),
+        ("a.", "a"),
+        (" a ", "a"),
+        ("option a", "a"),
+        ("Option B", "b"),
+        ("Option (b).", "b"),
+        ("1", "1"),
+        ("(2)", "2"),
+        ("option 3", "3"),
+        ("b\n", "b"),
+        ("99", "99"),     # syntactically valid; range is the CLI's job via --options
+    ])
+    def test_accepts_unambiguous_literal_choice(self, reply, expected):
+        from headless_interaction import parse_reply_choice
+        assert parse_reply_choice(reply) == expected
+
+    @pytest.mark.parametrize("reply", [
+        "",
+        "   ",
+        "go with the first one",
+        "proceed",
+        "approved",
+        "yes",
+        "I'll take a, thanks",
+        "a and b",
+        "ab",
+        "12a",
+        "123",
+        "option",
+        "0",       # 1-based options: a bare 0 is never a valid choice
+        "00",      # leading zero
+        "012",     # leading zero
+        None,
+    ])
+    def test_defers_ambiguous_or_natural_language(self, reply):
+        from headless_interaction import parse_reply_choice
+        assert parse_reply_choice(reply) is None
+
+
+def _valid_suspend(tmp_path, **overrides):
+    """Write a valid suspend file and return its path; overrides patch fields."""
+    from headless_interaction import format_suspend_state, write_suspend_state
+    state = format_suspend_state(
+        session_id="sess-1", issue=42, step=5,
+        question_id="abc-123", comment_url="https://example.com/c/1",
+    )
+    state.update(overrides)
+    path = tmp_path / "headless_suspend.json"
+    write_suspend_state(str(path), state)
+    return path
+
+
+class TestReadSuspendCLI:
+    """read-suspend reads + VALIDATES the suspend file in one step. A schema-valid
+    but unusable file (empty question_id, non-positive issue, missing timestamp)
+    must fail closed: a corrupt suspend file means a pending question was lost, so
+    resuming as if nothing were pending would silently drop the user's decision."""
+
+    def test_valid_file_prints_json(self, tmp_path):
+        path = _valid_suspend(tmp_path)
+        out, err, rc = _run_cli("read-suspend", "--path", str(path))
+        assert rc == 0, err
+        state = json.loads(out)
+        assert state["question_id"] == "abc-123"
+        assert state["issue"] == 42
+        assert state["comment_url"] == "https://example.com/c/1"
+        assert "suspended_at" in state
+
+    def test_missing_file_is_distinct_exit_3(self, tmp_path):
+        """Missing file = no pending question (benign): a distinct exit code lets
+        the orchestrator proceed to normal resumption, separate from a corrupt
+        file (exit 1) which must escalate."""
+        out, err, rc = _run_cli("read-suspend",
+                                "--path", str(tmp_path / "nope.json"))
+        assert rc == 3
+
+    def test_malformed_json_fails_closed(self, tmp_path):
+        path = tmp_path / "headless_suspend.json"
+        path.write_text("{not valid json")
+        _, _, rc = _run_cli("read-suspend", "--path", str(path))
+        assert rc == 1
+
+    @pytest.mark.parametrize("overrides", [
+        {"question_id": ""},
+        {"question_id": "   "},
+        {"comment_url": ""},
+        {"suspended_at": ""},
+        {"issue": 0},
+        {"issue": -1},
+        {"issue": "42"},      # wrong type (string, not int)
+        {"step": "0"},        # invalid step
+        {"step": "17"},       # out of range
+        {"clarification_round": -1},
+    ])
+    def test_schema_valid_but_unusable_fails_closed(self, tmp_path, overrides):
+        path = _valid_suspend(tmp_path, **overrides)
+        _, _, rc = _run_cli("read-suspend", "--path", str(path))
+        assert rc == 1
+
+    def test_missing_clarification_round_defaults_ok(self, tmp_path):
+        """clarification_round may be absent in an old/hand-written file; that is
+        not a corruption — it defaults to 0 and the read succeeds."""
+        from headless_interaction import write_suspend_state
+        state = {
+            "session_id": "s", "issue": 1, "step": 5,
+            "question_id": "q", "comment_url": "u",
+            "suspended_at": "2026-01-01T00:00:00Z",
+        }
+        path = tmp_path / "headless_suspend.json"
+        write_suspend_state(str(path), state)
+        out, err, rc = _run_cli("read-suspend", "--path", str(path))
+        assert rc == 0, err
+        # The default must be MATERIALIZED in the output JSON so a caller running
+        # `jq -r .clarification_round` gets 0, not the null an absent key yields.
+        assert json.loads(out)["clarification_round"] == 0
+
+
+class TestParseReplyCLI:
+    """parse-reply wraps parse_reply_choice for the skill's Bash resume block. The
+    reply is read on STDIN (not a CLI arg) so an arbitrary GitHub comment — which
+    may contain quotes/newlines/shell metacharacters — is never spliced into a
+    command the caller would have to escape."""
+
+    def test_literal_choice_on_stdin_prints_and_exits_zero(self):
+        out, err, rc = _run_cli("parse-reply", stdin="(a)")
+        assert rc == 0, err
+        assert out.strip() == "a"
+
+    def test_reply_with_single_quote_is_safe(self):
+        """The injection case from review: a reply containing a quote must not
+        break anything — it just doesn't match a literal token, so it defers."""
+        _, _, rc = _run_cli("parse-reply", stdin="I'll take a, thanks")
+        assert rc == 1
+
+    def test_ambiguous_reply_fails_so_prose_handles_it(self):
+        _, _, rc = _run_cli("parse-reply", stdin="go with the first one")
+        assert rc == 1
+
+    def test_empty_reply_fails(self):
+        _, _, rc = _run_cli("parse-reply", stdin="")
+        assert rc == 1
+
+    # --- --options membership (fail-closed against out-of-range answers) ---
+
+    def test_in_range_choice_passes_options_check(self):
+        out, err, rc = _run_cli("parse-reply", "--options", "a,b,c", stdin="b")
+        assert rc == 0, err
+        assert out.strip() == "b"
+
+    def test_out_of_range_choice_fails_closed(self):
+        """A syntactically-valid but un-offered choice (e.g. '99' when only a/b
+        were offered) must route to clarification, not resume."""
+        _, _, rc = _run_cli("parse-reply", "--options", "a,b", stdin="99")
+        assert rc == 1
+
+    def test_options_membership_is_case_insensitive(self):
+        out, _, rc = _run_cli("parse-reply", "--options", "A,B", stdin="a")
+        assert rc == 0
+        assert out.strip() == "a"
 
 
 class TestSkillCountCanary:

--- a/tests/hooks/test_resume_lib.py
+++ b/tests/hooks/test_resume_lib.py
@@ -1,0 +1,255 @@
+"""Tests for hooks/resume_lib.py — the WF2 resumption step-detection cascade.
+
+PR 4b extracts the priority-ordered resume cascade (previously hand-applied in
+SKILL.md prose) into a single tested decision function + CLI. The orchestrator
+gathers the facts (git/gh for PR + branch, session notes for design/issue/test
+status) and `detect-step` applies the canonical precedence, so the resume target
+can no longer drift from the order the prose intended.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import Python helper from hooks/
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+RESUME_CLI = HOOKS_DIR / "resume_lib.py"
+
+
+def _run_cli(*args, timeout=10):
+    """Invoke resume_lib.py as a CLI subprocess (exercises argparse + exit codes
+    exactly as the SKILL.md Bash block does)."""
+    import subprocess
+    result = subprocess.run(
+        ["python3", str(RESUME_CLI), *args],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+class TestDetectResumeStepFunction:
+    """The pure decision function. Each (pr_state, branch_state, notes_state)
+    maps to exactly one resume step; higher dimensions take precedence (a merged
+    PR resumes at post-deploy even if a stale design doc also exists)."""
+
+    # --- PR cascade (highest precedence) ---
+
+    def test_pr_merged_resumes_post_deploy(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("merged", "none", "none") == 15
+
+    def test_pr_ready_to_merge_resumes_merge_deploy(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("ready-to-merge", "none", "none") == 14
+
+    def test_pr_open_resumes_ci_verification(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("open", "none", "none") == 13
+
+    # --- branch cascade (only when no PR) ---
+
+    def test_branch_verified_resumes_code_review(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("none", "verified", "none") == 11
+
+    def test_branch_changes_resumes_drift_check(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("none", "changes", "none") == 9
+
+    def test_branch_empty_resumes_implementation(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("none", "empty", "none") == 8
+
+    # --- notes cascade (only when no PR, no branch) ---
+
+    def test_design_doc_resumes_create_plan(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("none", "none", "design-doc") == 5
+
+    def test_issue_validated_resumes_analyze(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("none", "none", "issue-validated") == 2
+
+    def test_nothing_starts_from_step_1(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("none", "none", "none") == 1
+
+    # --- precedence: higher dimension wins over lower ---
+
+    def test_pr_wins_over_branch_and_notes(self):
+        from resume_lib import detect_resume_step
+        # A merged PR with a still-present branch + stale design doc resumes at
+        # post-deploy, NOT at code review or create-plan.
+        assert detect_resume_step("merged", "verified", "design-doc") == 15
+
+    def test_branch_wins_over_notes(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("none", "changes", "design-doc") == 9
+
+    # --- completion-gate pre-check (rule 0) ---
+
+    def test_markers_complete_gate_not_printed_runs_gate(self):
+        from resume_lib import detect_resume_step
+        # All step markers present but the completion gate never printed: run the
+        # gate, do not redo Step 15.
+        assert detect_resume_step(
+            "merged", "none", "none",
+            markers_complete=True, completion_gate_printed=False
+        ) == "completion-gate"
+
+    def test_markers_complete_gate_already_printed_falls_through(self):
+        from resume_lib import detect_resume_step
+        # Gate already printed → the workflow is genuinely done; fall through to
+        # the normal cascade (no special completion-gate signal).
+        assert detect_resume_step(
+            "merged", "none", "none",
+            markers_complete=True, completion_gate_printed=True
+        ) == 15
+
+    def test_markers_incomplete_ignores_gate_flag(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step(
+            "open", "none", "none",
+            markers_complete=False, completion_gate_printed=False
+        ) == 13
+
+    # --- fail-closed on unknown state (importable function must not silently
+    #     fall through to Step 1, which would restart in-flight work) ---
+
+    @pytest.mark.parametrize("bad", ["", "bogus", "MERGED", "step15", None])
+    def test_invalid_pr_state_raises(self, bad):
+        from resume_lib import detect_resume_step
+        with pytest.raises(ValueError):
+            detect_resume_step(bad, "none", "none")
+
+    @pytest.mark.parametrize("bad", ["", "bogus", "Verified", None])
+    def test_invalid_branch_state_raises(self, bad):
+        from resume_lib import detect_resume_step
+        with pytest.raises(ValueError):
+            detect_resume_step("none", bad, "none")
+
+    @pytest.mark.parametrize("bad", ["", "bogus", "DesignDoc", None])
+    def test_invalid_notes_state_raises(self, bad):
+        from resume_lib import detect_resume_step
+        with pytest.raises(ValueError):
+            detect_resume_step("none", "none", bad)
+
+
+class TestDetectStepCLI:
+    """The `detect-step` subcommand the SKILL.md resumption block drives."""
+
+    def test_prints_step_number(self):
+        out, err, rc = _run_cli(
+            "detect-step", "--pr-state", "merged",
+            "--branch-state", "none", "--notes-state", "none",
+        )
+        assert rc == 0, err
+        assert out.strip() == "15"
+
+    def test_prints_completion_gate_sentinel(self):
+        out, _, rc = _run_cli(
+            "detect-step", "--pr-state", "merged",
+            "--branch-state", "none", "--notes-state", "none",
+            "--markers-complete", "true",
+        )
+        assert rc == 0
+        assert out.strip() == "completion-gate"
+
+    def test_completion_gate_suppressed_when_already_printed(self):
+        out, _, rc = _run_cli(
+            "detect-step", "--pr-state", "merged",
+            "--branch-state", "none", "--notes-state", "none",
+            "--markers-complete", "true", "--completion-gate-printed", "true",
+        )
+        assert rc == 0
+        assert out.strip() == "15"
+
+    @pytest.mark.parametrize("flag", ["--markers-complete", "--completion-gate-printed"])
+    def test_marker_flags_reject_non_boolean_value(self, flag):
+        """The marker flags take explicit true/false; a typo'd value must fail
+        closed (argparse choices), not be silently coerced to false."""
+        _, _, rc = _run_cli(
+            "detect-step", "--pr-state", "merged",
+            "--branch-state", "none", "--notes-state", "none",
+            flag, "maybe",
+        )
+        assert rc != 0
+
+    def test_default_no_state_is_step_1(self):
+        out, _, rc = _run_cli(
+            "detect-step", "--pr-state", "none",
+            "--branch-state", "none", "--notes-state", "none",
+        )
+        assert rc == 0
+        assert out.strip() == "1"
+
+    @pytest.mark.parametrize("dim,flag", [
+        ("--pr-state", "bogus"),
+        ("--branch-state", "bogus"),
+        ("--notes-state", "bogus"),
+    ])
+    def test_invalid_enum_fails_closed(self, dim, flag):
+        """argparse `choices=` rejects an unrecognized state with a non-zero exit
+        rather than silently mapping it to Step 1 (which would restart work)."""
+        valid = {"--pr-state": "merged", "--branch-state": "none",
+                 "--notes-state": "none"}
+        valid[dim] = flag
+        _, _, rc = _run_cli("detect-step",
+                            "--pr-state", valid["--pr-state"],
+                            "--branch-state", valid["--branch-state"],
+                            "--notes-state", valid["--notes-state"])
+        assert rc != 0
+
+    def test_missing_required_flag_fails(self):
+        _, _, rc = _run_cli("detect-step", "--pr-state", "merged")
+        assert rc != 0
+
+    def test_no_subcommand_fails(self):
+        _, _, rc = _run_cli()
+        assert rc != 0
+
+
+class TestResumeSkillWiring:
+    """Drift guard: the WF2 skill must drive resume step-detection through the
+    `detect-step` CLI, not by hand-applying the numbered cascade in prose (which
+    is exactly the ordering bug this extraction removes)."""
+
+    SKILL_MD = (Path(__file__).resolve().parent.parent.parent
+                / "skills" / "implement-feature" / "SKILL.md")
+
+    def _resumption_block(self):
+        content = self.SKILL_MD.read_text()
+        start = content.index("<resumption-protocol>")
+        end = content.index("</resumption-protocol>")
+        return content[start:end]
+
+    def test_skill_invokes_detect_step(self):
+        block = self._resumption_block()
+        assert "resume_lib.py detect-step" in block, (
+            "the resumption protocol must call `resume_lib.py detect-step`; if you "
+            "renamed the subcommand, update SKILL.md and this guard."
+        )
+
+    @pytest.mark.parametrize("flag", [
+        "--pr-state", "--branch-state", "--notes-state",
+        "--markers-complete", "--completion-gate-printed",
+    ])
+    def test_skill_passes_all_detect_step_flags(self, flag):
+        """All five flags must appear in the block — in particular the two marker
+        flags, so the completion-gate rule is part of the deterministic
+        invocation rather than left to prose (review finding)."""
+        assert flag in self._resumption_block(), (
+            f"detect-step invocation in SKILL.md must pass {flag}"
+        )
+
+    def test_skill_does_not_duplicate_the_numbered_cascade(self):
+        """The old hand-applied cascade ("PR exists and is merged? -> Resume at
+        Step 15") must not coexist with the CLI — two sources of the ordering is
+        how they drift apart."""
+        block = self._resumption_block()
+        assert "PR exists and is merged" not in block, (
+            "the prose cascade was re-introduced alongside detect-step; the CLI "
+            "is the single source of truth for the resume ordering."
+        )


### PR DESCRIPTION
## Summary

PR 4b of the WF2 (`implement-feature`) script-extraction effort. It moves the **resume-side** deterministic logic out of fragile SKILL.md prose into tested, fail-closed CLIs — the same pattern as PR #87 (the QUESTION-suspend side), now applied to resumption and the headless reply path.

Three deliverables (the larger "resume PR" scope):

### 1. `hooks/resume_lib.py` (new) — the resumption cascade
`detect_resume_step()` + a `detect-step` CLI encode the priority-ordered rule that decides which of the 16 steps a fresh session resumes at. Previously the orchestrator hand-applied this 9-rule ordered cascade in prose — if it checked "branch has changes" before "PR exists," it resumed at the wrong step (redoing work or skipping a quality gate).

- Composite-enum flags (`--pr-state`, `--branch-state`, `--notes-state`) make within-dimension contradictions *inexpressible* and let `argparse choices=` reject bad values fail-closed.
- An unrecognized state **raises / exits non-zero** rather than defaulting to Step 1 (silently restarting in-flight work).
- `--markers-complete`/`--completion-gate-printed` are explicit `{true,false}` value flags, so the completion-gate rule is part of the deterministic invocation (not left to prose).

### 2. `read-suspend` + `parse-reply` (in `hooks/headless_interaction.py`)
The resume-side subcommands deferred from PR #87.

- **`read-suspend`** — reads AND validates the suspend file in one step. Exit `0` (valid, JSON on stdout) / `1` (parses but unusable — empty identifier, non-positive issue, missing timestamp, bad step) / `3` (absent — benign "no pending question", kept distinct so the caller proceeds vs escalates). Materializes `clarification_round=0` into the output.
- **`parse-reply`** — extracts an unambiguous option choice from the reply read on **stdin** (so an arbitrary comment with quotes/newlines is never spliced into a command). Tightened regex rejects `0`/leading-zeros; optional `--options` membership check fails closed on out-of-range answers. Ambiguous / natural-language replies defer to the skill's judgement.

### 3. SKILL.md wiring
- `<resumption-protocol>` now gathers facts (git/gh + session notes) and calls `detect-step` — one tested source of the ordering.
- `<headless-resume>` drives `read-suspend`/`parse-reply`, keeps the reply in a quoted shell var, preserves `read-suspend`'s exit code (`rc=$?; … exit "$rc"`), and routes a `gh`-fetch failure to escalation (`FETCH_FAILED`) so a transient infra failure is no longer mistaken for "no reply."

## Testing
- TDD throughout (RED verified by neutralizing each fix before implementing).
- New: `tests/hooks/test_resume_lib.py`; extended `tests/hooks/test_headless.py`. Drift guards pin the SKILL.md↔CLI wiring.
- Full suite: **812 passed, 3 skipped**.
- **Cross-model adversarial review (Codex) iterated to CONVERGED over 4 rounds** — caught a cross-Bash-call shell-var regression, an exit-code-erasure pattern, an out-of-range fail-open in reply parsing, and a `gh`-failure→"no reply" conflation.

## Pre-PR checklist
- [x] Version bump `2.29.0` → `2.30.0` (minor — new feature) + pin updated
- [x] README updated
- [x] `docs/config-reference.md` updated (Python Helper + new Resume Step Detection section)
- [x] `pytest tests/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
