### PR TITLE
feat: extract config→capabilities derivation into a tested CLI across all 11 skills (WF2 PR 4c)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -416,11 +416,10 @@ Tracks all registered projects. Created automatically by `/rawgentic:new-project
 All 11 workflow skills share an identical config-loading block that runs before any workflow step:
 
 1. Read `.rawgentic_workspace.json` → find active project (if multiple are active, stop and prompt user to `/rawgentic:switch`)
-2. Read `<project-path>/.rawgentic.json` → validate version
-3. Build `capabilities` object (has_tests, has_ci, has_deploy, etc.)
-4. All subsequent steps use config and capabilities — never probe the filesystem
+2. Load + derive: `python3 hooks/capabilities_lib.py derive --config <project-path>/.rawgentic.json` validates the config and emits `{config, capabilities}`
+3. All subsequent steps use config and capabilities — never probe the filesystem
 
-This means skills adapt automatically: TDD mode when tests are configured, Implement-Verify mode when they're not. No capability detection, no guessing.
+The config→`capabilities` derivation lives in **one tested place** (`hooks/capabilities_lib.py`) instead of an identical prose block duplicated across all 11 skills + the docs table. It is fail-closed: a missing/corrupt config or a present-but-malformed optional section exits non-zero (rather than silently yielding a feature-less object), while an absent optional section yields its documented default. This means skills adapt automatically: TDD mode when tests are configured, Implement-Verify mode when they're not. No capability detection, no guessing.
 
 ### Learning Config
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -21,24 +21,31 @@ should be in the config. If it is detectable at setup time, it belongs in
 **Single source of truth.** No duplication between `.rawgentic.json` and CLAUDE.md.
 Config holds structured data; CLAUDE.md holds prose conventions and instructions.
 
-**Capabilities object.** Every workflow skill derives a boolean `capabilities` object
-from the config at startup. The exact flags are:
+**Capabilities object.** Every workflow skill derives a `capabilities` object from
+the config at startup via `hooks/capabilities_lib.py derive` — the single source of
+truth (skills no longer hand-derive it in prose). The fields are:
 
-| Flag | Derivation |
+| Field | Derivation |
 |------|-----------|
-| `has_tests` | `config.testing` exists AND `config.testing.frameworks.length > 0` |
-| `test_commands` | `config.testing.frameworks[].command` |
-| `has_ci` | `config.ci` exists AND `config.ci.provider` exists |
-| `has_deploy` | `config.deploy` exists AND `config.deploy.method` exists and != `"manual"` |
-| `has_database` | `config.database` exists AND `config.database.type` exists |
-| `has_docker` | `config.infrastructure` exists AND `config.infrastructure.docker.composeFiles.length > 0` |
-| `project_type` | `config.project.type` |
-| `repo` | `config.repo.fullName` |
-| `default_branch` | `config.repo.defaultBranch` |
+| `repo` | `config.repo.fullName` (required — derive errors if missing) |
+| `default_branch` | `config.repo.defaultBranch` (required — derive errors if missing) |
+| `project_type` | `config.project.type` (required — derive errors if missing) |
+| `has_tests` | `config.testing.frameworks` is a non-empty array |
+| `test_commands` | `config.testing.frameworks[].command` (one per framework) |
+| `has_ci` | `config.ci.provider` exists |
+| `has_deploy` | `config.deploy.method` exists and != `"manual"` |
+| `deploy_method` | `config.deploy.method` (one of `compose`/`ssh`/`script`/`manual`; `null` when absent, error if outside the enum) |
+| `has_database` | `config.database.type` exists |
+| `has_docker` | `config.infrastructure.docker.composeFiles` is a non-empty array |
+| `migration_dir` | `config.database.migrationsDir` (else `null`) |
 
 Skills adapt their behavior based on these flags -- for example, a project without
 tests uses implement-verify mode instead of TDD, and a project without CI skips the
-CI verification step.
+CI verification step. The derivation is fail-closed: a missing/corrupt config, or a
+present-but-malformed optional section, exits non-zero (rather than silently yielding
+a feature-less object), while an *absent* optional section yields its documented
+default (`false`/`[]`/`null`). The required `repo` and `project` sections must be
+present and well-typed or `derive` stops before any `git`/`gh` side effects.
 
 **Learning config.** Skills can update `.rawgentic.json` when they discover new
 project information during execution:
@@ -93,7 +100,11 @@ is relative (e.g., `./projects/my-app`), resolve it against the Claude root dire
 
 ### 3. Build the capabilities object
 
-Derive the boolean flags listed above from the parsed config.
+Run `python3 hooks/capabilities_lib.py derive --config <activeProject.path>/.rawgentic.json`.
+It loads + validates the config and emits `{"config": {...}, "capabilities": {...}}` —
+the deterministic load+derive (steps 2–3) in one fail-closed call, so the mapping
+above can't drift across the 11 skills. A non-zero exit means stop and run
+`/rawgentic:setup`; a `config.version` mismatch is a stderr warning only.
 
 ### Error behavior
 

--- a/hooks/capabilities_lib.py
+++ b/hooks/capabilities_lib.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Config->capabilities derivation for rawgentic workflow skills.
+
+Every workflow skill (implement-feature, fix-bug, create-issue, ... — 11 in all)
+derives a `capabilities` object from the project's `.rawgentic.json` at startup
+and branches on it (TDD vs implement-verify, skip-CI-gate, deploy method, etc.).
+That derivation used to be an IDENTICAL prose block duplicated across all 11
+SKILL.md files plus the docs table — three-plus copies that could silently drift,
+and a hand-applied mapping where a malformed config could masquerade as a
+feature-less project (skipping TDD on a project that actually has tests).
+
+This module encodes the derivation once, as a tested fail-closed function exposed
+as a `derive` CLI. The orchestrator still resolves the active project (Level
+1/2/3 fallback — conversation/registry/workspace) in prose, since that is
+environmental; the CLI takes the resolved config path and owns load + validate +
+derive. The contract is all-or-nothing: it either emits a fully-valid
+capabilities object or exits non-zero — never a best-effort partial.
+"""
+import argparse
+import json
+import sys
+
+
+# Canonical capability field set. The docs table (docs/config-reference.md) and
+# the SKILL.md drift guard check against this list, and the test asserts it
+# equals exactly the keys derive_capabilities() produces — so the three places
+# that describe capabilities can never drift apart again.
+CAPABILITY_FIELDS = (
+    "repo",
+    "default_branch",
+    "project_type",
+    "has_tests",
+    "test_commands",
+    "has_ci",
+    "has_deploy",
+    "deploy_method",
+    "has_database",
+    "has_docker",
+    "migration_dir",
+)
+
+
+class CapabilitiesError(ValueError):
+    """A config that cannot be safely derived into capabilities.
+
+    Raised for a missing/corrupt config, a wrong-typed essential field, or a
+    present-but-malformed optional section. Distinct from an ABSENT optional
+    section, which legitimately yields the documented default (false/[]/null).
+    """
+
+
+# Sentinel for "key absent" so it can be distinguished from "key present with a
+# null value." The fail-closed rule is: an ABSENT key yields the documented
+# default, but a PRESENT-but-invalid value (null OR wrong type) is an error —
+# setup omits empty sections rather than writing null, so a present null signals
+# a hand-edited/corrupt config that must not silently degrade (e.g. a null
+# `frameworks` silently skipping TDD on a project that has tests).
+_MISSING = object()
+
+# config.deploy.method is a closed enum (docs/config-reference.md). An unknown
+# method must fail closed, not yield has_deploy=true for a path that can't run.
+_DEPLOY_METHODS = ("compose", "ssh", "script", "manual")
+
+
+def _require_nonempty_str(value, field: str) -> str:
+    """A required string value. None (absent or null), wrong type, or empty ->
+    error. Used for both essential fields and present optional sub-values."""
+    if not isinstance(value, str) or not value.strip():
+        raise CapabilitiesError(
+            f"{field} must be a non-empty string (got {value!r}). Run /rawgentic:setup."
+        )
+    return value
+
+
+def _optional_section(config: dict, key: str):
+    """A top-level optional section: ABSENT -> _MISSING (caller defaults);
+    present-but-null or present-but-not-an-object -> error."""
+    val = config.get(key, _MISSING)
+    if val is _MISSING:
+        return _MISSING
+    if not isinstance(val, dict):
+        raise CapabilitiesError(
+            f"config.{key} must be an object when present (got {val!r}). "
+            f"Run /rawgentic:setup."
+        )
+    return val
+
+
+def derive_capabilities(config) -> dict:
+    """Derive the capabilities object from a parsed `.rawgentic.json` config.
+
+    Fail-closed: essential fields (repo.fullName, repo.defaultBranch,
+    project.type — the two required config sections) must be present and
+    well-typed or this raises; a present-but-malformed optional section raises
+    rather than silently degrading to false. An ABSENT optional section yields
+    its documented default.
+    """
+    if not isinstance(config, dict):
+        raise CapabilitiesError(
+            "config must be a JSON object (expected an object at top level). "
+            "Run /rawgentic:setup."
+        )
+
+    # --- Essential: repo + project (the two required config sections) ---
+    repo = config.get("repo")
+    if not isinstance(repo, dict):
+        raise CapabilitiesError("config.repo must be an object. Run /rawgentic:setup.")
+    project = config.get("project")
+    if not isinstance(project, dict):
+        raise CapabilitiesError("config.project must be an object. Run /rawgentic:setup.")
+
+    caps = {
+        "repo": _require_nonempty_str(repo.get("fullName"), "config.repo.fullName"),
+        "default_branch": _require_nonempty_str(
+            repo.get("defaultBranch"), "config.repo.defaultBranch"),
+        "project_type": _require_nonempty_str(
+            project.get("type"), "config.project.type"),
+    }
+
+    # --- testing -> has_tests, test_commands ---
+    testing = _optional_section(config, "testing")
+    if testing is _MISSING:
+        caps["has_tests"] = False
+        caps["test_commands"] = []
+    else:
+        frameworks = testing.get("frameworks", _MISSING)
+        if frameworks is _MISSING:
+            caps["has_tests"] = False
+            caps["test_commands"] = []
+        elif not isinstance(frameworks, list):  # null or wrong type
+            raise CapabilitiesError(
+                "config.testing.frameworks must be an array when present. "
+                "Run /rawgentic:setup.")
+        else:
+            commands = []
+            for i, fw in enumerate(frameworks):
+                if not isinstance(fw, dict):
+                    raise CapabilitiesError(
+                        f"config.testing.frameworks[{i}] must be an object. "
+                        f"Run /rawgentic:setup.")
+                # has_tests=true must imply a runnable command for every framework;
+                # an empty test_commands beside has_tests=true looks usable but
+                # breaks the TDD/verify step.
+                commands.append(_require_nonempty_str(
+                    fw.get("command"), f"config.testing.frameworks[{i}].command"))
+            caps["has_tests"] = len(frameworks) > 0
+            caps["test_commands"] = commands
+
+    # --- ci -> has_ci (keys on config.ci.provider) ---
+    ci = _optional_section(config, "ci")
+    if ci is _MISSING:
+        caps["has_ci"] = False
+    else:
+        provider = ci.get("provider", _MISSING)
+        if provider is _MISSING:
+            caps["has_ci"] = False  # ci section exists but no provider key -> false
+        else:
+            _require_nonempty_str(provider, "config.ci.provider")  # null/wrong/empty -> error
+            caps["has_ci"] = True
+
+    # --- deploy -> has_deploy, deploy_method (method=="manual" is the carve-out) ---
+    deploy = _optional_section(config, "deploy")
+    if deploy is _MISSING:
+        caps["has_deploy"] = False
+        caps["deploy_method"] = None
+    else:
+        method = deploy.get("method", _MISSING)
+        if method is _MISSING:
+            caps["deploy_method"] = None
+            caps["has_deploy"] = False
+        else:
+            _require_nonempty_str(method, "config.deploy.method")  # null/wrong/empty -> error
+            if method not in _DEPLOY_METHODS:
+                raise CapabilitiesError(
+                    f"config.deploy.method must be one of {list(_DEPLOY_METHODS)} "
+                    f"(got {method!r}). Run /rawgentic:setup.")
+            caps["deploy_method"] = method
+            caps["has_deploy"] = method != "manual"
+
+    # --- database -> has_database, migration_dir ---
+    database = _optional_section(config, "database")
+    if database is _MISSING:
+        caps["has_database"] = False
+        caps["migration_dir"] = None
+    else:
+        db_type = database.get("type", _MISSING)
+        if db_type is _MISSING:
+            caps["has_database"] = False
+        else:
+            _require_nonempty_str(db_type, "config.database.type")  # null/wrong/empty -> error
+            caps["has_database"] = True
+        mig = database.get("migrationsDir", _MISSING)
+        if mig is _MISSING:
+            caps["migration_dir"] = None
+        else:
+            caps["migration_dir"] = _require_nonempty_str(
+                mig, "config.database.migrationsDir")  # null/wrong/empty -> error
+
+    # --- infrastructure.docker -> has_docker (must null-guard the docker object:
+    #     infrastructure can legitimately exist with only `hosts` and no docker) ---
+    infra = _optional_section(config, "infrastructure")
+    if infra is _MISSING:
+        caps["has_docker"] = False
+    else:
+        docker = infra.get("docker", _MISSING)
+        if docker is _MISSING:
+            caps["has_docker"] = False
+        elif not isinstance(docker, dict):  # null or wrong type
+            raise CapabilitiesError(
+                "config.infrastructure.docker must be an object when present. "
+                "Run /rawgentic:setup.")
+        else:
+            compose = docker.get("composeFiles", _MISSING)
+            if compose is _MISSING:
+                caps["has_docker"] = False
+            elif not isinstance(compose, list):  # null or wrong type
+                raise CapabilitiesError(
+                    "config.infrastructure.docker.composeFiles must be an array "
+                    "when present. Run /rawgentic:setup.")
+            else:
+                caps["has_docker"] = len(compose) > 0
+
+    return caps
+
+
+def load_config(path: str) -> dict:
+    """Read + parse + shape-check a `.rawgentic.json`. Fail-closed: a missing or
+    corrupt file (or a valid-JSON-but-not-an-object file) raises rather than
+    returning something a caller could mistake for an empty config. The read and
+    json.loads are wrapped so a partial/truncated file can't fall through to
+    per-field access downstream."""
+    try:
+        with open(path) as f:
+            raw = f.read()
+    except FileNotFoundError:
+        raise CapabilitiesError(
+            f"Active project config not found at {path}. Run /rawgentic:setup.")
+    except OSError as exc:
+        raise CapabilitiesError(f"Could not read config at {path}: {exc}")
+    try:
+        config = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        raise CapabilitiesError(
+            f"Project config at {path} is corrupted (invalid JSON). "
+            f"Run /rawgentic:setup to regenerate.")
+    if not isinstance(config, dict):
+        raise CapabilitiesError(
+            f"Project config at {path} must be a JSON object. Run /rawgentic:setup.")
+    return config
+
+
+def main(argv=None) -> int:
+    """CLI entry point.
+
+    Subcommand:
+      derive  load + validate the config at --config and print
+              {"config": <parsed>, "capabilities": <derived>} as JSON
+
+    Exit codes:
+      0  success — both objects printed to stdout (a version mismatch is WARNED
+         on stderr but does not stop, matching the documented warn-and-continue
+         behavior and keeping in-flight projects on an older schema unblocked)
+      1  fail-closed: missing/corrupt config, or a config that derives invalidly
+      2  argparse usage error
+    """
+    parser = argparse.ArgumentParser(prog="capabilities_lib")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p = sub.add_parser(
+        "derive",
+        help="load + validate config, emit {config, capabilities} JSON")
+    p.add_argument("--config", required=True,
+                   help="path to the resolved <activeProject.path>/.rawgentic.json")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "derive":
+        try:
+            config = load_config(args.config)
+        except CapabilitiesError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        # Version handling stays warn-and-continue (faithful to config-reference
+        # docs + migration-path safety): a missing/newer version is surfaced but
+        # does not block, unlike a corrupt config which fails closed above.
+        version = config.get("version")
+        if version is None:
+            print("warning: config.version is missing; assuming version 1",
+                  file=sys.stderr)
+        elif version != 1:
+            print(f"warning: config.version is {version!r} (expected 1); "
+                  f"proceeding, but fields may have moved", file=sys.stderr)
+        try:
+            caps = derive_capabilities(config)
+        except CapabilitiesError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        print(json.dumps({"config": config, "capabilities": caps},
+                         separators=(",", ":")))
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -48,22 +48,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -46,22 +46,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/skills/create-tests/SKILL.md
+++ b/skills/create-tests/SKILL.md
@@ -48,22 +48,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/skills/fix-bug/SKILL.md
+++ b/skills/fix-bug/SKILL.md
@@ -79,22 +79,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -127,22 +127,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/skills/incident/SKILL.md
+++ b/skills/incident/SKILL.md
@@ -59,22 +59,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/skills/optimize-perf/SKILL.md
+++ b/skills/optimize-perf/SKILL.md
@@ -51,22 +51,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` -- never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -49,22 +49,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -55,22 +55,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -51,22 +51,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` -- never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -45,22 +45,15 @@ Before executing any workflow steps, load the project configuration:
      "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
    - Otherwise: proceed to step 2.
 
-2. Read `<activeProject.path>/.rawgentic.json`.
-   - Missing -> STOP. Tell user: "Active project <name> has no config. Run /rawgentic:setup."
-   - Malformed JSON -> STOP. Tell user: "Project config is corrupted. Run /rawgentic:setup to regenerate."
-   - Check `config.version`. If version > 1 (or missing), warn user about version mismatch.
-   - Parse full JSON into `config` object.
-
-3. Build the `capabilities` object from config:
-   - has_tests: config.testing exists AND config.testing.frameworks.length > 0
-   - test_commands: config.testing.frameworks[].command
-   - has_ci: config.ci exists AND config.ci.provider exists
-   - has_deploy: config.deploy exists AND config.deploy.method exists and != "manual"
-   - has_database: config.database exists AND config.database.type exists
-   - has_docker: config.infrastructure exists AND config.infrastructure.docker.composeFiles.length > 0
-   - project_type: config.project.type
-   - repo: config.repo.fullName
-   - default_branch: config.repo.defaultBranch
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
 
 All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
 </config-loading>

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.30.0"
+    assert plugin["version"] == "2.31.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_capabilities_lib.py
+++ b/tests/hooks/test_capabilities_lib.py
@@ -1,0 +1,359 @@
+"""Tests for hooks/capabilities_lib.py — the config->capabilities derivation.
+
+PR 4c extracts the "Build the capabilities object" derivation (previously an
+identical prose block duplicated across all 11 workflow SKILL.md files + the
+docs table) into one tested, fail-closed CLI. The orchestrator resolves the
+active project (semantic, stays in prose); the CLI loads + validates the config
+and derives the capabilities object so the mapping can no longer drift between
+11 copies, and a malformed config can't masquerade as a feature-less project.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+CAPS_CLI = HOOKS_DIR / "capabilities_lib.py"
+
+
+def _run_cli(*args, timeout=10):
+    import subprocess
+    result = subprocess.run(
+        ["python3", str(CAPS_CLI), *args],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+# A minimal VALID config: the three required sections only (no optional ones).
+def _base_config(**overrides):
+    cfg = {
+        "version": 1,
+        "project": {"type": "application"},
+        "repo": {"fullName": "owner/name", "defaultBranch": "main"},
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+class TestDeriveEssentialFields:
+    def test_repo_and_branch_and_type(self):
+        from capabilities_lib import derive_capabilities
+        caps = derive_capabilities(_base_config())
+        assert caps["repo"] == "owner/name"
+        assert caps["default_branch"] == "main"
+        assert caps["project_type"] == "application"
+
+    @pytest.mark.parametrize("mutate", [
+        lambda c: c.pop("repo"),
+        lambda c: c["repo"].pop("fullName"),
+        lambda c: c["repo"].update({"fullName": ""}),
+        lambda c: c["repo"].update({"fullName": 123}),
+        lambda c: c["repo"].pop("defaultBranch"),
+        lambda c: c["repo"].update({"defaultBranch": None}),
+        lambda c: c.pop("project"),
+        lambda c: c["project"].pop("type"),
+        lambda c: c["project"].update({"type": "  "}),
+    ])
+    def test_essential_missing_or_wrong_type_raises(self, mutate):
+        """repo/default_branch/project_type feed `gh`/`git` commands in every
+        skill — a null/empty/wrong-typed value would break a command after work
+        is done, so derive must fail closed BEFORE any side effects."""
+        from capabilities_lib import derive_capabilities, CapabilitiesError
+        cfg = _base_config()
+        mutate(cfg)
+        with pytest.raises(CapabilitiesError):
+            derive_capabilities(cfg)
+
+    def test_non_object_config_raises(self):
+        from capabilities_lib import derive_capabilities, CapabilitiesError
+        for bad in ([], "x", 5, None):
+            with pytest.raises(CapabilitiesError):
+                derive_capabilities(bad)
+
+
+class TestDeriveOptionalAbsentDefaults:
+    """An ABSENT optional section yields the documented degraded default — that
+    is the whole point of the has_* flags (false = "feature not available")."""
+
+    def test_all_optionals_absent(self):
+        from capabilities_lib import derive_capabilities
+        caps = derive_capabilities(_base_config())
+        assert caps["has_tests"] is False
+        assert caps["test_commands"] == []
+        assert caps["has_ci"] is False
+        assert caps["has_deploy"] is False
+        assert caps["deploy_method"] is None
+        assert caps["has_database"] is False
+        assert caps["migration_dir"] is None
+        assert caps["has_docker"] is False
+
+
+class TestDeriveTesting:
+    def test_frameworks_yield_has_tests_and_commands(self):
+        from capabilities_lib import derive_capabilities
+        cfg = _base_config(testing={"frameworks": [
+            {"name": "pytest", "command": "pytest tests/ -v"},
+            {"name": "vitest", "command": "npm test"},
+        ]})
+        caps = derive_capabilities(cfg)
+        assert caps["has_tests"] is True
+        assert caps["test_commands"] == ["pytest tests/ -v", "npm test"]
+
+    def test_empty_frameworks_list_is_no_tests(self):
+        from capabilities_lib import derive_capabilities
+        caps = derive_capabilities(_base_config(testing={"frameworks": []}))
+        assert caps["has_tests"] is False
+        assert caps["test_commands"] == []
+
+    def test_framework_missing_command_raises(self):
+        """has_tests=true with an empty/partial test_commands looks usable but
+        breaks the TDD/verify step — keep them consistent or fail closed."""
+        from capabilities_lib import derive_capabilities, CapabilitiesError
+        cfg = _base_config(testing={"frameworks": [{"name": "pytest"}]})
+        with pytest.raises(CapabilitiesError):
+            derive_capabilities(cfg)
+
+    @pytest.mark.parametrize("bad_testing", [
+        "pytest",                       # not an object
+        None,                           # null section (setup omits, never nulls)
+        {"frameworks": "pytest"},       # frameworks not a list
+        {"frameworks": None},           # frameworks present-but-null (orig .length would crash)
+        {"frameworks": ["pytest"]},     # element not an object
+    ])
+    def test_malformed_testing_raises_not_silently_false(self, bad_testing):
+        """A present-but-garbled testing block (incl. an explicit null) must ERROR,
+        not silently downgrade to has_tests=false (which would skip TDD on a
+        project that has tests). Absent is different — that yields the default."""
+        from capabilities_lib import derive_capabilities, CapabilitiesError
+        with pytest.raises(CapabilitiesError):
+            derive_capabilities(_base_config(testing=bad_testing))
+
+
+class TestDeriveDeploy:
+    def test_compose_method_has_deploy_true(self):
+        from capabilities_lib import derive_capabilities
+        caps = derive_capabilities(_base_config(deploy={"method": "compose"}))
+        assert caps["has_deploy"] is True
+        assert caps["deploy_method"] == "compose"
+
+    def test_manual_method_carveout_has_deploy_false(self):
+        """method=='manual' yields has_deploy=FALSE even though deploy exists."""
+        from capabilities_lib import derive_capabilities
+        caps = derive_capabilities(_base_config(deploy={"method": "manual"}))
+        assert caps["has_deploy"] is False
+        assert caps["deploy_method"] == "manual"
+
+    @pytest.mark.parametrize("method", ["compose", "ssh", "script"])
+    def test_each_real_method_has_deploy_true(self, method):
+        from capabilities_lib import derive_capabilities
+        caps = derive_capabilities(_base_config(deploy={"method": method}))
+        assert caps["has_deploy"] is True
+        assert caps["deploy_method"] == method
+
+    def test_deploy_present_without_method(self):
+        """method key ABSENT -> no deploy (the documented default), not an error."""
+        from capabilities_lib import derive_capabilities
+        caps = derive_capabilities(_base_config(deploy={"command": "x"}))
+        assert caps["has_deploy"] is False
+        assert caps["deploy_method"] is None
+
+    @pytest.mark.parametrize("bad", [5, None, "", "typo", "Compose"])
+    def test_deploy_method_invalid_raises(self, bad):
+        """Present-but-invalid method (wrong type, null, empty, or outside the
+        compose/ssh/script/manual enum) must fail closed — an unknown method
+        would otherwise yield has_deploy=true for a deploy path that can't run."""
+        from capabilities_lib import derive_capabilities, CapabilitiesError
+        with pytest.raises(CapabilitiesError):
+            derive_capabilities(_base_config(deploy={"method": bad}))
+
+
+class TestDeriveCiDatabaseDocker:
+    def test_ci_provider_present(self):
+        from capabilities_lib import derive_capabilities
+        assert derive_capabilities(_base_config(ci={"provider": "github-actions"}))["has_ci"] is True
+
+    def test_ci_present_without_provider(self):
+        from capabilities_lib import derive_capabilities
+        assert derive_capabilities(_base_config(ci={"workflowDir": ".github"}))["has_ci"] is False
+
+    def test_database_type_and_migration_dir(self):
+        from capabilities_lib import derive_capabilities
+        caps = derive_capabilities(_base_config(database={"type": "postgres", "migrationsDir": "sql"}))
+        assert caps["has_database"] is True
+        assert caps["migration_dir"] == "sql"
+
+    def test_database_without_migration_dir(self):
+        from capabilities_lib import derive_capabilities
+        caps = derive_capabilities(_base_config(database={"type": "postgres"}))
+        assert caps["has_database"] is True
+        assert caps["migration_dir"] is None
+
+    def test_docker_compose_files_present(self):
+        from capabilities_lib import derive_capabilities
+        cfg = _base_config(infrastructure={"docker": {"composeFiles": [{"name": "app", "path": "docker-compose.yml"}]}})
+        assert derive_capabilities(cfg)["has_docker"] is True
+
+    def test_infrastructure_without_docker_is_false_not_crash(self):
+        """The real transcribe case: infrastructure.hosts present, no docker
+        sub-object. Must null-guard infrastructure.docker, not throw."""
+        from capabilities_lib import derive_capabilities
+        cfg = _base_config(infrastructure={"hosts": [{"name": "vm1"}]})
+        assert derive_capabilities(cfg)["has_docker"] is False
+
+    def test_docker_empty_compose_files_is_false(self):
+        from capabilities_lib import derive_capabilities
+        cfg = _base_config(infrastructure={"docker": {"composeFiles": []}})
+        assert derive_capabilities(cfg)["has_docker"] is False
+
+    @pytest.mark.parametrize("cfg_kwargs", [
+        {"ci": "github"},                                       # ci not an object
+        {"ci": None},                                           # ci null section
+        {"ci": {"provider": 1}},                                # provider wrong type
+        {"ci": {"provider": None}},                             # provider present-but-null
+        {"database": "postgres"},                               # database not an object
+        {"database": {"type": 1}},                              # type wrong type
+        {"database": {"type": None}},                           # type present-but-null
+        {"database": {"type": "pg", "migrationsDir": 5}},       # migrationsDir wrong type
+        {"infrastructure": "hosts"},                            # infra not an object
+        {"infrastructure": {"docker": "compose.yml"}},          # docker not an object
+        {"infrastructure": {"docker": None}},                   # docker present-but-null
+        {"infrastructure": {"docker": {"composeFiles": "x"}}},  # composeFiles not a list
+        {"infrastructure": {"docker": {"composeFiles": None}}}, # composeFiles present-but-null
+    ])
+    def test_malformed_optional_sections_raise(self, cfg_kwargs):
+        """Present-but-invalid (null or wrong-type) -> error; never a silent
+        default. Only an ABSENT key yields the documented default."""
+        from capabilities_lib import derive_capabilities, CapabilitiesError
+        with pytest.raises(CapabilitiesError):
+            derive_capabilities(_base_config(**cfg_kwargs))
+
+
+class TestCanonicalFieldSet:
+    def test_capability_fields_constant_matches_output(self):
+        """CAPABILITY_FIELDS is the canonical list the docs table + drift guard
+        check against; it must equal exactly the keys derive produces."""
+        from capabilities_lib import derive_capabilities, CAPABILITY_FIELDS
+        caps = derive_capabilities(_base_config())
+        assert set(caps.keys()) == set(CAPABILITY_FIELDS)
+        # the two gap fields fixed by this PR are present
+        assert "deploy_method" in CAPABILITY_FIELDS
+        assert "migration_dir" in CAPABILITY_FIELDS
+
+
+class TestDeriveCLI:
+    def test_valid_config_emits_config_and_capabilities(self, tmp_path):
+        p = tmp_path / ".rawgentic.json"
+        p.write_text(json.dumps(_base_config(testing={"frameworks": [{"name": "pytest", "command": "pytest"}]})))
+        out, err, rc = _run_cli("derive", "--config", str(p))
+        assert rc == 0, err
+        payload = json.loads(out)
+        assert payload["config"]["repo"]["fullName"] == "owner/name"
+        assert payload["capabilities"]["has_tests"] is True
+        assert payload["capabilities"]["repo"] == "owner/name"
+
+    def test_missing_file_fails_closed(self, tmp_path):
+        _, err, rc = _run_cli("derive", "--config", str(tmp_path / "nope.json"))
+        assert rc == 1
+        assert "setup" in err.lower()
+
+    def test_malformed_json_fails_closed(self, tmp_path):
+        p = tmp_path / ".rawgentic.json"
+        p.write_text("{not valid")
+        _, err, rc = _run_cli("derive", "--config", str(p))
+        assert rc == 1
+
+    def test_non_object_json_fails_closed(self, tmp_path):
+        p = tmp_path / ".rawgentic.json"
+        p.write_text("[1,2,3]")
+        _, _, rc = _run_cli("derive", "--config", str(p))
+        assert rc == 1
+
+    def test_essential_missing_fails_closed(self, tmp_path):
+        p = tmp_path / ".rawgentic.json"
+        cfg = _base_config()
+        cfg["repo"].pop("fullName")
+        p.write_text(json.dumps(cfg))
+        _, _, rc = _run_cli("derive", "--config", str(p))
+        assert rc == 1
+
+    def test_version_mismatch_warns_but_succeeds(self, tmp_path):
+        """Faithful to the existing docs: a version mismatch WARNS on stderr but
+        does NOT stop (migration-path safety), unlike a corrupt config."""
+        p = tmp_path / ".rawgentic.json"
+        p.write_text(json.dumps(_base_config(version=2)))
+        out, err, rc = _run_cli("derive", "--config", str(p))
+        assert rc == 0, err
+        assert "version" in err.lower()
+        assert json.loads(out)["capabilities"]["repo"] == "owner/name"
+
+    def test_missing_version_warns_but_succeeds(self, tmp_path):
+        p = tmp_path / ".rawgentic.json"
+        cfg = _base_config()
+        cfg.pop("version")
+        p.write_text(json.dumps(cfg))
+        out, err, rc = _run_cli("derive", "--config", str(p))
+        assert rc == 0, err
+
+    def test_no_subcommand_fails(self):
+        _, _, rc = _run_cli()
+        assert rc != 0
+
+
+# The 11 workflow skills whose config-loading block carried the identical
+# (now-extracted) capabilities derivation.
+WIRED_SKILLS = [
+    "adversarial-review", "create-issue", "create-tests", "fix-bug",
+    "implement-feature", "incident", "optimize-perf", "refactor",
+    "security-audit", "update-deps", "update-docs",
+]
+SKILLS_DIR = Path(__file__).resolve().parent.parent.parent / "skills"
+DOCS = Path(__file__).resolve().parent.parent.parent / "docs" / "config-reference.md"
+
+
+class TestCapabilitiesSkillWiring:
+    """Drift guard: every workflow skill must drive the derivation through the CLI,
+    not a re-introduced prose copy of the (formerly duplicated) mapping."""
+
+    @pytest.mark.parametrize("skill", WIRED_SKILLS)
+    def test_skill_invokes_derive_cli(self, skill):
+        content = (SKILLS_DIR / skill / "SKILL.md").read_text()
+        assert "capabilities_lib.py derive" in content, (
+            f"{skill}/SKILL.md must invoke `capabilities_lib.py derive`; if you "
+            f"renamed the subcommand, update the skills and this guard."
+        )
+
+    @pytest.mark.parametrize("skill", WIRED_SKILLS)
+    def test_skill_has_no_prose_derivation(self, skill):
+        """The old hand-derivation lines must not coexist with the CLI — two
+        sources of the mapping is exactly the drift this PR removes."""
+        content = (SKILLS_DIR / skill / "SKILL.md").read_text()
+        assert "has_tests: config.testing exists AND" not in content, (
+            f"{skill}/SKILL.md re-introduced the prose capabilities derivation; "
+            f"the CLI is the single source of truth."
+        )
+        assert "Build the `capabilities` object from config:" not in content
+
+
+class TestDocsTableDriftGuard:
+    """The docs/config-reference.md capabilities table must list exactly the
+    fields the lib produces — so the doc, the lib, and the skills stay in sync."""
+
+    def _doc_table_fields(self):
+        import re
+        text = DOCS.read_text()
+        start = text.index("**Capabilities object.**")
+        end = text.index("Skills adapt their behavior", start)
+        region = text[start:end]
+        # rows look like:  | `field` | ... |
+        return set(re.findall(r"^\|\s*`([a-z_]+)`\s*\|", region, re.MULTILINE))
+
+    def test_doc_table_matches_capability_fields(self):
+        from capabilities_lib import CAPABILITY_FIELDS
+        assert self._doc_table_fields() == set(CAPABILITY_FIELDS), (
+            "docs/config-reference.md capabilities table is out of sync with "
+            "capabilities_lib.CAPABILITY_FIELDS — update the table (or the lib)."
+        )


### PR DESCRIPTION
## Summary

PR 4c (final slice of the WF2 script-extraction arc). The **"Build the capabilities object" derivation** was an *identical* prose block duplicated across **all 11 workflow SKILL.md files** plus the `docs/config-reference.md` table — three-plus copies that could silently drift, and a hand-applied mapping where a malformed config could masquerade as a feature-less project (e.g. a garbled `testing` block → `has_tests=false` → skip TDD on a project that *has* tests).

### `hooks/capabilities_lib.py` (new)
`derive_capabilities(config)` + `load_config(path)` + a `derive --config <path>` CLI that loads, validates, and emits `{"config":{…},"capabilities":{…}}`. All 11 skills' config-loading blocks now call this single source of truth instead of hand-deriving; the docs table is reconciled against it via a drift guard.

**Fail-closed contract:**
- **Essential** `repo.fullName` / `repo.defaultBranch` / `project.type` (the two *required* config sections) → error if missing/null/wrong-type. They feed `gh`/`git` in every skill, so a bad value fails *before* side effects rather than mid-workflow.
- **Optional sections**: *absent* key → documented default (`false`/`[]`/`null`); *present-but-invalid* (null **or** wrong-type) → error, not a silent downgrade. (`setup` omits empty sections rather than writing null, so a present-null signals corruption.)
- `deploy.method` validated against the `{compose,ssh,script,manual}` enum; `manual` keeps its carve-out (`has_deploy=false`).
- `has_docker` null-guards `infrastructure.docker` (real configs like `transcribe` have `infrastructure.hosts` but no `docker`).

### Bug fix: completes the derivation
`deploy_method` and `migration_dir` were *consumed* by implement-feature but never *derived* (always null). Now derived from `config.deploy.method` / `config.database.migrationsDir` (camelCase confirmed canonical across the schema + real configs).

### Faithful to existing behavior
`config.version` handling stays **warn-and-continue** (not a hard error) — preserving migration-path safety for in-flight projects on an older schema.

## How it was built
- **Understand phase via a 4-agent workflow** (schema extraction, consumer mapping across 11 skills, gap analysis, fail-closed policy) — confirmed step-3 is byte-identical across all 11 and surfaced the `deploy_method`/`migration_dir` gap and the `infrastructure`-without-`docker` crash case.
- TDD throughout (RED verified by neutralizing each fix); **Codex cross-model review iterated to CONVERGED** (caught a null-vs-absent fail-open and the missing deploy-method enum check).

## Testing
- New `tests/hooks/test_capabilities_lib.py` (function + CLI + drift guards). Drift guards pin: all 11 skills invoke the CLI and carry no prose derivation; the docs table field set equals `CAPABILITY_FIELDS`.
- Full suite: **895 passed, 3 skipped**.

## Pre-PR checklist
- [x] Version `2.30.0` → `2.31.0` (minor) + pin updated
- [x] README updated (Config-Loading Protocol section)
- [x] `docs/config-reference.md` updated (capabilities table + protocol step 3)
- [x] `pytest tests/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
