### PR TITLE
feat(security): WF2 Step 11.5 tool-based security scan + WF9 reuse

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.31.1",
+  "version": "2.32.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ jobs:
       - name: Verify jq available
         run: jq --version
 
+      - name: Install security scanners
+        # Dogfoods scripts/install-scanners.sh on a clean box (so installer
+        # regressions surface here) and lets the real-tool smoke test actually
+        # run instead of skipping. Best-effort: a scanner that fails to install
+        # just makes its tests skip — it never fails CI. GITHUB_TOKEN avoids the
+        # unauthenticated release-API rate limit on shared runner IPs.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          bash scripts/install-scanners.sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Report scanner presence
+        run: bash scripts/install-scanners.sh --check || true
+
       - name: Install test deps
         run: pip install pytest jsonschema
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Verify jq available
         run: jq --version
 
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install test deps
+        run: pip install pytest jsonschema
 
       - name: Run tests
         run: pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,19 +18,23 @@ jobs:
         run: jq --version
 
       - name: Install security scanners
-        # Dogfoods scripts/install-scanners.sh on a clean box (so installer
-        # regressions surface here) and lets the real-tool smoke test actually
-        # run instead of skipping. Best-effort: a scanner that fails to install
-        # just makes its tests skip — it never fails CI. GITHUB_TOKEN avoids the
+        # Only the scanners the real-tool smoke test actually exercises
+        # (project_type=python, has_docker=False): gitleaks + semgrep +
+        # osv-scanner. trivy (~167MB, IaC-only) and pip-audit (osv fallback) are
+        # deliberately omitted — the smoke never invokes them, and their parsers
+        # are covered by injected-runner unit tests. Dogfoods the installer on a
+        # clean box (installer regressions surface here) and lets the smoke run
+        # instead of skipping. Best-effort: a scanner that fails to install just
+        # makes its test skip, never fails CI. GITHUB_TOKEN avoids the
         # unauthenticated release-API rate limit on shared runner IPs.
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          bash scripts/install-scanners.sh
+          bash scripts/install-scanners.sh gitleaks semgrep osv-scanner
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Report scanner presence
-        run: bash scripts/install-scanners.sh --check || true
+        run: bash scripts/install-scanners.sh --check gitleaks semgrep osv-scanner || true
 
       - name: Install test deps
         run: pip install pytest jsonschema

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ pytest tests/ -v
 pytest tests/hooks/test_wal_guard.py -v
 ```
 
-**~980 tests** across the hook + skill-helper modules. See [docs/testing.md](docs/testing.md) for full details.
+**~990 tests** across the hook + skill-helper modules. See [docs/testing.md](docs/testing.md) for full details.
 
 **CI:** GitHub Actions runs `pytest tests/ -v` on all PRs to `main` (`.github/workflows/ci.yml`). SDLC workflows also run tests automatically when `.rawgentic.json` has a `testing` section configured.
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Multiple projects can be active simultaneously. Use `/rawgentic:switch` to bind 
 **Key Features:**
 - Config-driven: TDD mode when tests configured, Implement-Verify mode when not
 - 4-agent code review (general, security, performance, test coverage)
+- **Step 11.5 tool-based security scan** (pre-PR gate): runs gitleaks (secrets, diff-scoped), an SCA dependency-CVE scan (osv-scanner → npm/pip-audit fallback), semgrep SAST, and trivy IaC (Docker projects) via the shared `hooks/security_scan.py` lib — fail-closed on a real finding, visible-skip when a tool is absent
 - Parallelized analysis (Step 2) and review (Step 4) phases for lower latency
 - Global loopback budget of 3 across all retry loops
 - Learning config: updates `.rawgentic.json` when new patterns discovered
@@ -238,6 +239,7 @@ Multiple projects can be active simultaneously. Use `/rawgentic:switch` to bind 
 **Key Features:**
 - STRIDE model (Spoofing, Tampering, Repudiation, Info Disclosure, DoS, Elevation)
 - Enumerates data channels from config (REST, WebSocket, gRPC, etc.)
+- **Tool-based scan** (Step 2/8): runs the same `hooks/security_scan.py` lib as WF2 Step 11.5, in `--full` (whole-tree) mode — so the secret/CVE/SAST/IaC tooling never drifts between the two workflows; tool findings feed STRIDE, they don't replace it
 - Learning config: adds discovered auth mechanisms to config
 </details>
 
@@ -305,12 +307,14 @@ Rawgentic includes hooks that run automatically on Claude Code events:
 | `wal-context` | UserPromptSubmit | Injects session context (project, recent WAL activity) |
 | `wal-bind-guard` | PreToolUse | Blocks tool use if session unbound with multiple active projects; blocks cross-project file writes |
 | `wal-guard` | PreToolUse | Blocks dangerous production commands with per-project protection levels (sandbox/standard/strict) |
-| `session-start` | SessionStart | WAL recovery, **notes size handler**, project reconciliation, security pattern staleness check, resume context |
+| `session-start` | SessionStart | WAL recovery, **notes size handler**, project reconciliation, security pattern staleness check, **security scanner bootstrap** (once, background, opt-out), resume context |
 | `notes-size-handler` | (called by session-start) | Trims session notes exceeding 800 lines to keep last 200; optionally ingests to memorypalace before trimming |
 | `security-guard` | PreToolUse | Blocks writing dangerous patterns (credentials, secrets, eval) to files |
 | `security-guard-check` | SessionStart | Warns if the official security-guidance plugin conflicts |
 
 **Security Guard** blocks writes containing dangerous code patterns (eval, innerHTML, pickle, os.system, etc.). Patterns are defined in `hooks/security-patterns.json`. Protection level controls which rules are active (sandbox: none, standard: 6 common patterns, strict: all). Per-path exceptions via `guards.securityExcludePaths` in `.rawgentic.json`. Uses the Claude Code `permissionDecision: deny` protocol for hard blocking (not retried).
+
+**Security Scan** (`hooks/security_scan.py`) is the tool-based scanner shared by WF2 Step 11.5 (diff-scoped, pre-PR) and WF9 (`--full`, whole-tree audit): gitleaks (secrets), an SCA dependency-CVE scan (osv-scanner, falling back to `npm audit`/`pip-audit`), semgrep SAST, and trivy IaC for Docker projects. It is **fail-closed** — a leaked secret, a Critical/High CVE, or an installed-but-broken scanner blocks; blocking severities are tunable via `RAWGENTIC_SECURITY_BLOCK_SEVERITIES`. A scanner whose tool isn't installed is a **visible skip**, never a silent pass. `scripts/install-scanners.sh` provisions the tools (idempotent, best-effort); the session-start hook runs it once in the background on first plugin use, and `/rawgentic:setup` runs it explicitly. Installs are **opt-out** (`RAWGENTIC_SKIP_SCANNER_INSTALL=1` or `"installScanners": false`), never opt-in. See `docs/security-scan.md`.
 
 **WAL (Write-Ahead Log)** records every mutation tool call to `claude_docs/wal/{project}.jsonl`. On session resume, incomplete operations are surfaced for recovery. WAL files are per-project — each active project gets its own log. As of v2.20.0, session data is migrated to `~/claude_docs/` on first startup, with a symlink left at the old workspace-relative location for backward compatibility. The path is configurable via `claudeDocsPath` in `.rawgentic_workspace.json`.
 
@@ -586,7 +590,7 @@ pytest tests/ -v
 pytest tests/hooks/test_wal_guard.py -v
 ```
 
-**~895 tests** across the hook + skill-helper modules. See [docs/testing.md](docs/testing.md) for full details.
+**~980 tests** across the hook + skill-helper modules. See [docs/testing.md](docs/testing.md) for full details.
 
 **CI:** GitHub Actions runs `pytest tests/ -v` on all PRs to `main` (`.github/workflows/ci.yml`). SDLC workflows also run tests automatically when `.rawgentic.json` has a `testing` section configured.
 

--- a/docs/security-scan.md
+++ b/docs/security-scan.md
@@ -1,0 +1,90 @@
+# Security Scan (`hooks/security_scan.py`)
+
+The shared, tool-based security scanner used by **WF2 Step 11.5** (pre-PR gate)
+and **WF9** (`/rawgentic:security-audit`). One tested lib so the actual scanning —
+running real tools and turning their output into a gate decision — lives in a
+single fail-closed place instead of being re-derived in each workflow's prose.
+
+It complements, and does **not** replace, the LLM security review (WF2 Step 11
+Agent 3; WF9 STRIDE). Scanners find concrete, known-pattern problems (a leaked
+token, a CVE'd dependency, an injection-shaped code pattern). They cannot find
+authorization or business-logic flaws — that is what the review and STRIDE are
+for. "Scan passed" means "no known-pattern issue," not "secure."
+
+## What it runs
+
+Each scanner is gated on `capabilities` (project type / Docker) **and** on the
+tool being installed:
+
+| Kind | Tool | Notes |
+|------|------|-------|
+| secrets | `gitleaks` | Always. Diff-scoped to the branch's new commits in WF2; whole working tree in WF9 (`--full`). |
+| SCA (dependency CVEs) | `osv-scanner` → `npm audit` → `pip-audit` | Prefers osv-scanner (one binary, every ecosystem); falls back to the per-language tool when osv-scanner is absent. |
+| SAST | `semgrep` | `p/ci` ruleset (low false-positive). Diff-scoped (`--baseline-commit`) in WF2; whole tree in WF9. |
+| IaC | `trivy config` | Only when `capabilities.has_docker` (Dockerfile/compose/Actions/k8s/Terraform misconfig). |
+
+## The gate (fail-closed)
+
+- **Fail closed on a real finding.** A leaked secret always blocks. A
+  Critical/High dependency CVE, SAST, or IaC finding blocks. A *known CVE with no
+  severity rating* blocks (it is still a known CVE). Medium/Low are advisory.
+- **Fail closed on a broken scanner.** A tool that ran but produced unparseable
+  output is recorded as an error and blocks — "I couldn't tell" is never "clean."
+- **Degrade visibly on a missing tool.** A scanner whose tool isn't installed is
+  a *skip* (with a reason) and does **not** block. It is surfaced in the report
+  and PR body so the coverage gap stays visible — never silently treated as a
+  pass. `/rawgentic:setup` (and the session-start bootstrap) install the tools.
+
+The blocking threshold is tunable from v1 via `RAWGENTIC_SECURITY_BLOCK_SEVERITIES`
+(comma-separated, default `critical,high`). It is a **threshold**, not exact
+membership: the lowest level listed blocks that level *and everything above it*,
+so a lower setting only makes the gate stricter (e.g. `medium` blocks
+medium/high/critical) and can never accidentally let a high/critical through. An
+empty or unrecognized value falls back to the fail-closed default.
+
+## CLI
+
+```bash
+# WF2 pre-PR gate (diff-scoped against the default branch)
+python3 hooks/security_scan.py scan \
+  --project-root <path> --project-type <type> \
+  --base-ref origin/<default-branch> [--has-docker] --json
+
+# WF9 audit (whole tree)
+python3 hooks/security_scan.py scan \
+  --project-root <path> --project-type <type> --full [--has-docker] --json
+```
+
+Exit codes: `0` gate PASS · `1` BLOCKED (blocking finding or broken scanner) ·
+`2` usage error. With `--json` the output is `{findings, skipped, gate}` where
+`gate` is `{blocked, blocking, advisory, errors}`.
+
+## Installing the scanners
+
+Installs are **opt-out, never opt-in**. `scripts/install-scanners.sh` is
+idempotent and best-effort (a present tool is left alone; one that can't be
+auto-installed is reported, never fatal):
+
+```bash
+bash scripts/install-scanners.sh           # install every missing scanner
+bash scripts/install-scanners.sh --check    # report presence only (exit 1 if any missing)
+```
+
+It runs automatically at two points, both honoring the opt-outs:
+
+- **On first plugin use** — the `session-start` hook runs it once in the
+  background (marker: `~/.rawgentic/scanners-bootstrapped`, log:
+  `~/.rawgentic/scanner-install.log`). It never blocks startup.
+- **At `/rawgentic:setup`** — Step 2e runs it explicitly and reports results.
+
+**Opt out** with either:
+
+- `RAWGENTIC_SKIP_SCANNER_INSTALL=1` (environment — good for CI/headless), or
+- `"installScanners": false` at the top level of `.rawgentic_workspace.json`
+  (persisted; `/rawgentic:setup` writes this when you decline).
+
+Install strategy per tool: Homebrew if present → `pipx`/`pip --user` for the
+Python tools (semgrep, pip-audit) → GitHub release binary for the Go tools
+(gitleaks, osv-scanner, trivy), downloaded to `~/.local/bin`. No remote script is
+piped to a shell. If a tool can't be installed, the scan simply skips it
+(visibly) until it is available.

--- a/hooks/security_scan.py
+++ b/hooks/security_scan.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+"""Shared tool-based security scanner for rawgentic workflows.
+
+WF2 (implement-feature) Step 11.5 and WF9 (security-audit) both shell out to this
+one tested lib so the *tool-based* part of a security review — running actual
+scanners and turning their output into a gate decision — lives in a single
+fail-closed place instead of being re-derived in fragile prose. The LLM-reasoning
+part of security review (authorization/business-logic, STRIDE) is unchanged and
+complementary; scanners cannot find those, and this lib never pretends to.
+
+Coverage (each gated on project_type/has_docker AND on the tool being installed):
+- secrets : gitleaks, scanned over the branch diff (`<base>..HEAD`) so a
+            pre-existing fixture secret elsewhere in history doesn't block the PR.
+- sca     : dependency-CVE scan. Prefers osv-scanner (one binary, every
+            ecosystem); falls back to `npm audit` (node) or `pip-audit` (python).
+- sast    : semgrep with the low-false-positive `p/ci` ruleset, diff-scoped via
+            --baseline-commit; blocks only on ERROR-severity findings.
+- iac     : trivy config (Dockerfile/compose/Actions/k8s/Terraform misconfig),
+            only when the project has Docker (capabilities.has_docker).
+
+Gate philosophy (the security-critical heart, exhaustively unit-tested):
+- FAIL CLOSED on a real finding: a leaked secret always blocks; a Critical/High
+  dependency CVE or SAST/IaC finding blocks; a known CVE with *no* severity
+  rating blocks (it is still a known CVE). The blocking severity set is
+  env-configurable (RAWGENTIC_SECURITY_BLOCK_SEVERITIES, default critical,high).
+- FAIL CLOSED on a broken scanner: a tool that ran but produced unparseable
+  output is recorded as an error and blocks — "I couldn't tell" is never "clean".
+- DEGRADE VISIBLY on a missing tool: a scanner whose tool isn't installed is
+  reported as a skip (with a reason) and does NOT block. setup is what ensures
+  the tools exist; this gate must still run usefully on whatever is present.
+
+Design: pure functions (normalize_severity, the per-tool parsers,
+select_scanners, decide_gate) carry all the logic and are fully unit-tested; the
+single impure orchestrator `run_scan` takes injectable `which`/`runner` so the
+subprocess wiring is deterministic in tests with no scanner installed.
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+
+class SecurityScanError(ValueError):
+    """A scanner produced output that could not be parsed. Surfaced as a gate
+    error (fail-closed) rather than mistaken for a clean result."""
+
+
+# Default blocking threshold. Findings at this severity OR ABOVE block the PR;
+# below is advisory. Override via RAWGENTIC_SECURITY_BLOCK_SEVERITIES (comma-
+# separated) — treated as a THRESHOLD (the lowest level listed blocks that level
+# and everything above), so a lower setting only makes the gate STRICTER and can
+# never accidentally make high/critical advisory. Env-configurable from v1.
+BLOCK_SEVERITIES_DEFAULT = ("critical", "high")
+
+_SEV_ORDER = {"critical": 4, "high": 3, "medium": 2, "low": 1, "unknown": 0}
+
+# A scanner that exits with an unexpected code AND produced no findings may have
+# failed — fail closed — UNLESS its stderr says there was simply nothing to scan
+# (e.g. osv-scanner on a project with no lockfiles), which is a benign skip.
+_NOTHING_TO_SCAN_RE = re.compile(
+    r"no package sources found|no packages? found|nothing to scan|"
+    r"no supported (?:lockfiles?|manifests?)", re.IGNORECASE)
+
+# Per-tool severity vocabularies folded into the canonical scale.
+_NPM_SEV = {"critical": "critical", "high": "high", "moderate": "medium",
+            "low": "low", "info": "low"}
+_GENERIC_SEV = {"critical": "critical", "high": "high", "moderate": "medium",
+                "medium": "medium", "low": "low"}
+_SEMGREP_SEV = {"ERROR": "high", "WARNING": "medium", "INFO": "low"}
+_TRIVY_SEV = {"critical": "critical", "high": "high", "medium": "medium",
+              "low": "low", "unknown": "unknown"}
+
+
+def normalize_severity(tool: str, raw) -> str:
+    """Fold a tool-specific severity into {critical,high,medium,low,unknown}.
+
+    Unrecognized/absent values degrade to "unknown" rather than guessing — the
+    gate then decides what "unknown" means per finding kind."""
+    if tool == "gitleaks":
+        return "critical"  # any secret is critical, regardless of metadata
+    if raw is None:
+        return "unknown"
+    if tool == "semgrep":
+        return _SEMGREP_SEV.get(str(raw).upper(), "unknown")
+    if tool == "npm":
+        return _NPM_SEV.get(str(raw).lower(), "unknown")
+    if tool == "trivy":
+        return _TRIVY_SEV.get(str(raw).lower(), "unknown")
+    # osv-scanner / generic database severities
+    return _GENERIC_SEV.get(str(raw).lower(), "unknown")
+
+
+def _finding(scanner, kind, severity, identifier, location, title):
+    return {"scanner": scanner, "kind": kind, "severity": severity,
+            "identifier": identifier, "location": location, "title": title}
+
+
+def _loads(stdout):
+    """Parse JSON; blank output means the tool emitted nothing (no findings)."""
+    text = (stdout or "").strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise SecurityScanError(f"unparseable scanner output: {exc}")
+
+
+# --- parsers ---------------------------------------------------------------
+
+def parse_gitleaks(stdout) -> list:
+    """gitleaks --report-format json emits a JSON array of leak objects (or
+    nothing/null when clean)."""
+    data = _loads(stdout)
+    if not data:
+        return []
+    if not isinstance(data, list):
+        raise SecurityScanError("gitleaks output was not a JSON array")
+    out = []
+    for leak in data:
+        rule = leak.get("RuleID") or leak.get("Rule") or "secret"
+        loc = leak.get("File", "")
+        line = leak.get("StartLine")
+        if line:
+            loc = f"{loc}:{line}"
+        out.append(_finding(
+            "gitleaks", "secrets", "critical", rule, loc,
+            leak.get("Description", "potential secret")))
+    return out
+
+
+def parse_osv_scanner(stdout) -> list:
+    """osv-scanner --format json: results[].packages[].vulnerabilities[].
+    Severity prefers database_specific.severity, else falls through to unknown."""
+    data = _loads(stdout)
+    if not data:
+        return []
+    out = []
+    for res in data.get("results", []) or []:
+        src = (res.get("source") or {}).get("path", "")
+        for pkg in res.get("packages", []) or []:
+            name = (pkg.get("package") or {}).get("name", "?")
+            for vuln in pkg.get("vulnerabilities", []) or []:
+                raw_sev = (vuln.get("database_specific") or {}).get("severity")
+                out.append(_finding(
+                    "osv-scanner", "sca",
+                    normalize_severity("osv-scanner", raw_sev),
+                    vuln.get("id", "?"), src,
+                    f"{name}: {vuln.get('id', 'vulnerability')}"))
+    return out
+
+
+def parse_npm_audit(stdout) -> list:
+    """npm audit --json (v7+): vulnerabilities is a map keyed by package name.
+
+    On failure (e.g. no lockfile) npm emits {"error": {...}} with no
+    "vulnerabilities" key AND exits 1 — the same exit code as "vulns found" — so
+    the error envelope, not the exit code, is what distinguishes a failed audit
+    from a clean one. Treat it as fail-closed, never as "no vulnerabilities"."""
+    data = _loads(stdout)
+    if not data:
+        return []
+    if isinstance(data, dict) and data.get("error"):
+        err = data["error"]
+        summary = err.get("summary") if isinstance(err, dict) else err
+        raise SecurityScanError(f"npm audit failed: {summary}")
+    out = []
+    for name, info in (data.get("vulnerabilities") or {}).items():
+        out.append(_finding(
+            "npm", "sca", normalize_severity("npm", info.get("severity")),
+            name, "package-lock.json", f"{name}: vulnerable dependency"))
+    return out
+
+
+def parse_pip_audit(stdout) -> list:
+    """pip-audit --format json: dependencies[].vulns[] (severity usually absent
+    -> unknown, which the gate treats conservatively for a known CVE)."""
+    data = _loads(stdout)
+    if not data:
+        return []
+    out = []
+    deps = data.get("dependencies", data) if isinstance(data, dict) else data
+    for dep in deps or []:
+        name = dep.get("name", "?")
+        for vuln in dep.get("vulns", []) or []:
+            raw_sev = vuln.get("severity")  # frequently None
+            out.append(_finding(
+                "pip-audit", "sca",
+                normalize_severity("osv-scanner", raw_sev),
+                vuln.get("id", "?"), "requirements",
+                f"{name}: {vuln.get('id', 'vulnerability')}"))
+    return out
+
+
+def parse_semgrep(stdout) -> list:
+    """semgrep --json: results[] with extra.severity (ERROR/WARNING/INFO)."""
+    data = _loads(stdout)
+    if not data:
+        return []
+    out = []
+    for r in data.get("results", []) or []:
+        extra = r.get("extra") or {}
+        loc = r.get("path", "")
+        line = (r.get("start") or {}).get("line")
+        if line:
+            loc = f"{loc}:{line}"
+        out.append(_finding(
+            "semgrep", "sast",
+            normalize_severity("semgrep", extra.get("severity")),
+            r.get("check_id", "?"), loc,
+            extra.get("message", "static-analysis finding")))
+    return out
+
+
+def parse_trivy_config(stdout) -> list:
+    """trivy config --format json: Results[].Misconfigurations[]."""
+    data = _loads(stdout)
+    if not data:
+        return []
+    out = []
+    for res in data.get("Results", []) or []:
+        target = res.get("Target", "")
+        for mis in res.get("Misconfigurations", []) or []:
+            out.append(_finding(
+                "trivy", "iac",
+                normalize_severity("trivy", mis.get("Severity")),
+                mis.get("ID", "?"), target,
+                mis.get("Title", "misconfiguration")))
+    return out
+
+
+# --- scanner registry + selection -----------------------------------------
+
+# project_type strings that imply a Node / Python toolchain for SCA fallback.
+_NODE_TYPES = {"node", "nodejs", "javascript", "typescript", "ts", "js",
+               "sveltekit", "svelte", "next", "react", "vue", "express"}
+_PYTHON_TYPES = {"python", "py", "django", "flask", "fastapi"}
+
+
+def _is_node(project_type: str) -> bool:
+    return (project_type or "").lower() in _NODE_TYPES
+
+
+def _is_python(project_type: str) -> bool:
+    return (project_type or "").lower() in _PYTHON_TYPES
+
+
+def _build_gitleaks(project_root, base_ref, full):
+    # gitleaks 8.x: `detect` is deprecated. `-r -` streams the JSON report to
+    # stdout (logs go to stderr); --redact so secret values never land in our
+    # output. Diff mode (WF2 pre-PR gate): `git <path> --log-opts <base>..HEAD`
+    # scopes to the branch's new commits so a pre-existing fixture secret
+    # elsewhere doesn't block the PR. Full mode (WF9 audit): `dir <path>` scans
+    # the whole working tree.
+    common = ["--no-banner", "--redact", "--report-format", "json",
+              "--report-path", "-"]
+    if full:
+        return ["gitleaks", "dir", project_root, *common]
+    return ["gitleaks", "git", project_root, *common,
+            "--log-opts", f"{base_ref}..HEAD"]
+
+
+def _build_osv(project_root, base_ref, full):
+    return ["osv-scanner", "--format", "json", "--recursive", project_root]
+
+
+def _build_npm(project_root, base_ref, full):
+    return ["npm", "audit", "--json", "--prefix", project_root]
+
+
+def _build_pip_audit(project_root, base_ref, full):
+    # `pip-audit` with no target audits the AMBIENT Python environment, not the
+    # project — so it must be pointed at the project's requirements files with
+    # -r. If there are none (e.g. a poetry/pyproject project, which osv-scanner
+    # handles as the primary tool), return None so the orchestrator records a
+    # visible skip rather than silently auditing the wrong thing.
+    reqs = sorted(glob.glob(os.path.join(project_root, "requirements*.txt")))
+    if not reqs:
+        return None
+    cmd = ["pip-audit", "--format", "json"]
+    for r in reqs:
+        cmd += ["-r", r]
+    return cmd
+
+
+def _build_semgrep(project_root, base_ref, full):
+    # p/ci is the low-false-positive ruleset. Diff mode: --baseline-commit reports
+    # only findings introduced since base. Full mode (WF9 audit): scan everything.
+    cmd = ["semgrep", "--config", "p/ci", "--json", "--quiet"]
+    if not full:
+        cmd += ["--baseline-commit", base_ref]
+    cmd.append(project_root)
+    return cmd
+
+
+def _build_trivy_config(project_root, base_ref, full):
+    return ["trivy", "config", "--quiet", "--format", "json", project_root]
+
+
+# Each scanner: a kind + ordered tool candidates. select_scanners picks the first
+# candidate whose tool is installed AND applies to the project; if a candidate
+# applies but its tool is missing, the scanner is skipped *with a reason*.
+SCANNERS = [
+    # clean_rc = exit codes meaning "ran fine, NO findings"; found_rc = "ran fine,
+    # findings PRESENT". An rc in found_rc with zero parsed findings is an
+    # inconsistency (the tool flagged findings but we extracted none — schema
+    # drift / error envelope) and fails closed. An rc in neither is abnormal.
+    {"kind": "secrets", "applies": lambda pt, docker: True,
+     "candidates": [
+         {"tool": "gitleaks", "applies": lambda pt: True,
+          "build": _build_gitleaks, "parse": parse_gitleaks,
+          "clean_rc": frozenset({0}), "found_rc": frozenset({1})}],  # 0=clean,1=leaks,>1=error
+     "missing_reason": "gitleaks not installed (install via /rawgentic:setup)"},
+    {"kind": "sca", "applies": lambda pt, docker: True,
+     "candidates": [
+         {"tool": "osv-scanner", "applies": lambda pt: True,
+          "build": _build_osv, "parse": parse_osv_scanner,
+          "clean_rc": frozenset({0}), "found_rc": frozenset({1})},  # "no sources"=128->stderr skip
+         {"tool": "npm", "applies": _is_node,
+          "build": _build_npm, "parse": parse_npm_audit,
+          "clean_rc": frozenset({0}), "found_rc": frozenset({1})},  # error envelope caught in parser
+         {"tool": "pip-audit", "applies": _is_python,
+          "build": _build_pip_audit, "parse": parse_pip_audit,
+          "clean_rc": frozenset({0}), "found_rc": frozenset({1})}],
+     "missing_reason": "no dependency scanner installed "
+                       "(osv-scanner/npm/pip-audit) — install via /rawgentic:setup"},
+    {"kind": "sast", "applies": lambda pt, docker: True,
+     "candidates": [
+         {"tool": "semgrep", "applies": lambda pt: True,
+          "build": _build_semgrep, "parse": parse_semgrep,
+          # no --error: semgrep exits 0 on success WITH or WITHOUT findings, so
+          # there is no findings-indicated code; nonzero is always an error.
+          "clean_rc": frozenset({0}), "found_rc": frozenset()}],
+     "missing_reason": "semgrep not installed (install via /rawgentic:setup)"},
+    {"kind": "iac", "applies": lambda pt, docker: bool(docker),
+     "candidates": [
+         {"tool": "trivy", "applies": lambda pt: True,
+          "build": _build_trivy_config, "parse": parse_trivy_config,
+          # no --exit-code: trivy exits 0 on success (with or without findings).
+          "clean_rc": frozenset({0}), "found_rc": frozenset()}],
+     "missing_reason": "trivy not installed (install via /rawgentic:setup)"},
+]
+
+
+def select_scanners(project_type, has_docker, available):
+    """Resolve which scanners run given the project + installed tools.
+
+    Returns (to_run, skipped). to_run items are
+    {kind, tool, build, parse}; skipped items are {kind, reason}. A scanner not
+    applicable to the project is skipped with a distinct reason from one whose
+    tool is merely missing — both are surfaced, never silently dropped.
+    """
+    available = set(available)
+    to_run, skipped = [], []
+    for scanner in SCANNERS:
+        if not scanner["applies"](project_type, has_docker):
+            skipped.append({"kind": scanner["kind"],
+                            "reason": "not applicable to this project"})
+            continue
+        # candidates that apply to this project, in preference order
+        applicable = [c for c in scanner["candidates"] if c["applies"](project_type)]
+        chosen = next((c for c in applicable if c["tool"] in available), None)
+        if chosen is None:
+            skipped.append({"kind": scanner["kind"],
+                            "reason": scanner["missing_reason"]})
+            continue
+        to_run.append({"kind": scanner["kind"], "tool": chosen["tool"],
+                       "build": chosen["build"], "parse": chosen["parse"],
+                       "clean_rc": chosen.get("clean_rc", frozenset({0})),
+                       "found_rc": chosen.get("found_rc", frozenset({1}))})
+    return to_run, skipped
+
+
+# --- gate ------------------------------------------------------------------
+
+def _resolve_block_severities(env):
+    raw = (env or {}).get("RAWGENTIC_SECURITY_BLOCK_SEVERITIES")
+    if not raw:
+        return tuple(BLOCK_SEVERITIES_DEFAULT)
+    return tuple(s.strip().lower() for s in raw.split(",") if s.strip())
+
+
+def _block_threshold(block_severities) -> int:
+    """The minimum severity RANK that blocks. block_severities is treated as a
+    THRESHOLD, not exact membership: the lowest configured severity blocks that
+    level and everything above it. So `medium` blocks medium/high/critical and
+    can never accidentally make high/critical advisory.
+
+    Fail-closed on a bad config: if it is empty OR contains ANY unrecognized
+    token (a typo like `critical,hgih` must not silently drop to blocking only
+    `critical`), the WHOLE override is rejected and we fall back to the default
+    (block high+critical). This guarantees a typo can never make the gate laxer
+    than the default — though it may not honor an intended *stricter* config
+    (e.g. `medium,hgih` falls back to `high`), so run_scan also warns when the
+    configured value is invalid."""
+    tokens = [s.strip().lower() for s in block_severities if s and s.strip()]
+    if not tokens or any(t not in _SEV_ORDER for t in tokens):
+        tokens = list(BLOCK_SEVERITIES_DEFAULT)
+    return min(_SEV_ORDER[t] for t in tokens)
+
+
+def _is_blocking(finding, min_rank) -> bool:
+    if finding["kind"] == "secrets":
+        return True  # a leaked secret is never advisory
+    if finding["kind"] == "sca" and finding["severity"] == "unknown":
+        return True  # a known CVE with no rating is still a known CVE
+    return _SEV_ORDER.get(finding["severity"], 0) >= min_rank
+
+
+def decide_gate(findings, errors=(), block_severities=None) -> dict:
+    """Partition findings into blocking vs advisory and decide the gate.
+
+    Fail-closed: any blocking finding OR any scanner error -> blocked. Errors are
+    installed-but-broken scanners (unparseable output) — distinct from a missing
+    tool, which never reaches here (it is a skip)."""
+    if block_severities is None:
+        block_severities = BLOCK_SEVERITIES_DEFAULT
+    min_rank = _block_threshold(block_severities)
+    blocking, advisory = [], []
+    for f in findings:
+        (blocking if _is_blocking(f, min_rank) else advisory).append(f)
+    errors = list(errors)
+    return {
+        "blocked": bool(blocking) or bool(errors),
+        "blocking": blocking,
+        "advisory": advisory,
+        "errors": errors,
+    }
+
+
+# --- orchestrator ----------------------------------------------------------
+
+def _default_runner(cmd, **kwargs):
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+def run_scan(project_root, *, project_type="unknown", has_docker=False,
+             base_ref="origin/main", full=False, which=None, runner=None,
+             env=None) -> dict:
+    """Run the applicable, installed scanners over `project_root` and return
+    {findings, skipped, gate}. `full` switches secrets/SAST from diff-scoped (WF2
+    pre-PR gate) to whole-tree (WF9 audit). `which`/`runner`/`env` are injectable
+    so the whole orchestration is deterministic in tests with no scanner
+    installed."""
+    which = which or shutil.which
+    runner = runner or _default_runner
+    env = os.environ if env is None else env
+
+    # Resolve availability against the union of every candidate tool.
+    candidate_tools = {c["tool"] for s in SCANNERS for c in s["candidates"]}
+    available = {t for t in candidate_tools if which(t)}
+    to_run, skipped = select_scanners(project_type, has_docker, available)
+
+    findings, errors = [], []
+    for scanner in to_run:
+        cmd = scanner["build"](project_root, base_ref, full)
+        if cmd is None:
+            # The scanner has nothing to point at in this project (e.g. pip-audit
+            # with no requirements file). Visible skip, not a silent clean.
+            skipped.append({
+                "kind": scanner["kind"],
+                "reason": f"{scanner['tool']}: no scannable target in project"})
+            continue
+        try:
+            proc = runner(cmd)
+        except (OSError, subprocess.SubprocessError) as exc:
+            errors.append({"scanner": scanner["tool"],
+                           "message": f"failed to run: {exc}"})
+            continue
+        before = len(findings)
+        try:
+            # A nonzero exit is EXPECTED on findings (gitleaks=1, npm audit=1,
+            # osv=1), so findings come from stdout, not the exit code.
+            findings.extend(scanner["parse"](proc.stdout))
+        except Exception as exc:
+            # Fail closed on ANY parse failure — the SecurityScanError we raise
+            # for non-JSON / an npm error envelope, or an unexpected-but-valid
+            # JSON shape that trips a KeyError/TypeError/AttributeError. Either
+            # way it becomes a blocking error, never a crash and never "no
+            # findings." Then move on — the exit-code check below would
+            # double-count this scanner.
+            errors.append({
+                "scanner": scanner["tool"],
+                "message": f"{type(exc).__name__}: {exc} "
+                           f"(rc={proc.returncode}; "
+                           f"{(proc.stderr or '').strip()[:200]})"})
+            continue
+        produced = len(findings) > before
+        rc = proc.returncode
+        stderr = proc.stderr or ""
+        if rc in scanner["found_rc"] and not produced:
+            # The exit code says "findings present" but the parser extracted
+            # none — schema drift or an error envelope masking real findings.
+            # Fail closed: "the tool found something we couldn't read" is never
+            # "clean."
+            errors.append({
+                "scanner": scanner["tool"],
+                "message": f"exited rc={rc} indicating findings, but none were "
+                           f"parsed — possible scanner/output drift; "
+                           f"{stderr.strip()[:200]}"})
+        elif rc not in scanner["clean_rc"] and rc not in scanner["found_rc"]:
+            # An unexpected exit code: the scan may have run incompletely — fail
+            # closed EVEN IF some findings were parsed. The only benign exception
+            # is a *dependency* (SCA) scanner reporting it had no package sources
+            # AND producing nothing — genuinely "nothing to scan." SCA-only, so a
+            # secrets/SAST/IaC tool whose stderr happens to say "no packages"
+            # still fails closed.
+            if (not produced and scanner["kind"] == "sca"
+                    and _NOTHING_TO_SCAN_RE.search(stderr)):
+                skipped.append({
+                    "kind": scanner["kind"],
+                    "reason": f"{scanner['tool']}: nothing to scan (rc={rc})"})
+            else:
+                errors.append({
+                    "scanner": scanner["tool"],
+                    "message": f"exited rc={rc}; scan may be incomplete; "
+                               f"{stderr.strip()[:200]}"})
+
+    block_severities = _resolve_block_severities(env)
+    # Surface an invalid override instead of silently falling back to default —
+    # otherwise an intended-stricter config (e.g. "medium,hgih") is dropped with
+    # no signal.
+    invalid = [s for s in block_severities
+               if s.strip() and s.strip().lower() not in _SEV_ORDER]
+    if invalid:
+        print(f"warning: RAWGENTIC_SECURITY_BLOCK_SEVERITIES has unrecognized "
+              f"value(s) {invalid}; falling back to the fail-closed default "
+              f"{list(BLOCK_SEVERITIES_DEFAULT)}", file=sys.stderr)
+    gate = decide_gate(findings, errors, block_severities)
+    return {"findings": findings, "skipped": skipped, "gate": gate}
+
+
+# --- human rendering + CLI -------------------------------------------------
+
+def render_text(result: dict) -> str:
+    gate = result["gate"]
+    lines = []
+    status = "BLOCKED" if gate["blocked"] else "PASS"
+    lines.append(f"Security scan: {status}")
+    if gate["blocking"]:
+        lines.append(f"\nBlocking ({len(gate['blocking'])}) — fix before PR:")
+        for f in gate["blocking"]:
+            lines.append(f"  [{f['severity']}] {f['kind']}: {f['identifier']} "
+                         f"@ {f['location']} — {f['title']}")
+    if gate["errors"]:
+        lines.append(f"\nScanner errors ({len(gate['errors'])}) — fail-closed:")
+        for e in gate["errors"]:
+            lines.append(f"  {e['scanner']}: {e['message']}")
+    if gate["advisory"]:
+        lines.append(f"\nAdvisory ({len(gate['advisory'])}) — note, fix if easy:")
+        for f in gate["advisory"]:
+            lines.append(f"  [{f['severity']}] {f['kind']}: {f['identifier']} "
+                         f"@ {f['location']}")
+    if result["skipped"]:
+        lines.append(f"\nSkipped ({len(result['skipped'])}) — tool absent / "
+                     f"not applicable (NOT a pass):")
+        for s in result["skipped"]:
+            lines.append(f"  {s['kind']}: {s['reason']}")
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    """CLI entry point.
+
+    Subcommand:
+      scan  run the applicable installed scanners over --project-root and print a
+            report ({findings, skipped, gate} JSON with --json, else human text).
+
+    Exit codes:
+      0  scan ran; gate PASS (no blocking findings; skips are allowed)
+      1  gate BLOCKED — blocking finding(s) or an installed-but-broken scanner
+      2  argparse usage error
+    """
+    parser = argparse.ArgumentParser(prog="security_scan")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p = sub.add_parser("scan", help="run tool-based security scanners")
+    p.add_argument("--project-root", required=True)
+    p.add_argument("--project-type", default="unknown",
+                   help="capabilities.project_type (drives SCA tool fallback)")
+    p.add_argument("--has-docker", action="store_true",
+                   help="capabilities.has_docker (enables the IaC scan)")
+    p.add_argument("--base-ref", default="origin/main",
+                   help="diff base for secret/SAST scoping (e.g. origin/main)")
+    p.add_argument("--full", action="store_true",
+                   help="scan the whole tree (WF9 audit) instead of the branch "
+                        "diff (WF2 pre-PR gate)")
+    p.add_argument("--json", action="store_true",
+                   help="emit JSON instead of human-readable text")
+    args = parser.parse_args(argv)
+
+    if args.cmd == "scan":
+        result = run_scan(
+            args.project_root, project_type=args.project_type,
+            has_docker=args.has_docker, base_ref=args.base_ref, full=args.full)
+        if args.json:
+            print(json.dumps(result, separators=(",", ":")))
+        else:
+            print(render_text(result))
+        return 1 if result["gate"]["blocked"] else 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -498,6 +498,53 @@ _do_security_staleness_check() {
 _do_security_staleness_check 2>/dev/null || true
 
 # =========================================================================
+# SECTION 2d: Security Scanner Bootstrap (startup only, opt-out, run-once)
+# =========================================================================
+# WF2 Step 11.5 + WF9 shell out to real scanners (gitleaks/semgrep/osv-scanner/
+# trivy). On the first startup after the plugin is added, install any that are
+# missing — in the BACKGROUND (this hook has a 10s budget, so it must
+# fire-and-forget) and exactly ONCE (marker-guarded). Installs are opt-OUT, never
+# opt-in: a user declines with RAWGENTIC_SKIP_SCANNER_INSTALL=1 or
+# "installScanners": false in .rawgentic_workspace.json. Skipped in headless/CI.
+_do_scanner_bootstrap() {
+    [ "$EVENT_TYPE" = "startup" ] || return 0
+    if [ "${RAWGENTIC_HEADLESS:-}" = "1" ]; then return 0; fi
+    if [ "${RAWGENTIC_SKIP_SCANNER_INSTALL:-}" = "1" ]; then return 0; fi
+
+    # Workspace-level opt-out (lets /rawgentic:setup persist the choice).
+    if [ -n "$WORKSPACE_FILE" ] && command -v "$JQ" &>/dev/null; then
+        local _optout
+        _optout=$("$JQ" -r '.installScanners // ""' "$WORKSPACE_FILE" 2>/dev/null || true)
+        if [ "$_optout" = "false" ]; then return 0; fi
+    fi
+
+    local installer="$SCRIPT_DIR/../scripts/install-scanners.sh"
+    [ -f "$installer" ] || return 0
+
+    local marker_dir="$HOME/.rawgentic"
+    local marker="$marker_dir/scanners-bootstrapped"
+    if [ -f "$marker" ]; then return 0; fi
+
+    # Marker is machine-global because the scanners are; write it FIRST so a slow
+    # or failed install never re-fires on every subsequent startup.
+    mkdir -p "$marker_dir" 2>/dev/null || true
+
+    # Nothing missing? Record and stay quiet.
+    if bash "$installer" --check >/dev/null 2>&1; then
+        : > "$marker" 2>/dev/null || true
+        return 0
+    fi
+
+    : > "$marker" 2>/dev/null || true
+    local logf="$marker_dir/scanner-install.log"
+    nohup bash "$installer" >"$logf" 2>&1 &
+    disown 2>/dev/null || true
+
+    CONTEXT_PARTS+=("rawgentic is installing the WF2/WF9 security scanners (gitleaks/semgrep/osv-scanner/trivy) in the background — log at ~/.rawgentic/scanner-install.log. This runs once. Opt out anytime with RAWGENTIC_SKIP_SCANNER_INSTALL=1 or \"installScanners\": false in .rawgentic_workspace.json.")
+}
+_do_scanner_bootstrap 2>/dev/null || true
+
+# =========================================================================
 # SECTION 3: Rawgentic Workspace Context (always runs)
 # =========================================================================
 if [ -z "$WORKSPACE_FILE" ]; then

--- a/scripts/install-scanners.sh
+++ b/scripts/install-scanners.sh
@@ -59,11 +59,20 @@ esac
 
 # Fetch a GitHub release asset whose name matches a grep pattern, to BIN_DIR.
 # $1=owner/repo  $2=asset-name grep pattern  $3=output binary name
-# Handles a raw binary, a .tar.gz (extracts the binary), best-effort.
+# Handles a raw binary, a .tar.gz (extracts the binary), best-effort. Uses
+# GITHUB_TOKEN/GH_TOKEN when set so CI (whose shared IPs hit the unauthenticated
+# 60/hr API limit) doesn't intermittently 403.
 _gh_release_binary() {
   repo="$1"; pattern="$2"; out="$3"
-  url=$(curl -fsSL "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null \
-    | python3 -c "import sys,json,re
+  local tok api_json
+  tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+  if [ -n "$tok" ]; then
+    api_json=$(curl -fsSL -H "Authorization: Bearer $tok" \
+      "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null)
+  else
+    api_json=$(curl -fsSL "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null)
+  fi
+  url=$(printf '%s' "$api_json" | python3 -c "import sys,json,re
 try:
     d=json.load(sys.stdin)
 except Exception:
@@ -115,8 +124,10 @@ install_one() {
         && chmod +x "$BIN_DIR/osv-scanner" && have osv-scanner \
         && { echo "  installed osv-scanner"; return 0; } ;;
     gitleaks)
-      echo "installing gitleaks (release binary, ${os}_${arch})..."
-      _gh_release_binary "gitleaks/gitleaks" "${os}_${arch}\\.tar\\.gz$" "gitleaks" \
+      # gitleaks names the x86_64 asset "x64" (not "amd64"); arm64 stays arm64.
+      garch=$(echo "$arch" | sed 's/amd64/x64/')
+      echo "installing gitleaks (release binary, ${os}_${garch})..."
+      _gh_release_binary "gitleaks/gitleaks" "${os}_${garch}\\.tar\\.gz$" "gitleaks" \
         && { echo "  installed gitleaks"; return 0; } ;;
     trivy)
       echo "installing trivy (release binary, ${os}_${arch})..."

--- a/scripts/install-scanners.sh
+++ b/scripts/install-scanners.sh
@@ -20,7 +20,7 @@
 set -u
 
 BIN_DIR="${RAWGENTIC_SCANNER_BIN:-$HOME/.local/bin}"
-TOOLS="gitleaks semgrep osv-scanner trivy pip-audit"
+ALL_TOOLS="gitleaks semgrep osv-scanner trivy pip-audit"
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -33,8 +33,18 @@ _arch() {
   esac
 }
 
-# --- check mode ------------------------------------------------------------
-if [ "${1:-}" = "--check" ]; then
+# --- arg parsing -----------------------------------------------------------
+# Usage: install-scanners.sh [--check] [tool ...]
+#   --check       report presence only (exit 1 if any in scope is missing)
+#   tool ...      restrict to these tools (default: all). Lets a caller (e.g. CI)
+#                 install only the scanners it actually exercises — trivy is a
+#                 ~167MB binary only needed for IaC/Docker scans, so a smoke run
+#                 that never touches IaC has no reason to pull it.
+CHECK=0
+if [ "${1:-}" = "--check" ]; then CHECK=1; shift; fi
+if [ "$#" -gt 0 ]; then TOOLS="$*"; else TOOLS="$ALL_TOOLS"; fi
+
+if [ "$CHECK" = "1" ]; then
   missing=0
   for t in $TOOLS; do
     if have "$t"; then echo "present: $t"; else echo "MISSING: $t"; missing=1; fi

--- a/scripts/install-scanners.sh
+++ b/scripts/install-scanners.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Install the security scanners that hooks/security_scan.py (WF2 Step 11.5 +
+# WF9) shells out to. Idempotent and best-effort: a tool already on PATH is left
+# alone, and a tool that can't be auto-installed is reported (never fatal) so the
+# scanner just degrades to a visible skip rather than the install blocking work.
+#
+# Tools: gitleaks (secrets), semgrep (SAST), osv-scanner (dependency CVEs),
+# trivy (IaC/Dockerfile, only needed for Docker projects), pip-audit (SCA
+# fallback when osv-scanner is unavailable).
+#
+# Usage:
+#   install-scanners.sh            install every missing scanner (best-effort)
+#   install-scanners.sh --check    report presence only; exit 1 if any missing
+#
+# Install strategy per tool, in order of preference:
+#   - Homebrew (macOS/Linux) if `brew` is present — handles os/arch/version
+#   - pipx (Python tools: semgrep, pip-audit), else `pip install --user`
+#   - GitHub release binary (Go tools: gitleaks, osv-scanner, trivy)
+# No remote script is piped to a shell; binaries are downloaded to BIN_DIR.
+set -u
+
+BIN_DIR="${RAWGENTIC_SCANNER_BIN:-$HOME/.local/bin}"
+TOOLS="gitleaks semgrep osv-scanner trivy pip-audit"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+_os() { case "$(uname -s)" in Darwin) echo darwin ;; *) echo linux ;; esac; }
+_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64) echo amd64 ;;
+    arm64|aarch64) echo arm64 ;;
+    *) echo unknown ;;
+  esac
+}
+
+# --- check mode ------------------------------------------------------------
+if [ "${1:-}" = "--check" ]; then
+  missing=0
+  for t in $TOOLS; do
+    if have "$t"; then echo "present: $t"; else echo "MISSING: $t"; missing=1; fi
+  done
+  exit "$missing"
+fi
+
+# Opt-out: installs are on by default (opt-OUT, never opt-in). A user who does
+# not want rawgentic touching their toolchain sets this env var (or the
+# workspace `installScanners: false`, which the session-start bootstrap honors).
+if [ "${RAWGENTIC_SKIP_SCANNER_INSTALL:-}" = "1" ]; then
+  echo "rawgentic: scanner install opted out (RAWGENTIC_SKIP_SCANNER_INSTALL=1) — skipping."
+  echo "the WF2/WF9 scan will skip any scanner that isn't already installed."
+  exit 0
+fi
+
+mkdir -p "$BIN_DIR" 2>/dev/null || true
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *) echo "note: $BIN_DIR is not on PATH — add it so the scanners are found" ;;
+esac
+
+# Fetch a GitHub release asset whose name matches a grep pattern, to BIN_DIR.
+# $1=owner/repo  $2=asset-name grep pattern  $3=output binary name
+# Handles a raw binary, a .tar.gz (extracts the binary), best-effort.
+_gh_release_binary() {
+  repo="$1"; pattern="$2"; out="$3"
+  url=$(curl -fsSL "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null \
+    | python3 -c "import sys,json,re
+try:
+    d=json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+pat=re.compile(r'''$pattern''')
+for a in d.get('assets',[]):
+    if pat.search(a.get('name','')):
+        print(a['browser_download_url']); break" 2>/dev/null)
+  [ -n "$url" ] || { echo "  could not resolve a release asset for $repo"; return 1; }
+  tmp=$(mktemp -d)
+  case "$url" in
+    *.tar.gz|*.tgz)
+      curl -fsSL "$url" -o "$tmp/a.tgz" 2>/dev/null \
+        && tar -xzf "$tmp/a.tgz" -C "$tmp" 2>/dev/null \
+        && bin=$(find "$tmp" -type f -name "$out" | head -1) \
+        && [ -n "$bin" ] && install -m 0755 "$bin" "$BIN_DIR/$out" ;;
+    *)
+      curl -fsSL "$url" -o "$BIN_DIR/$out" 2>/dev/null && chmod +x "$BIN_DIR/$out" ;;
+  esac
+  rc=$?
+  rm -rf "$tmp"
+  return "$rc"
+}
+
+_install_python_tool() {  # $1 = pip/pipx package name
+  if have pipx; then pipx install "$1" >/dev/null 2>&1 && return 0; fi
+  if have pip3; then pip3 install --user "$1" >/dev/null 2>&1 && return 0; fi
+  if have pip; then pip install --user "$1" >/dev/null 2>&1 && return 0; fi
+  return 1
+}
+
+install_one() {
+  tool="$1"
+  if have "$tool"; then echo "present: $tool"; return 0; fi
+  if have brew; then
+    echo "installing $tool via brew..."
+    brew install "$tool" >/dev/null 2>&1 && { echo "  installed $tool"; return 0; }
+  fi
+  os=$(_os); arch=$(_arch)
+  case "$tool" in
+    semgrep|pip-audit)
+      echo "installing $tool via pipx/pip..."
+      _install_python_tool "$tool" && { echo "  installed $tool"; return 0; } ;;
+    osv-scanner)
+      echo "installing osv-scanner (release binary, ${os}_${arch})..."
+      # osv-scanner publishes a stable latest/download URL
+      curl -fsSL -o "$BIN_DIR/osv-scanner" \
+        "https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_${os}_${arch}" 2>/dev/null \
+        && chmod +x "$BIN_DIR/osv-scanner" && have osv-scanner \
+        && { echo "  installed osv-scanner"; return 0; } ;;
+    gitleaks)
+      echo "installing gitleaks (release binary, ${os}_${arch})..."
+      _gh_release_binary "gitleaks/gitleaks" "${os}_${arch}\\.tar\\.gz$" "gitleaks" \
+        && { echo "  installed gitleaks"; return 0; } ;;
+    trivy)
+      echo "installing trivy (release binary, ${os}_${arch})..."
+      tos=$(echo "$os" | sed 's/darwin/macOS/; s/linux/Linux/')
+      tarch=$(echo "$arch" | sed 's/amd64/64bit/; s/arm64/ARM64/')
+      _gh_release_binary "aquasecurity/trivy" "${tos}-${tarch}\\.tar\\.gz$" "trivy" \
+        && { echo "  installed trivy"; return 0; } ;;
+  esac
+  echo "  could not auto-install $tool — install it manually (see docs/security-scan.md)"
+  return 1
+}
+
+echo "rawgentic: ensuring security scanners are installed (target: $BIN_DIR)"
+failed=""
+for t in $TOOLS; do
+  install_one "$t" || failed="$failed $t"
+done
+
+echo ""
+if [ -n "$failed" ]; then
+  echo "scanners not installed:$failed (the WF2/WF9 scan will skip these — see docs/security-scan.md)"
+else
+  echo "all scanners present."
+fi
+# Best-effort: never fail the caller (setup / bootstrap) on a missing scanner.
+exit 0

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -1049,6 +1049,85 @@ Code review result with filtered findings and fixes applied. Committed `.rawgent
 
 ---
 
+## Step 11.5: Tool-Based Security Scan (Pre-PR Gate)
+
+### Instructions
+
+Step 11's review is the LLM *reasoning* about the diff; this step runs the
+*actual* scanners — secrets, dependency CVEs, SAST, and (for Docker projects)
+IaC misconfig — via the shared `hooks/security_scan.py` lib. WF9
+(`/rawgentic:security-audit`) calls the **same** lib, so the tool-based scanning
+can never drift between the two workflows. Scanners catch concrete, known-pattern
+problems that reasoning misses (a leaked token, a CVE'd transitive dependency);
+they do **not** replace the review or WF9's STRIDE/authorization analysis — those
+find logic and authz flaws that no scanner can. Run this AFTER Step 11 has applied
+its fixes and committed, and BEFORE pushing in Step 12.
+
+1. Run the scan. Carry `capabilities` values in as **literals** (each step is its
+   own Bash call, so shell variables from earlier steps do not persist). Append
+   `--has-docker` only when `capabilities.has_docker` is true:
+   ```bash
+   python3 hooks/security_scan.py scan \
+     --project-root <activeProject.path> \
+     --project-type <capabilities.project_type> \
+     --base-ref origin/<capabilities.default_branch> \
+     --json
+   rc=$?
+   ```
+   The JSON `gate` object is authoritative (exit code mirrors it: `0` PASS, `1`
+   BLOCKED, `2` usage error). Read `gate.blocking`, `gate.advisory`,
+   `gate.errors`, and the top-level `skipped` / `findings`.
+
+2. **Blocking findings (`gate.blocking`) — fix before the PR, exactly like a
+   Step 11 Critical/High:**
+   - `secrets`: the secret is in the branch's new commits. Remove it, and if it
+     is a *real* credential it must be **rotated** — a deleted-but-already-
+     committed secret is still leaked in history. Surface this to the user; do
+     not silently delete-and-continue.
+   - `sca` (dependency CVE): bump to the fixed version; if none exists, evaluate
+     the exposure and either pin/replace or get explicit user acknowledgement.
+   - `sast` / `iac`: fix the flagged pattern. Only if it is a *verified* false
+     positive, suppress it at the tool's rule level with a justifying comment —
+     never by removing the scan.
+   Commit the fix and re-run the scan until `gate.blocking` is empty.
+
+3. **Scanner errors (`gate.errors`) — fail closed:** an *installed* scanner
+   produced unparseable output. Do NOT treat this as clean. Investigate (often a
+   missing lockfile or a tool-version mismatch), fix the cause and re-run, or
+   escalate. "I couldn't tell" is never "secure."
+
+4. **Advisory findings (`gate.advisory`):** Medium/Low — note them in the PR body
+   and fix if easy.
+
+5. **Skipped scanners (`skipped`):** a tool wasn't installed, or wasn't
+   applicable to this project. This is **NOT a pass** — record the skips in
+   session notes and the PR body so the gap stays visible. If a scanner the
+   project *should* run was skipped for "tool not installed," recommend
+   `/rawgentic:setup` (which installs the scanners).
+
+6. **Ambiguity circuit breaker:** if a finding's validity or severity is unclear,
+   STOP and present to the user. **[Headless: if `gate.blocking` is non-empty and
+   cannot be auto-resolved, post an error comment listing the blocking findings,
+   add the `rawgentic:ai-error` label, and exit. A leaked *real* secret is ALWAYS
+   an escalation in headless mode — never auto-handle a live credential.]**
+
+Log a marker in `claude_docs/session_notes.md`:
+`### WF2 Step 11.5: Security Scan — DONE (blocking: N resolved, advisory: N, skipped: <kinds>)`
+
+### Output
+Security scan gate PASS with all blocking findings resolved; skips and advisories
+recorded for the PR body and session notes.
+
+### Failure Modes
+- Blocking finding is out of WF2 scope to fix → create a follow-up issue and get
+  user sign-off before proceeding; a Critical secret/CVE never ships silently.
+- All scanners skipped (no tools installed) → the gate is effectively a no-op for
+  this run; warn the user and recommend `/rawgentic:setup` to install them.
+- Scanner slow on a large repo → secrets/SAST are diff-scoped already; for
+  SCA/IaC accept the one-time cost or narrow scope with the user.
+
+---
+
 ## Step 12: Create PR and Push
 
 ### Instructions
@@ -1110,6 +1189,7 @@ Code review result with filtered findings and fixes applied. Committed `.rawgent
    - Plan drift check (Step 6): N findings
    - Implementation drift check (Step 9): N findings
    - Code review (Step 11): N findings (all Critical/High resolved)
+   - Security scan (Step 11.5): N blocking resolved, N advisory, skipped: <kinds or "none">
    ```
 
 ### Output
@@ -1244,6 +1324,7 @@ Quality Gates:
 - Step 9 (Implementation Drift): N findings
 - Step 10 (Memorize): [N insights saved / skipped]
 - Step 11 (Code Review): N findings (all Critical/High resolved)
+- Step 11.5 (Security Scan): [N blocking resolved / N advisory / skipped: <kinds or "none">]
 - Step 15 (Post-Deploy): [pass / skipped / deferred]
 
 Verification:                              # Adapt based on capabilities
@@ -1277,6 +1358,7 @@ Before declaring WF2 complete, verify the following. Items marked (conditional) 
 7. [ ] (conditional: has_deploy) Deployment verified or manual deploy confirmed
 8. [ ] (conditional: architecture changed) CLAUDE.md updated
 9. [ ] All Critical/High code review findings resolved
+10. [ ] Security scan (Step 11.5) ran; all blocking findings resolved (or, if no scanners were installed, the skips are recorded in session notes + PR body)
 
 If ANY applicable item fails, complete it before declaring "WF2 complete."
 </completion-gate>

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -148,16 +148,23 @@ Proceeding to enumerate attack surface. Confirm scope.
 2. **Authentication mapping:** For each endpoint, verify auth middleware is applied per `config.security.authMechanisms[]`.
 3. **Data channel mapping:** Enumerate all data channels from `config.security.dataChannels[]` and verify their auth mechanisms.
 4. **Input boundary mapping:** All points where external data enters the system (request bodies, parameters, queries, WebSocket messages, message queues, etc.).
-5. **Secret inventory:** Scan for hardcoded secrets, .env patterns, credential storage.
-6. **Dependency inventory:** List packages with known CVEs.
+5. **Tool-based scan (shared lib):** Run the same scanner WF2 Step 11.5 uses, so the secret / dependency-CVE / SAST / IaC findings come from one tested place and can never drift between the two workflows. Use `--full` (audit the whole tree, not a branch diff):
+   ```bash
+   python3 hooks/security_scan.py scan \
+     --project-root <PROJECT_ROOT> \
+     --project-type <capabilities.project_type> \
+     --full --json
+   ```
+   Append `--has-docker` when `capabilities.has_docker` is true. Feed every `findings[]` entry into the STRIDE analysis (Step 3) and the report (Step 4) — tool findings are **inputs** to the audit, not a substitute for it (scanners find known patterns; STRIDE finds the logic/authz/abuse flaws they can't). A `skipped` scanner is a **coverage gap**: record it in the report and recommend `/rawgentic:setup` to install the missing tool. A `gate.errors` entry is an installed-but-broken scanner — investigate, do not treat as clean.
+6. **Manual augmentation:** beyond the tool scan, note credential-storage patterns, `.env` handling, and any inputs the scanners could not assess (vendored code, lockfile-less ecosystems, dynamic config).
 
 ### Output
 
-Attack surface map (internal working artifact).
+Attack surface map (internal working artifact), including the `security_scan.py --full` findings, skips, and any scanner errors.
 
 ### Failure Modes
 
-- Serena MCP unavailable → fall back to Grep for endpoint/symbol discovery
+- Symbol/endpoint discovery tooling unavailable → fall back to Grep for endpoint/symbol discovery
 - Endpoint list incomplete → grep for route definitions across all files using patterns appropriate to the project's framework
 - Data channel missed → cross-check against `config.security.dataChannels[]` to ensure all channels are covered
 
@@ -279,7 +286,15 @@ For each finding (Critical first, then High, Medium, Low):
 3. **Implement fix:** Minimum change to close the vulnerability.
 4. **Verify test passes.**
 5. **Run full suite:** No regressions.
-6. **Commit:** `security(scope): fix <finding-summary>`
+6. **Re-scan to confirm closure:** for findings the tools can verify (secrets, dependency CVEs, SAST/IaC patterns), re-run the shared scanner and confirm the finding is gone:
+   ```bash
+   python3 hooks/security_scan.py scan \
+     --project-root <PROJECT_ROOT> \
+     --project-type <capabilities.project_type> \
+     --full --json
+   ```
+   A remediated finding that still appears means the fix is incomplete. (A removed-but-already-committed secret still shows in history until rotated — rotation, not deletion, closes a real credential leak.)
+7. **Commit:** `security(scope): fix <finding-summary>`
 
 **Security-specific considerations:**
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -262,6 +262,51 @@ Check the active project's entry for the `adversarialReview` field.
 
 ---
 
+## Step 2e: Security Scan Tooling
+
+This step runs on **every** setup invocation (including Sub-flow A re-runs).
+
+WF2 Step 11.5 (pre-PR gate) and WF9 (`/rawgentic:security-audit`) both run
+`hooks/security_scan.py`, which shells out to real scanners (gitleaks, semgrep,
+osv-scanner, and — for Docker projects — trivy). The scanner degrades gracefully
+(a tool that isn't installed is a *visible skip*, never a silent "clean"), but a
+skipped scanner is a real coverage gap, so setup installs whatever is missing.
+
+**Installs are opt-OUT, not opt-in** — install by default; let the user decline.
+
+1. **Check the workspace opt-out.** Read `installScanners` from
+   `.rawgentic_workspace.json`. If it is `false`, the user previously opted out:
+   print "Security scanner install is opted out (`installScanners: false`)." and
+   skip the rest of this step.
+
+2. **Install missing scanners (default).** Unless opted out, run the idempotent
+   installer (best-effort; a tool already present is left alone, and one that
+   can't be auto-installed is reported, never fatal):
+   ```bash
+   bash <plugin-root>/scripts/install-scanners.sh
+   ```
+   In an interactive setup, tell the user this is happening and that they can
+   decline. If they decline, persist it: read `.rawgentic_workspace.json`, set
+   top-level `"installScanners": false`, write it back (and skip the install).
+   In **headless** mode do NOT install — just record the gap.
+
+3. **Report** which scanners are now present and which remain missing (so the
+   user knows the WF2/WF9 scan will skip those). The installer's `--check` mode
+   prints this:
+   ```bash
+   bash <plugin-root>/scripts/install-scanners.sh --check
+   ```
+   No `.rawgentic.json` field is written for *presence* — the scanner probes tool
+   presence at run time (exactly like WF5 probes for the Codex CLI). Only the
+   opt-out decision is persisted, and only to the workspace file.
+
+Note: the session-start hook also runs this installer once in the background the
+first time the plugin is added, honoring the same `RAWGENTIC_SKIP_SCANNER_INSTALL=1`
+/ `installScanners: false` opt-outs — so most projects already have the scanners
+by the time setup runs; this step is the explicit, user-visible confirmation.
+
+---
+
 ## Step 3: Detect or Brainstorm
 
 Read `templates/rawgentic-json-schema.json` from the rawgentic plugin directory to understand the full schema structure.

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.31.1"
+    assert plugin["version"] == "2.32.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_adversarial_review_schema.py
+++ b/tests/hooks/test_adversarial_review_schema.py
@@ -12,8 +12,14 @@ import adversarial_review_lib as arl  # noqa: E402
 
 
 def _finding(**over):
+    # ambiguity_flag/ambiguity_reason are "required-but-nullable" in
+    # FINDINGS_SCHEMA (OpenAI strict structured-output requires every property in
+    # `required`, recursively — see #80). A realistic finding always carries them
+    # (null when not flagged), so the helper must too, or it diverges from the
+    # schema the strict jsonschema test enforces.
     base = {"severity": "High", "category": "security",
-            "description": "d", "recommendation": "r", "location": "S1"}
+            "description": "d", "recommendation": "r", "location": "S1",
+            "ambiguity_flag": False, "ambiguity_reason": None}
     base.update(over)
     return base
 

--- a/tests/hooks/test_bmad_detection.py
+++ b/tests/hooks/test_bmad_detection.py
@@ -138,7 +138,7 @@ class TestHeadlessInteractionBlock:
 
     # Expected [Headless annotation counts per skill
     EXPECTED_COUNTS = {
-        "implement-feature": 25,  # 17 base + 1 disabled-skill cleanup + 7 P15 (#73): Step 5 warn/halt/decompose + 8a ambiguity/dispatch-failure/design-flaw/headless-suspend + Step 11 deferred-High
+        "implement-feature": 26,  # 17 base + 1 disabled-skill cleanup + 7 P15 (#73): Step 5 warn/halt/decompose + 8a ambiguity/dispatch-failure/design-flaw/headless-suspend + Step 11 deferred-High + 1 Step 11.5 security-scan block
         "fix-bug": 11,            # 10 interaction points + 1 disabled-skill cleanup
     }
 

--- a/tests/hooks/test_security_scan.py
+++ b/tests/hooks/test_security_scan.py
@@ -1,0 +1,869 @@
+"""Tests for hooks/security_scan.py — the shared tool-based security scanner.
+
+WF2 (implement-feature) Step 11.5 and WF9 (security-audit) both call this one
+tested lib so the actual *tool-based* scanning (secrets / dependency-CVE / SAST /
+IaC) lives in a single fail-closed place instead of being re-derived in prose.
+
+The design splits cleanly into PURE functions (severity normalization, per-tool
+output parsers, scanner selection, the gate decision) — exhaustively unit-tested
+here — and one orchestrator (`run_scan`) that takes injectable `which`/`runner`
+so the subprocess wiring is deterministic without any scanner installed. The gate
+is the security-critical heart, so it gets the most adversarial coverage:
+fail-CLOSED on a real finding or an unparseable scanner, but degrade with a
+VISIBLE skip (never silent) when a tool simply isn't installed.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+SCAN_CLI = HOOKS_DIR / "security_scan.py"
+
+
+# --- helpers ---------------------------------------------------------------
+
+def _proc(returncode=0, stdout="", stderr=""):
+    """A fake subprocess.CompletedProcess-alike for the injected runner."""
+    class _P:
+        pass
+    p = _P()
+    p.returncode = returncode
+    p.stdout = stdout
+    p.stderr = stderr
+    return p
+
+
+def _fake_runner_from(mapping):
+    """Build a runner(cmd) that dispatches on the tool name (cmd[0])."""
+    calls = []
+
+    def runner(cmd, **kwargs):
+        calls.append(cmd)
+        tool = cmd[0]
+        return mapping.get(tool, _proc(returncode=0, stdout=""))
+    runner.calls = calls
+    return runner
+
+
+def _which_from(present):
+    present = set(present)
+    return lambda tool: ("/usr/bin/" + tool) if tool in present else None
+
+
+# --- normalize_severity ----------------------------------------------------
+
+class TestNormalizeSeverity:
+    """Each tool speaks a different severity vocabulary; the lib folds them all
+    into one ordered scale {critical, high, medium, low, unknown} so the gate can
+    reason uniformly."""
+
+    @pytest.mark.parametrize("tool,raw,expected", [
+        # gitleaks findings carry no severity — a leaked secret is always critical
+        ("gitleaks", None, "critical"),
+        ("gitleaks", "whatever", "critical"),
+        # npm audit: moderate maps to medium, info to low
+        ("npm", "critical", "critical"),
+        ("npm", "high", "high"),
+        ("npm", "moderate", "medium"),
+        ("npm", "low", "low"),
+        ("npm", "info", "low"),
+        # osv / generic database severities (upper-case)
+        ("osv-scanner", "CRITICAL", "critical"),
+        ("osv-scanner", "HIGH", "high"),
+        ("osv-scanner", "MODERATE", "medium"),
+        ("osv-scanner", "MEDIUM", "medium"),
+        ("osv-scanner", "LOW", "low"),
+        # semgrep
+        ("semgrep", "ERROR", "high"),
+        ("semgrep", "WARNING", "medium"),
+        ("semgrep", "INFO", "low"),
+        # trivy keeps its own buckets; UNKNOWN stays unknown
+        ("trivy", "CRITICAL", "critical"),
+        ("trivy", "HIGH", "high"),
+        ("trivy", "UNKNOWN", "unknown"),
+        # anything unrecognized degrades to unknown rather than guessing
+        ("npm", None, "unknown"),
+        ("osv-scanner", "", "unknown"),
+        ("semgrep", "bogus", "unknown"),
+    ])
+    def test_maps(self, tool, raw, expected):
+        from security_scan import normalize_severity
+        assert normalize_severity(tool, raw) == expected
+
+
+# --- parsers ---------------------------------------------------------------
+
+class TestParseGitleaks:
+    def test_empty_array_is_no_findings(self):
+        from security_scan import parse_gitleaks
+        assert parse_gitleaks("[]") == []
+
+    def test_blank_output_is_no_findings(self):
+        from security_scan import parse_gitleaks
+        # gitleaks with --report-path - prints nothing when there are no leaks
+        assert parse_gitleaks("") == []
+        assert parse_gitleaks("null") == []
+
+    def test_parses_leak_as_critical_secret(self):
+        from security_scan import parse_gitleaks
+        out = json.dumps([
+            {"RuleID": "aws-access-key", "File": "src/app.py",
+             "StartLine": 10, "Description": "AWS Access Key"},
+        ])
+        findings = parse_gitleaks(out)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f["kind"] == "secrets"
+        assert f["severity"] == "critical"
+        assert f["scanner"] == "gitleaks"
+        assert "src/app.py" in f["location"]
+        assert f["identifier"] == "aws-access-key"
+
+    def test_malformed_json_raises(self):
+        from security_scan import parse_gitleaks, SecurityScanError
+        with pytest.raises(SecurityScanError):
+            parse_gitleaks("{not json")
+
+
+class TestParseOsvScanner:
+    def test_empty_results(self):
+        from security_scan import parse_osv_scanner
+        assert parse_osv_scanner('{"results": []}') == []
+        assert parse_osv_scanner("") == []
+
+    def test_parses_db_specific_severity(self):
+        from security_scan import parse_osv_scanner
+        out = json.dumps({"results": [{
+            "source": {"path": "package-lock.json"},
+            "packages": [{
+                "package": {"name": "lodash", "version": "4.17.0"},
+                "vulnerabilities": [{
+                    "id": "GHSA-xxxx",
+                    "database_specific": {"severity": "HIGH"},
+                }],
+            }],
+        }]})
+        findings = parse_osv_scanner(out)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f["kind"] == "sca"
+        assert f["severity"] == "high"
+        assert f["identifier"] == "GHSA-xxxx"
+        assert "lodash" in f["title"]
+
+    def test_known_vuln_without_severity_is_unknown(self):
+        from security_scan import parse_osv_scanner
+        out = json.dumps({"results": [{
+            "source": {"path": "requirements.txt"},
+            "packages": [{
+                "package": {"name": "requests", "version": "2.0.0"},
+                "vulnerabilities": [{"id": "PYSEC-1234"}],
+            }],
+        }]})
+        findings = parse_osv_scanner(out)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "unknown"
+
+    def test_malformed_raises(self):
+        from security_scan import parse_osv_scanner, SecurityScanError
+        with pytest.raises(SecurityScanError):
+            parse_osv_scanner("{oops")
+
+
+class TestParseNpmAudit:
+    def test_no_vulns(self):
+        from security_scan import parse_npm_audit
+        assert parse_npm_audit('{"vulnerabilities": {}}') == []
+
+    def test_parses_vuln_map(self):
+        from security_scan import parse_npm_audit
+        out = json.dumps({"vulnerabilities": {
+            "minimist": {"severity": "moderate", "via": ["prototype pollution"]},
+            "axios": {"severity": "high", "via": ["SSRF"]},
+        }})
+        findings = parse_npm_audit(out)
+        sev = {f["identifier"]: f["severity"] for f in findings}
+        assert sev["minimist"] == "medium"
+        assert sev["axios"] == "high"
+        assert all(f["kind"] == "sca" for f in findings)
+
+
+class TestParsePipAudit:
+    def test_no_vulns(self):
+        from security_scan import parse_pip_audit
+        assert parse_pip_audit('{"dependencies": []}') == []
+
+    def test_parses_vulns_without_severity_as_unknown(self):
+        from security_scan import parse_pip_audit
+        out = json.dumps({"dependencies": [
+            {"name": "flask", "version": "0.1", "vulns": [
+                {"id": "PYSEC-2020-1", "fix_versions": ["1.0"]}]},
+            {"name": "safe", "version": "1.0", "vulns": []},
+        ]})
+        findings = parse_pip_audit(out)
+        assert len(findings) == 1
+        assert findings[0]["identifier"] == "PYSEC-2020-1"
+        assert findings[0]["severity"] == "unknown"
+        assert findings[0]["kind"] == "sca"
+
+
+class TestParseSemgrep:
+    def test_no_results(self):
+        from security_scan import parse_semgrep
+        assert parse_semgrep('{"results": [], "errors": []}') == []
+
+    def test_parses_results_by_severity(self):
+        from security_scan import parse_semgrep
+        out = json.dumps({"results": [
+            {"check_id": "python.lang.security.audit.dangerous-exec",
+             "path": "app.py", "start": {"line": 5},
+             "extra": {"severity": "ERROR", "message": "exec is dangerous"}},
+        ], "errors": []})
+        findings = parse_semgrep(out)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f["kind"] == "sast"
+        assert f["severity"] == "high"
+        assert "app.py" in f["location"]
+        assert f["identifier"].endswith("dangerous-exec")
+
+
+class TestParseTrivyConfig:
+    def test_no_misconfig(self):
+        from security_scan import parse_trivy_config
+        assert parse_trivy_config('{"Results": []}') == []
+
+    def test_parses_misconfigurations(self):
+        from security_scan import parse_trivy_config
+        out = json.dumps({"Results": [{
+            "Target": "Dockerfile",
+            "Misconfigurations": [
+                {"ID": "DS002", "Severity": "HIGH", "Title": "root user"}],
+        }]})
+        findings = parse_trivy_config(out)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f["kind"] == "iac"
+        assert f["severity"] == "high"
+        assert f["identifier"] == "DS002"
+        assert "Dockerfile" in f["location"]
+
+
+# --- select_scanners -------------------------------------------------------
+
+class TestSelectScanners:
+    """Which scanners run is a function of project_type + has_docker + which
+    tools are actually installed. A scanner whose tool is missing is SKIPPED with
+    a reason (never silently dropped); a scanner not applicable to the project is
+    also skipped with a distinct reason."""
+
+    def _kinds(self, to_run):
+        return {(s["kind"], s["tool"]) for s in to_run}
+
+    def test_node_with_all_tools(self):
+        from security_scan import select_scanners
+        to_run, skipped = select_scanners(
+            "node", False, {"gitleaks", "osv-scanner", "semgrep"})
+        assert ("secrets", "gitleaks") in self._kinds(to_run)
+        assert ("sca", "osv-scanner") in self._kinds(to_run)
+        assert ("sast", "semgrep") in self._kinds(to_run)
+        # no docker -> iac skipped, not run
+        assert all(s["kind"] != "iac" for s in to_run)
+        assert any(s["kind"] == "iac" for s in skipped)
+
+    def test_sca_falls_back_to_npm_for_node(self):
+        from security_scan import select_scanners
+        to_run, _ = select_scanners("node", False, {"gitleaks", "npm", "semgrep"})
+        assert ("sca", "npm") in self._kinds(to_run)
+
+    def test_sca_falls_back_to_pip_audit_for_python(self):
+        from security_scan import select_scanners
+        to_run, _ = select_scanners(
+            "python", False, {"gitleaks", "pip-audit", "semgrep"})
+        assert ("sca", "pip-audit") in self._kinds(to_run)
+
+    def test_osv_preferred_over_per_language(self):
+        from security_scan import select_scanners
+        to_run, _ = select_scanners(
+            "node", False, {"osv-scanner", "npm"})
+        assert ("sca", "osv-scanner") in self._kinds(to_run)
+        assert ("sca", "npm") not in self._kinds(to_run)
+
+    def test_iac_runs_when_docker_and_trivy_present(self):
+        from security_scan import select_scanners
+        to_run, _ = select_scanners("node", True, {"trivy"})
+        assert ("iac", "trivy") in self._kinds(to_run)
+
+    def test_iac_skipped_when_docker_but_trivy_missing(self):
+        from security_scan import select_scanners
+        to_run, skipped = select_scanners("node", True, {"gitleaks"})
+        assert all(s["kind"] != "iac" for s in to_run)
+        iac_skip = [s for s in skipped if s["kind"] == "iac"]
+        assert iac_skip and "trivy" in iac_skip[0]["reason"].lower()
+
+    def test_missing_secret_tool_is_skipped_with_reason(self):
+        from security_scan import select_scanners
+        to_run, skipped = select_scanners("node", False, set())
+        assert all(s["kind"] != "secrets" for s in to_run)
+        sec = [s for s in skipped if s["kind"] == "secrets"]
+        assert sec and "gitleaks" in sec[0]["reason"].lower()
+
+    def test_no_sca_tool_at_all_is_skipped(self):
+        from security_scan import select_scanners
+        to_run, skipped = select_scanners("node", False, {"gitleaks", "semgrep"})
+        assert all(s["kind"] != "sca" for s in to_run)
+        assert any(s["kind"] == "sca" for s in skipped)
+
+
+# --- decide_gate (the fail-closed heart) -----------------------------------
+
+class TestDecideGate:
+    def _finding(self, kind="sast", severity="high", scanner="semgrep"):
+        return {"scanner": scanner, "kind": kind, "severity": severity,
+                "identifier": "X", "location": "f", "title": "t"}
+
+    def test_clean_passes(self):
+        from security_scan import decide_gate
+        g = decide_gate([], [])
+        assert g["blocked"] is False
+        assert g["blocking"] == [] and g["advisory"] == []
+
+    def test_secret_always_blocks(self):
+        from security_scan import decide_gate
+        g = decide_gate([self._finding(kind="secrets", severity="critical",
+                                        scanner="gitleaks")], [])
+        assert g["blocked"] is True
+        assert len(g["blocking"]) == 1
+
+    def test_high_blocks_medium_is_advisory(self):
+        from security_scan import decide_gate
+        g = decide_gate([
+            self._finding(kind="sca", severity="high"),
+            self._finding(kind="sca", severity="medium"),
+        ], [])
+        assert g["blocked"] is True
+        assert len(g["blocking"]) == 1
+        assert len(g["advisory"]) == 1
+
+    def test_low_is_advisory_only(self):
+        from security_scan import decide_gate
+        g = decide_gate([self._finding(kind="sast", severity="low")], [])
+        assert g["blocked"] is False
+        assert len(g["advisory"]) == 1
+
+    def test_unknown_severity_sca_blocks_conservatively(self):
+        # A known CVE with no severity rating is still a known CVE — fail closed.
+        from security_scan import decide_gate
+        g = decide_gate([self._finding(kind="sca", severity="unknown")], [])
+        assert g["blocked"] is True
+
+    def test_unknown_severity_sast_is_advisory(self):
+        # SAST/IaC unknown is not a known-vuln signal, so it stays advisory.
+        from security_scan import decide_gate
+        g = decide_gate([self._finding(kind="sast", severity="unknown")], [])
+        assert g["blocked"] is False
+
+    def test_scanner_error_blocks_even_with_no_findings(self):
+        # An installed scanner that produced unparseable output must not be read
+        # as "clean" — fail closed.
+        from security_scan import decide_gate
+        g = decide_gate([], [{"scanner": "semgrep", "message": "boom"}])
+        assert g["blocked"] is True
+        assert g["errors"]
+
+    def test_block_severities_override_demotes_high(self):
+        from security_scan import decide_gate
+        g = decide_gate([self._finding(kind="sca", severity="high")], [],
+                        block_severities=("critical",))
+        assert g["blocked"] is False
+        assert len(g["advisory"]) == 1
+
+    def test_block_severities_are_a_threshold_not_exact_membership(self):
+        # Finding #3: a lower configured severity must block that level AND ABOVE,
+        # so setting "medium" can never accidentally make high/critical advisory.
+        from security_scan import decide_gate
+        g = decide_gate([
+            self._finding(kind="sast", severity="high"),
+            self._finding(kind="sast", severity="critical"),
+        ], [], block_severities=("medium",))
+        assert g["blocked"] is True
+        assert len(g["blocking"]) == 2
+
+    def test_garbage_block_severities_fall_back_to_failclosed_default(self):
+        # An unrecognized/empty config must NOT disable blocking (fail-closed).
+        from security_scan import decide_gate
+        g = decide_gate([self._finding(kind="sca", severity="high")], [],
+                        block_severities=("nonsense",))
+        assert g["blocked"] is True
+
+    def test_mixed_garbage_block_severities_fails_closed(self):
+        # A TYPO in one token ("hgih") must not silently relax the gate to the
+        # remaining (stricter-looking) token — the whole override is invalid, so
+        # fall back to the fail-closed default. Otherwise a fat-finger downgrades
+        # High to advisory.
+        from security_scan import decide_gate
+        g = decide_gate([self._finding(kind="sast", severity="high")], [],
+                        block_severities=("critical", "hgih"))
+        assert g["blocked"] is True
+
+
+# --- run_scan orchestration (dependency-injected, no real tools) -----------
+
+class TestRunScanOrchestration:
+    def test_runs_selected_scanners_and_aggregates(self):
+        from security_scan import run_scan
+        gitleaks_out = json.dumps([
+            {"RuleID": "aws", "File": "a.py", "StartLine": 1, "Description": "x"}])
+        osv_out = json.dumps({"results": [{
+            "source": {"path": "package-lock.json"},
+            "packages": [{"package": {"name": "lodash", "version": "1"},
+                          "vulnerabilities": [{"id": "G1",
+                              "database_specific": {"severity": "HIGH"}}]}]}]})
+        semgrep_out = json.dumps({"results": [], "errors": []})
+        runner = _fake_runner_from({
+            "gitleaks": _proc(1, gitleaks_out),  # rc=1 means leaks found, not error
+            "osv-scanner": _proc(1, osv_out),
+            "semgrep": _proc(0, semgrep_out),
+        })
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            base_ref="origin/main",
+            which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+            runner=runner, env={})
+        assert result["gate"]["blocked"] is True
+        kinds = {f["kind"] for f in result["findings"]}
+        assert {"secrets", "sca"} <= kinds
+        # semgrep ran but found nothing -> no sast finding, but it's not skipped
+        assert all(s["kind"] != "sast" for s in result["skipped"])
+
+    def test_missing_tool_is_visible_skip_not_block(self):
+        from security_scan import run_scan
+        runner = _fake_runner_from({})
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from(set()),  # nothing installed
+            runner=runner, env={})
+        # nothing could run, but that is NOT a block — it is surfaced as skips
+        assert result["gate"]["blocked"] is False
+        assert result["skipped"]
+        assert runner.calls == []  # never invoked a missing tool
+
+    def test_unparseable_scanner_output_fails_closed(self):
+        from security_scan import run_scan
+        runner = _fake_runner_from({
+            "gitleaks": _proc(2, "<<garbage not json>>", stderr="crashed"),
+            "osv-scanner": _proc(0, '{"results": []}'),
+            "semgrep": _proc(0, '{"results": [], "errors": []}'),
+        })
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+            runner=runner, env={})
+        assert result["gate"]["blocked"] is True
+        assert any(e["scanner"] == "gitleaks" for e in result["gate"]["errors"])
+
+    def test_pip_audit_targets_requirements_files(self, tmp_path):
+        # Finding #1: pip-audit with no target audits the AMBIENT env, missing the
+        # project's pinned deps. It must be pointed at the project's requirements.
+        from security_scan import run_scan
+        (tmp_path / "requirements.txt").write_text("flask==0.1\n")
+        runner = _fake_runner_from({
+            "gitleaks": _proc(0, "[]"),
+            "pip-audit": _proc(0, '{"dependencies": []}'),
+            "semgrep": _proc(0, '{"results": [], "errors": []}')})
+        run_scan(str(tmp_path), project_type="python", has_docker=False,
+                 which=_which_from({"gitleaks", "pip-audit", "semgrep"}),  # no osv -> fallback
+                 runner=runner, env={})
+        pip_cmd = next(c for c in runner.calls if c[0] == "pip-audit")
+        assert "-r" in pip_cmd
+        assert any(str(tmp_path) in str(part) for part in pip_cmd)
+
+    def test_pip_audit_skips_when_no_requirements_file(self, tmp_path):
+        # No requirements file -> pip-audit must NOT run against the ambient env;
+        # it's a visible skip instead.
+        from security_scan import run_scan
+        runner = _fake_runner_from({
+            "gitleaks": _proc(0, "[]"),
+            "semgrep": _proc(0, '{"results": [], "errors": []}')})
+        result = run_scan(
+            str(tmp_path), project_type="python", has_docker=False,
+            which=_which_from({"gitleaks", "pip-audit", "semgrep"}),
+            runner=runner, env={})
+        assert all(c[0] != "pip-audit" for c in runner.calls)
+        assert any(s["kind"] == "sca" for s in result["skipped"])
+
+    def test_abnormal_rc_with_findings_still_fails_closed(self):
+        # Finding #2: a scanner that exits abnormally AFTER producing a finding
+        # ran incompletely — fail closed even though `produced` is True.
+        from security_scan import run_scan
+        semgrep_out = json.dumps({"results": [
+            {"check_id": "x", "path": "a.py", "start": {"line": 1},
+             "extra": {"severity": "INFO", "message": "m"}}], "errors": []})
+        runner = _fake_runner_from({
+            "gitleaks": _proc(0, "[]"),
+            "osv-scanner": _proc(0, '{"results": []}'),
+            "semgrep": _proc(2, semgrep_out)})  # rc=2 not in {0} -> incomplete
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+            runner=runner, env={})
+        assert result["gate"]["blocked"] is True
+        assert any(e["scanner"] == "semgrep" for e in result["gate"]["errors"])
+
+    def test_benign_skip_only_applies_to_sca(self):
+        # Finding #4: a non-SCA scanner failing with "no packages found" in stderr
+        # must NOT be misread as a benign skip — only SCA has that benign case.
+        from security_scan import run_scan
+        runner = _fake_runner_from({
+            "gitleaks": _proc(2, "", stderr="no packages found"),
+            "osv-scanner": _proc(0, '{"results": []}'),
+            "semgrep": _proc(0, '{"results": [], "errors": []}')})
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+            runner=runner, env={})
+        assert result["gate"]["blocked"] is True
+        assert any(e["scanner"] == "gitleaks" for e in result["gate"]["errors"])
+        assert not any(s["kind"] == "secrets" for s in result["skipped"])
+
+    def test_npm_error_envelope_fails_closed(self):
+        # npm audit emits {"error": {...}} (no "vulnerabilities") on failure AND
+        # exits 1 — the SAME code as "vulns found" — so the exit code can't catch
+        # it. The parser must treat the error envelope as a fail-closed error,
+        # never as "no vulnerabilities".
+        from security_scan import run_scan
+        runner = _fake_runner_from({
+            "gitleaks": _proc(0, "[]"),
+            "npm": _proc(1, '{"error": {"code": "ENOLOCK", "summary": "no lockfile"}}'),
+            "semgrep": _proc(0, '{"results": [], "errors": []}'),
+        })
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from({"gitleaks", "npm", "semgrep"}),
+            runner=runner, env={})
+        assert result["gate"]["blocked"] is True
+        assert any(e["scanner"] == "npm" for e in result["gate"]["errors"])
+
+    def test_abnormal_exit_no_findings_fails_closed(self):
+        # A scanner that exits with an unexpected code and produced NO findings
+        # may have failed to run — do not read it as clean.
+        from security_scan import run_scan
+        runner = _fake_runner_from({
+            "gitleaks": _proc(2, "", stderr="fatal: bad revision"),  # rc 2 = error
+            "osv-scanner": _proc(0, '{"results": []}'),
+            "semgrep": _proc(0, '{"results": [], "errors": []}'),
+        })
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+            runner=runner, env={})
+        assert result["gate"]["blocked"] is True
+        assert any(e["scanner"] == "gitleaks" for e in result["gate"]["errors"])
+
+    def test_benign_nothing_to_scan_is_skip_not_error(self):
+        # osv-scanner exits nonzero with "No package sources found" on a project
+        # with no lockfiles — that is "nothing to scan", NOT a failure. It must be
+        # a skip (visible, non-blocking), not a fail-closed error.
+        from security_scan import run_scan
+        runner = _fake_runner_from({
+            "gitleaks": _proc(0, "[]"),
+            "osv-scanner": _proc(128, "", stderr="No package sources found, --recursive may help"),
+            "semgrep": _proc(0, '{"results": [], "errors": []}'),
+        })
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+            runner=runner, env={})
+        assert result["gate"]["blocked"] is False
+        assert not result["gate"]["errors"]
+        assert any(s["kind"] == "sca" for s in result["skipped"])
+
+    def test_findings_indicated_rc_but_none_parsed_fails_closed(self):
+        # osv-scanner exits 1 ("vulnerabilities found") but the parser extracted
+        # ZERO — schema drift or an error envelope masking real findings. The
+        # tool said "I found things"; parsing nothing must fail closed, not pass.
+        from security_scan import run_scan
+        runner = _fake_runner_from({
+            "gitleaks": _proc(0, "[]"),
+            "osv-scanner": _proc(1, '{"results": []}'),  # rc=1 vs 0 findings
+            "semgrep": _proc(0, '{"results": [], "errors": []}')})
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+            runner=runner, env={})
+        assert result["gate"]["blocked"] is True
+        assert any(e["scanner"] == "osv-scanner" for e in result["gate"]["errors"])
+
+    def test_findings_indicated_rc_with_findings_is_ok(self):
+        # The consistency check must NOT misfire when rc=1 DOES come with findings.
+        from security_scan import run_scan
+        osv_out = json.dumps({"results": [{
+            "source": {"path": "package-lock.json"},
+            "packages": [{"package": {"name": "p", "version": "1"},
+                          "vulnerabilities": [{"id": "G",
+                              "database_specific": {"severity": "HIGH"}}]}]}]})
+        runner = _fake_runner_from({
+            "gitleaks": _proc(0, "[]"),
+            "osv-scanner": _proc(1, osv_out),
+            "semgrep": _proc(0, '{"results": [], "errors": []}')})
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+            runner=runner, env={})
+        assert not result["gate"]["errors"]
+        assert result["gate"]["blocked"] is True  # the high SCA finding blocks
+
+    def test_valid_json_but_wrong_shape_fails_closed_not_crash(self):
+        # A scanner that emits valid JSON of an UNEXPECTED shape (here a gitleaks
+        # array whose element is a string, not an object) must be recorded as a
+        # fail-closed error, NOT crash run_scan with an AttributeError/TypeError.
+        from security_scan import run_scan
+        runner = _fake_runner_from({
+            "gitleaks": _proc(1, '["not-an-object"]'),
+            "osv-scanner": _proc(0, '{"results": []}'),
+            "semgrep": _proc(0, '{"results": [], "errors": []}'),
+        })
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+            runner=runner, env={})
+        assert result["gate"]["blocked"] is True
+        assert any(e["scanner"] == "gitleaks" for e in result["gate"]["errors"])
+
+    def test_env_block_severity_override(self):
+        from security_scan import run_scan
+        osv_out = json.dumps({"results": [{
+            "source": {"path": "package-lock.json"},
+            "packages": [{"package": {"name": "p", "version": "1"},
+                          "vulnerabilities": [{"id": "G",
+                              "database_specific": {"severity": "HIGH"}}]}]}]})
+        runner = _fake_runner_from({
+            "gitleaks": _proc(0, "[]"),
+            "osv-scanner": _proc(1, osv_out),
+            "semgrep": _proc(0, '{"results": [], "errors": []}'),
+        })
+        result = run_scan(
+            "/proj", project_type="node", has_docker=False,
+            which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+            runner=runner,
+            env={"RAWGENTIC_SECURITY_BLOCK_SEVERITIES": "critical"})
+        # high demoted to advisory by the env override
+        assert result["gate"]["blocked"] is False
+        assert any(f["severity"] == "high" for f in result["gate"]["advisory"])
+
+    def test_gitleaks_invoked_with_diff_scope(self):
+        from security_scan import run_scan
+        runner = _fake_runner_from({"gitleaks": _proc(0, "[]")})
+        run_scan("/proj", project_type="unknown", has_docker=False,
+                 base_ref="origin/develop",
+                 which=_which_from({"gitleaks"}), runner=runner, env={})
+        gitleaks_cmd = next(c for c in runner.calls if c[0] == "gitleaks")
+        joined = " ".join(gitleaks_cmd)
+        assert "origin/develop..HEAD" in joined
+        assert "git" in gitleaks_cmd  # diff mode uses the `git` subcommand
+
+    def test_full_mode_scans_whole_tree_not_diff(self):
+        # WF9 audits the entire codebase, not a branch diff: gitleaks scans the
+        # working tree (`dir`) and semgrep drops its baseline so it reports all
+        # findings, not only new ones.
+        from security_scan import run_scan
+        runner = _fake_runner_from({
+            "gitleaks": _proc(0, "[]"),
+            "semgrep": _proc(0, '{"results": [], "errors": []}'),
+        })
+        run_scan("/proj", project_type="unknown", has_docker=False,
+                 base_ref="origin/main", full=True,
+                 which=_which_from({"gitleaks", "semgrep"}),
+                 runner=runner, env={})
+        gitleaks_cmd = next(c for c in runner.calls if c[0] == "gitleaks")
+        assert "dir" in gitleaks_cmd and "--log-opts" not in gitleaks_cmd
+        semgrep_cmd = next(c for c in runner.calls if c[0] == "semgrep")
+        assert "--baseline-commit" not in semgrep_cmd
+
+
+# --- CLI -------------------------------------------------------------------
+
+class TestCli:
+    def _run(self, *args, timeout=30):
+        import subprocess
+        r = subprocess.run(["python3", str(SCAN_CLI), *args],
+                           capture_output=True, text=True, timeout=timeout)
+        return r.stdout, r.stderr, r.returncode
+
+    def test_cli_exit_zero_when_gate_passes(self, monkeypatch):
+        import security_scan
+        monkeypatch.setattr(security_scan, "run_scan", lambda *a, **k: {
+            "findings": [], "skipped": [{"kind": "sast", "reason": "no semgrep"}],
+            "gate": {"blocked": False, "blocking": [], "advisory": [], "errors": []},
+        })
+        rc = security_scan.main(
+            ["scan", "--project-root", "/p", "--project-type", "node", "--json"])
+        assert rc == 0
+
+    def test_cli_exit_one_when_blocked(self, monkeypatch):
+        import security_scan
+        monkeypatch.setattr(security_scan, "run_scan", lambda *a, **k: {
+            "findings": [{"kind": "secrets", "severity": "critical",
+                          "scanner": "gitleaks", "identifier": "x",
+                          "location": "f", "title": "t"}],
+            "skipped": [],
+            "gate": {"blocked": True, "blocking": [{"kind": "secrets"}],
+                     "advisory": [], "errors": []},
+        })
+        rc = security_scan.main(
+            ["scan", "--project-root", "/p", "--project-type", "node", "--json"])
+        assert rc == 1
+
+    def test_cli_json_shape(self, monkeypatch, capsys):
+        import security_scan
+        monkeypatch.setattr(security_scan, "run_scan", lambda *a, **k: {
+            "findings": [], "skipped": [],
+            "gate": {"blocked": False, "blocking": [], "advisory": [], "errors": []},
+        })
+        security_scan.main(
+            ["scan", "--project-root", "/p", "--project-type", "node", "--json"])
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert set(data) >= {"findings", "skipped", "gate"}
+
+    def test_cli_requires_subcommand(self):
+        _, _, rc = self._run()
+        assert rc == 2  # argparse usage error
+
+
+# --- real-tool smoke (skips when scanners absent, e.g. CI) -----------------
+
+class TestRealToolSmoke:
+    """Exercises run_scan against the real repo with whatever scanners happen to
+    be installed. Skips entirely in a bare environment (CI installs none), so it
+    never flakes — it only adds signal locally where the tools exist."""
+
+    def test_scan_repo_does_not_crash(self):
+        import shutil
+        from security_scan import run_scan
+        if not shutil.which("gitleaks"):
+            pytest.skip("no scanners installed")
+        repo = str(Path(__file__).resolve().parent.parent.parent)
+        result = run_scan(repo, project_type="python", has_docker=False,
+                          base_ref="HEAD")  # empty diff -> no new secrets
+        assert set(result) >= {"findings", "skipped", "gate"}
+        assert isinstance(result["gate"]["blocked"], bool)
+
+
+# --- wiring drift guards ---------------------------------------------------
+
+REPO_ROOT = HOOKS_DIR.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+INSTALLER = REPO_ROOT / "scripts" / "install-scanners.sh"
+
+
+class TestWF2Wiring:
+    """WF2 Step 11.5 must invoke the shared lib as a real pre-PR gate."""
+
+    def _text(self):
+        return (SKILLS_DIR / "implement-feature" / "SKILL.md").read_text()
+
+    def test_step_11_5_exists_and_invokes_lib(self):
+        t = self._text()
+        assert "## Step 11.5" in t
+        assert "hooks/security_scan.py" in t
+        # positioned before Step 12 (the PR step), i.e. a true pre-PR gate
+        assert t.index("## Step 11.5") < t.index("## Step 12:")
+
+    def test_step_11_5_reads_gate_and_handles_secrets(self):
+        t = self._text()
+        assert "gate.blocking" in t
+        assert "rotat" in t.lower()  # real secret -> must be rotated, not just deleted
+
+    def test_completion_gate_includes_security_scan(self):
+        t = self._text()
+        gate = t[t.index("<completion-gate>"):t.index("</completion-gate>")]
+        assert "Security scan" in gate and "11.5" in gate
+
+
+class TestWF9Wiring:
+    """WF9 must reuse the SAME lib (full mode) and the stale Serena ref is gone."""
+
+    def _text(self):
+        return (SKILLS_DIR / "security-audit" / "SKILL.md").read_text()
+
+    def test_wf9_invokes_shared_lib_full_mode(self):
+        t = self._text()
+        assert "hooks/security_scan.py" in t
+        assert "--full" in t
+
+    def test_stale_serena_reference_removed(self):
+        assert "Serena" not in self._text()
+
+
+class TestSetupWiring:
+    """Setup Step 2e installs the scanners by default (opt-out, not opt-in)."""
+
+    def _text(self):
+        return (SKILLS_DIR / "setup" / "SKILL.md").read_text()
+
+    def test_step_2e_exists_and_runs_installer(self):
+        t = self._text()
+        assert "## Step 2e" in t
+        assert "install-scanners.sh" in t
+
+    def test_step_2e_is_opt_out(self):
+        t = self._text()
+        low = t.lower()
+        assert "opt-out" in low or "opt out" in low
+        assert "installScanners" in t  # the persisted decline flag
+
+
+class TestInstallerScript:
+    """The installer is idempotent, opt-out-aware, and covers every scanner."""
+
+    def test_exists_and_executable(self):
+        assert INSTALLER.exists()
+        assert os.access(INSTALLER, os.X_OK), "install-scanners.sh must be +x"
+
+    def test_lists_all_scanners(self):
+        t = INSTALLER.read_text()
+        for tool in ("gitleaks", "semgrep", "osv-scanner", "trivy", "pip-audit"):
+            assert tool in t, f"installer must handle {tool}"
+
+    def test_opt_out_env_is_honored(self):
+        import subprocess
+        r = subprocess.run(
+            ["bash", str(INSTALLER)],
+            env={**os.environ, "RAWGENTIC_SKIP_SCANNER_INSTALL": "1"},
+            capture_output=True, text=True, timeout=30)
+        assert r.returncode == 0
+        assert "opted out" in r.stdout.lower()
+
+    def test_check_mode_reports_presence(self):
+        import subprocess
+        r = subprocess.run(["bash", str(INSTALLER), "--check"],
+                           capture_output=True, text=True, timeout=30)
+        # exit 0 iff all present, 1 if any missing; either way it reports lines
+        assert r.returncode in (0, 1)
+        assert "gitleaks" in r.stdout
+
+
+class TestSessionStartBootstrap:
+    """The session-start bootstrap is startup-only, opt-out, and run-once."""
+
+    def _text(self):
+        return (HOOKS_DIR / "session-start").read_text()
+
+    def test_bootstrap_section_present(self):
+        t = self._text()
+        assert "_do_scanner_bootstrap" in t
+        assert "install-scanners.sh" in t
+
+    def test_bootstrap_is_opt_out_and_guarded(self):
+        t = self._text()
+        assert "RAWGENTIC_SKIP_SCANNER_INSTALL" in t
+        assert "installScanners" in t
+        assert "scanners-bootstrapped" in t  # run-once marker
+        # must not block the hook: fire-and-forget
+        assert "nohup" in t


### PR DESCRIPTION
## Summary

Adds a **tool-based security/vulnerability scan** to the rawgentic workflows. WF2 (implement-feature) gains a pre-PR **Step 11.5**; WF9 (security-audit) is refreshed to reuse the **same** lib. Both call one tested, fail-closed `hooks/security_scan.py` so the actual scanning lives in a single place instead of being re-derived in each workflow's prose. This *complements* the existing LLM security review (WF2 Step 11 Agent 3; WF9 STRIDE) — scanners catch concrete known-pattern issues those can't, and the gate never claims "secure," only "no known-pattern issue."

Closes the gap identified in discussion: WF2/WF9 had security *reasoning* but **no tool-based secret/CVE/SAST/IaC scan**.

## Scanners (each gated on `capabilities` AND tool presence)

| Kind | Tool | Notes |
|------|------|-------|
| secrets | gitleaks | diff-scoped (`git … --log-opts base..HEAD`) in WF2; whole tree (`dir`) in WF9 `--full` |
| SCA | osv-scanner → npm audit / pip-audit | osv preferred (all ecosystems); per-language fallback |
| SAST | semgrep `p/ci` | diff-scoped (`--baseline-commit`) / whole-tree in `--full` |
| IaC | trivy config | Docker projects only (`capabilities.has_docker`) |

## Fail-closed gate

- Leaked secret **always** blocks. Findings at/above the threshold block; the threshold (`RAWGENTIC_SECURITY_BLOCK_SEVERITIES`, default `critical,high`) is a *threshold* — a lower value only makes it stricter, and an invalid value rejects the whole override (fail-closed default + stderr warning).
- A known CVE with no severity rating blocks. A parse failure, an npm `{"error"}` envelope, a findings-indicated exit code that yields zero parsed findings, or any unexpected exit code all **fail closed**.
- A **missing tool is a visible skip**, never a silent pass; a SCA scanner with no package sources is a benign skip.

## Wiring

- **WF2 implement-feature**: Step 11.5 (between review and PR) + PR-body Quality-Gate line + Step 16 summary + completion-gate item.
- **WF9 security-audit**: Steps 2/8 reuse the lib (`--full`); stale "Serena MCP" reference removed.
- **Install (opt-OUT, never opt-in)**: `scripts/install-scanners.sh` (idempotent, best-effort, `--check`). setup **Step 2e** installs by default; the session-start hook installs once in the background on first plugin use. Opt out via `RAWGENTIC_SKIP_SCANNER_INSTALL=1` or `"installScanners": false`.

## Verification

- **991 passed, 3 skipped** (~90 new tests incl. drift guards for every wiring point). TDD throughout.
- **Real-validated against live tools**: gitleaks caught planted GitHub/Slack tokens (diff + full); osv-scanner found 19 real CVEs (GHSA→high, PYSEC→unknown-blocks); trivy flagged real Dockerfile misconfigs.
- **Cross-model adversarial review (Codex)**: converged after three rounds of fixed fail-open findings (parser-crash → fail-closed; npm error envelope; abnormal-exit; benign-skip scoping; severity threshold semantics; findings-indicated-rc consistency).
- New docs: `docs/security-scan.md`. Plugin **v2.32.0**.

## Quality Gate Summary
- Cross-model adversarial review (Codex): CONVERGED (3 rounds, ~8 fail-open defects fixed pre-merge)
- Real-tool validation: secrets / SCA / SAST / IaC all confirmed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Folded-in follow-up: make the jsonschema tests load-bearing
CI now installs `jsonschema` so the 3 `test_adversarial_review_schema.py` tests run instead of perpetually skipping. Doing so surfaced (and this PR fixes) a latent test-helper bug — `_finding()` omitted the `ambiguity_flag`/`ambiguity_reason` fields that `FINDINGS_SCHEMA` requires-but-nullable for OpenAI strict structured-output (#80). The schema was correct; the helper was stale.