### PR TITLE
docs: WF2 extraction impact report + reproducible Tier-1 metrics script

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -586,9 +586,11 @@ pytest tests/ -v
 pytest tests/hooks/test_wal_guard.py -v
 ```
 
-**385 tests** across 13 test modules covering all hooks. See [docs/testing.md](docs/testing.md) for full details.
+**~895 tests** across the hook + skill-helper modules. See [docs/testing.md](docs/testing.md) for full details.
 
 **CI:** GitHub Actions runs `pytest tests/ -v` on all PRs to `main` (`.github/workflows/ci.yml`). SDLC workflows also run tests automatically when `.rawgentic.json` has a `testing` section configured.
+
+**Impact measurement:** `scripts/wf2_impact_metrics.py` computes deterministic Tier-1 impact metrics (test growth, fail-closed coverage, dedup, diff volume) for a skill-extraction effort over a `--baseline`/`--head` git range. See [docs/measurements/2026-06-15-wf2-extraction-impact.md](docs/measurements/2026-06-15-wf2-extraction-impact.md) for the WF2 extraction analysis.
 
 Skills are tested via the `/skill-creator` eval pipeline (15/17 skills have evals.json; the lightweight `add-exception` and `interview` skills have none).
 

--- a/docs/measurements/2026-06-15-wf2-extraction-impact.md
+++ b/docs/measurements/2026-06-15-wf2-extraction-impact.md
@@ -1,0 +1,69 @@
+# WF2 extraction effort — impact measurement (Tier 1)
+
+**Date:** 2026-06-15
+**Range:** `fcd22b2` (pre-#83 baseline) .. `86fbbf7` (#89 merge)
+**PRs:** #83 (cleanup), #84 (parallelism), #86 (parallel_group validator), #87/#88/#89 (CLI extraction: headless / resume / capabilities)
+
+Reproduce the deterministic numbers with:
+
+```bash
+python3 scripts/wf2_impact_metrics.py              # markdown
+python3 scripts/wf2_impact_metrics.py --json       # machine-readable
+```
+
+## Scope of this report (Tier 1 only)
+
+The effort splits into two measurement regimes:
+
+| PRs | Lever | Claim | Measurable how |
+|-----|-------|-------|----------------|
+| #84, #86 | parallelism | *faster* | **Tier 2** — end-to-end A/B runs, high variance (not done here) |
+| #87, #88, #89 | deterministic code extraction | *more correct / safer / consistent* | **Tier 1** — provable from tests + git, no runs |
+
+This report covers **Tier 1**: the cheap, deterministic, run-free metrics. **Speed and output-quality are deliberately NOT claimed here** — they require the Tier-2 end-to-end harness (fixed issue corpus, baseline-via-`git worktree`, N replicates, pinned model). What follows is what we can prove without paying for ~100 full workflow runs.
+
+## 1. Reliability / correctness
+
+### Cross-model review bug ledger
+Cross-model (Codex) review caught these concrete defects in the *prose / first-draft* of each PR **before merge** — i.e. bugs the old prose versions had latent:
+
+| PR | Defects surfaced + fixed pre-merge |
+|----|------|
+| #87 (headless) | shell-vars don't persist across separate Bash tool calls → empty comment/suspend; `write-suspend` accepted empty `--question-id`/`--comment-url` (argparse `required` only checks presence); missing non-empty comment-URL guard; step validation holes (`""`/`0`/`-1`/whitespace/`>16`/`"5\n"`) |
+| #88 (resume) | cross-Bash-call shell-vars (recurrence) + `step` never extracted; `clarification_round` null≠0 contract bug; completion-gate rule not in the deterministic invocation; `parse-reply` single-quote injection via CLI literal; `cmd; echo $?` erased the fail-closed exit code; out-of-range reply fail-open; `gh`-fetch-failure conflated with "no reply" |
+| #89 (capabilities) | null-vs-absent fail-open (present-null silently defaulted); `deploy.method` accepted any string (no enum) |
+
+**~14 concrete correctness defects** caught and fixed before shipping, each now pinned by a regression test.
+
+### Fail-closed coverage
+**69** fail-closed / adversarial test markers (grep matches — a proxy/lower-bound, *not* a literal `assert` count) across the three new CLI test files (`test_headless.py`, `test_resume_lib.py`, `test_capabilities_lib.py`) — covering malformed configs, corrupt suspend files, out-of-range steps/replies, and injection-shaped inputs, each asserting the code fails *safe* rather than producing usable-looking-but-wrong output.
+
+### Test suite growth
+- Test functions: **482 → 596** (+114, +24%)
+- Parametrize blocks: 32 → 52
+- Collected cases: ~672 → ~895
+
+## 2. Consistency / determinism (proven by construction)
+
+The interpretation work — headless suspend/resume, the resumption cascade, reply parsing, and the config→capabilities derivation — is now **pure deterministic code**, so identical input yields identical output by construction. The old prose drove an LLM to re-derive a 9-rule cascade or reconstruct a nested `python3 -c` block on every run, which varies run-to-run. This is the cleanest win of the extraction and is self-evident from the code being deterministic.
+
+## 3. Maintainability / drift-resistance (countable)
+
+- Config→capabilities derivation: **12 copies → 1** (11 byte-identical SKILL.md blocks + 1 docs table → `hooks/capabilities_lib.py`).
+- Inline fragile `python3 -c` / `from … import` blocks in implement-feature: **4 → 1**.
+- **4 drift-guard test classes** added (`TestHeadlessCLISkillWiring`, `TestResumeSkillWiring`, `TestCapabilitiesSkillWiring`, `TestDocsTableDriftGuard`) so the dedup can't silently re-diverge.
+- Diff volume: skills/ `+267 / -274` (interpretation removed from 11 files), hooks/*.py `+896 / -7` (tested code added), tests/ `+1374`.
+
+## 4. Speed (MODELED, not measured)
+
+Not run end-to-end. Static critical-path model for #84:
+- **Step 2:** old = *N* sequential component analyses on the critical path → new = fan-out + 1 synthesize ≈ 2 hops regardless of *N*.
+- **Step 4:** old = critique *then* reflexion (2 sequential gate phases) → new = concurrent ≈ 1 phase.
+
+This is a latency *model*, not a measurement. Proving the wall-clock win requires the Tier-2 harness (or a focused micro-benchmark of Steps 2/4 in isolation).
+
+## Honest caveats
+
+- The extraction PRs' value is overwhelmingly **reliability + consistency + maintainability**, NOT speed; trying to prove their wall-clock impact end-to-end would mostly measure noise.
+- "Quality" of produced features is only weakly proxied here (gate findings, CI-pass) — true output quality needs judge-graded A/B.
+- Tier-2 (the real speed/quality proof) needs a fixed corpus, `git worktree` baselines, N≥5 replicates, a pinned model, and ~100+ full workflow runs. The natural telemetry substrate for it is a per-run structured run-record (see the work-summary feature).

--- a/scripts/wf2_impact_metrics.py
+++ b/scripts/wf2_impact_metrics.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Compute deterministic Tier-1 impact metrics for a rawgentic skill-extraction
+effort.
+
+These are the cheap, run-free metrics that prove RELIABILITY, CONSISTENCY, and
+MAINTAINABILITY impact (test growth, fail-closed coverage, dedup, diff volume) —
+as opposed to SPEED/QUALITY, which require expensive end-to-end workflow A/B runs
+(a separate, Tier-2 harness). Reusable across efforts: pass --baseline and --head
+git refs.
+
+Usage:
+  python3 scripts/wf2_impact_metrics.py [--baseline REF] [--head REF] [--json]
+
+Defaults target the WF2 script-extraction effort (#83..#89).
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+# Effort default range: parent-of-#83 .. #89 merge.
+DEFAULT_BASELINE = "fcd22b2"
+DEFAULT_HEAD = "86fbbf7"
+
+# Test files that received the new fail-closed CLI coverage in this effort.
+FAILCLOSED_TEST_FILES = [
+    "tests/hooks/test_headless.py",
+    "tests/hooks/test_resume_lib.py",
+    "tests/hooks/test_capabilities_lib.py",
+]
+# Regex (alternation) marking an adversarial / fail-closed test line. NOTE: this
+# counts matching LINES (test names + assertions) across the adversarial test
+# surface — a proxy/lower-bound indicator, NOT a literal `assert`-statement count.
+_FAILCLOSED_RE = (
+    r"pytest\.raises|assert rc != 0|assert rc == 1|fails_closed|rejects|"
+    r"_invalid|_raises|malformed|present_null|out_of_range|unusable|corrupt"
+)
+
+_SHORTSTAT_RE = re.compile(
+    r"(?:(\d+) files? changed)?"
+    r"(?:, (\d+) insertions?\(\+\))?"
+    r"(?:, (\d+) deletions?\(-\))?"
+)
+
+
+def parse_shortstat(line: str) -> dict:
+    """Parse a `git diff --shortstat` line into {files, insertions, deletions}.
+
+    Any clause may be absent (git omits the insertions/deletions clause when that
+    side is zero) — an absent clause counts as 0 rather than crashing.
+    """
+    m = _SHORTSTAT_RE.match(line.strip())
+    if not m:
+        return {"files": 0, "insertions": 0, "deletions": 0}
+    files, ins, dels = m.groups()
+    return {
+        "files": int(files or 0),
+        "insertions": int(ins or 0),
+        "deletions": int(dels or 0),
+    }
+
+
+def _git(*args) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], capture_output=True, text=True)
+
+
+def _grep_count(ref: str, pattern: str, pathspec: str, extended: bool = False) -> int:
+    """Count matching lines via `git grep` at a ref. git grep exits 1 on no
+    matches (not an error); anything else is surfaced."""
+    flags = ["-h"] + (["-E"] if extended else [])
+    r = _git("grep", *flags, pattern, ref, "--", pathspec)
+    if r.returncode not in (0, 1):
+        raise RuntimeError(f"git grep failed: {r.stderr.strip()}")
+    return len([ln for ln in r.stdout.splitlines() if ln])
+
+
+def _shortstat(base: str, head: str, pathspec: str) -> dict:
+    r = _git("diff", "--shortstat", f"{base}..{head}", "--", pathspec)
+    if r.returncode != 0:
+        raise RuntimeError(f"git diff failed: {r.stderr.strip()}")
+    return parse_shortstat(r.stdout.strip().splitlines()[0] if r.stdout.strip() else "")
+
+
+def collect_metrics(baseline: str, head: str) -> dict:
+    """Collect the deterministic Tier-1 metrics over baseline..head."""
+    metrics = {
+        "baseline": baseline,
+        "head": head,
+        "test_defs": {
+            "baseline": _grep_count(baseline, "def test_", "tests/"),
+            "head": _grep_count(head, "def test_", "tests/"),
+        },
+        "parametrize_blocks": {
+            "baseline": _grep_count(baseline, "parametrize", "tests/"),
+            "head": _grep_count(head, "parametrize", "tests/"),
+        },
+        "diff": {
+            "skills": _shortstat(baseline, head, "skills/"),
+            "hooks_py": _shortstat(baseline, head, "hooks/*.py"),
+            "tests": _shortstat(baseline, head, "tests/"),
+        },
+        "failclosed_markers": {},
+        "new_hooks_libs": [],
+    }
+    for f in FAILCLOSED_TEST_FILES:
+        metrics["failclosed_markers"][f] = _grep_count(
+            head, _FAILCLOSED_RE, f, extended=True)
+    # New hooks/*.py libraries added in the range.
+    r = _git("diff", "--name-status", f"{baseline}..{head}", "--", "hooks/*.py")
+    metrics["new_hooks_libs"] = [
+        ln.split("\t", 1)[1] for ln in r.stdout.splitlines()
+        if ln.startswith("A")
+    ]
+    return metrics
+
+
+def render_markdown(m: dict) -> str:
+    td, pb = m["test_defs"], m["parametrize_blocks"]
+    fc_total = sum(m["failclosed_markers"].values())
+    lines = [
+        f"# WF2 impact metrics ({m['baseline']}..{m['head']})",
+        "",
+        f"- Test functions: **{td['baseline']} -> {td['head']}** "
+        f"(+{td['head'] - td['baseline']})",
+        f"- Parametrize blocks: {pb['baseline']} -> {pb['head']}",
+        f"- Fail-closed/adversarial test markers (grep matches, new CLI test files): **{fc_total}**",
+        f"- New hooks libraries: {', '.join(m['new_hooks_libs']) or '(none)'}",
+        "- Diff volume:",
+        f"    - skills/ (prose): +{m['diff']['skills']['insertions']} "
+        f"-{m['diff']['skills']['deletions']} ({m['diff']['skills']['files']} files)",
+        f"    - hooks/*.py (code): +{m['diff']['hooks_py']['insertions']} "
+        f"-{m['diff']['hooks_py']['deletions']}",
+        f"    - tests/: +{m['diff']['tests']['insertions']} "
+        f"-{m['diff']['tests']['deletions']}",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(prog="wf2_impact_metrics")
+    p.add_argument("--baseline", default=DEFAULT_BASELINE)
+    p.add_argument("--head", default=DEFAULT_HEAD)
+    p.add_argument("--json", action="store_true", help="emit JSON instead of markdown")
+    args = p.parse_args(argv)
+    try:
+        m = collect_metrics(args.baseline, args.head)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(m, indent=2) if args.json else render_markdown(m))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.31.0"
+    assert plugin["version"] == "2.31.1"
 
 
 def test_descriptions_consistent_count():

--- a/tests/test_wf2_impact_metrics.py
+++ b/tests/test_wf2_impact_metrics.py
@@ -1,0 +1,65 @@
+"""Tests for scripts/wf2_impact_metrics.py.
+
+The metrics script computes the cheap, deterministic Tier-1 impact metrics for a
+skill-extraction effort (test growth, fail-closed coverage, dedup, diff volume).
+The pure shortstat parser is unit-tested here; the git-backed collectors get a
+smoke test against the real (now-permanent) effort commit range.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _ref_exists(ref: str) -> bool:
+    """True if the git ref resolves to a commit. CI shallow checkouts
+    (actions/checkout defaults to fetch-depth 1) may not have old SHAs."""
+    return subprocess.run(
+        ["git", "cat-file", "-e", f"{ref}^{{commit}}"],
+        capture_output=True,
+    ).returncode == 0
+
+
+class TestParseShortstat:
+    """`git diff --shortstat` output omits the insertions/deletions clause when
+    that side is zero, and uses singular nouns for a count of 1 — the parser must
+    handle every shape, returning 0 for an absent clause (not crash)."""
+
+    @pytest.mark.parametrize("line,expected", [
+        ("", {"files": 0, "insertions": 0, "deletions": 0}),
+        (" 11 files changed, 267 insertions(+), 274 deletions(-)",
+         {"files": 11, "insertions": 267, "deletions": 274}),
+        (" 1 file changed, 2 insertions(+)",
+         {"files": 1, "insertions": 2, "deletions": 0}),
+        (" 1 file changed, 3 deletions(-)",
+         {"files": 1, "insertions": 0, "deletions": 3}),
+        (" 1 file changed, 1 insertion(+), 1 deletion(-)",
+         {"files": 1, "insertions": 1, "deletions": 1}),
+    ])
+    def test_parses_all_shapes(self, line, expected):
+        from wf2_impact_metrics import parse_shortstat
+        assert parse_shortstat(line) == expected
+
+
+class TestCollectSmoke:
+    """Smoke test the git-backed collection over the real effort range. Asserts
+    structural sanity (keys present, test count grew) rather than exact numbers,
+    so it stays robust."""
+
+    BASE = "fcd22b2"   # pre-#83 baseline
+    HEAD = "86fbbf7"   # #89 merge
+
+    def test_collect_returns_expected_shape(self):
+        if not (_ref_exists(self.BASE) and _ref_exists(self.HEAD)):
+            pytest.skip("effort commit range not present (shallow checkout)")
+        from wf2_impact_metrics import collect_metrics
+        m = collect_metrics(self.BASE, self.HEAD)
+        for key in ("test_defs", "parametrize_blocks", "diff", "new_hooks_libs"):
+            assert key in m, f"missing metric key {key}"
+        # the effort added tests
+        assert m["test_defs"]["head"] >= m["test_defs"]["baseline"]
+        assert m["test_defs"]["head"] > 0


### PR DESCRIPTION
## Summary

Adds a deterministic, **run-free** impact measurement for the WF2 script-extraction effort (#83→#89) — the cheap "Tier 1" metrics that prove **reliability, consistency, and maintainability** impact without paying for ~100 end-to-end workflow A/B runs.

### What's here
- **`scripts/wf2_impact_metrics.py`** — parameterized (`--baseline`/`--head`) git-metrics computation: `parse_shortstat` (unit-tested), `git grep`/`diff` collectors, markdown/JSON render. Reusable for future efforts.
- **`docs/measurements/2026-06-15-wf2-extraction-impact.md`** — the report.
- **README** — refresh the stale test count (385 → ~895) + a pointer to the script.

### Headline findings (computed, not hand-waved)
- **Reliability:** ~14 concrete defects (fail-open holes, shell-var/exit-code/null-vs-absent/injection) caught by cross-model review *before merge* across #87/#88/#89; **69** fail-closed/adversarial test markers across the 3 new CLI test files.
- **Consistency:** the interpretation work is now pure deterministic code (prose varied run-to-run).
- **Maintainability:** capabilities derivation **12 copies → 1**; inline `python3 -c` **4 → 1**; 4 drift-guard classes.
- **Tests:** `def test_` **482 → 596**; ~895 collected.

### Honest scope
**Speed is explicitly MODELED, not measured**, and output-quality is scoped out — both require the Tier-2 end-to-end A/B harness (fixed corpus, `git worktree` baselines, N replicates, pinned model). The report says so plainly and doesn't overclaim.

## Testing
- TDD'd the `parse_shortstat` parser; smoke-tests the collectors over the real effort range and **skips on shallow CI checkout** (old SHAs may be absent).
- Full suite: **901 passed, 3 skipped**.
- Cross-model review (Codex) **CONVERGED in 2 rounds** (caught the shallow-checkout test fragility + an "assertions" overstatement).

## Pre-PR checklist
- [x] Version `2.31.0` → `2.31.1` (patch — docs+tooling, no workflow behavior change) + pin
- [x] README updated
- [x] `pytest tests/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
