### PR TITLE
feat(implement-feature): WF2 Step 16 run-record + completion summary (work_summary.py)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the Tier-1 metrics smoke test
+          # (tests/test_wf2_impact_metrics.py::TestCollectSmoke) can resolve the
+          # historic effort commit range; a shallow checkout makes it skip.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -513,6 +513,20 @@ runs are unchanged unless explicitly opted in via `adversarialReview` in
 (`curl -fsSL https://codex.openai.com/install.sh | bash`) and authenticated
 (`codex login`). See [config-reference.md](docs/config-reference.md#adversarial-review-data-handling).
 
+### Run-Record Telemetry (Tier-2 substrate)
+
+WF2 Step 16 no longer hand-types its completion summary. Instead it assembles a
+structured **run-record** — issue/type, change volume, tests, each quality gate's
+*findings caught vs resolved*, the Step 11.5 security-scan status, loop-backs, and
+the PR/CI/deploy outcome — and drives `hooks/work_summary.py`, which renders the
+standardized "WF2 COMPLETE" block **and** appends the record as one JSON line to
+`<project>/docs/measurements/run_records.jsonl` (override via `--store` or
+`RAWGENTIC_RUN_RECORD_STORE`). Accumulated across runs the store is the telemetry
+substrate the Tier-2 A/B measurement harness aggregates. The store is
+**fail-closed** (a record failing validation is never persisted) while the human
+summary renders best-effort (a schema nit never costs the user their Step 16
+output). See [run-records.md](docs/run-records.md).
+
 ### Shared Invariants
 
 1. **Config-loading protocol** — All workflow skills read `.rawgentic.json` before executing
@@ -573,6 +587,7 @@ The `docs/` directory contains detailed design documentation for contributors:
   - [Security Guard](docs/plans/2026-03-07-security-guard-design.md)
   - [Multi-Project Concurrent Sessions](docs/plans/2026-03-07-multi-project-sessions-design.md)
   - [Dual Memory Backend (draft)](docs/superpowers/specs/2026-04-08-dual-memory-backend-design.md)
+- **[Run-Records](docs/run-records.md)** — Per-run structured run-record schema + store + the `work_summary.py` CLI (WF2 Step 16; Tier-2 telemetry substrate)
 - **[Testing](docs/testing.md)** — Test suite overview, hook test descriptions, skill evaluation methodology
 - **Diagrams** (in `diagrams/`): Excalidraw visual diagrams for each workflow and the framework architecture
 

--- a/docs/consolidation.md
+++ b/docs/consolidation.md
@@ -474,6 +474,6 @@ The architecture diagram shows:
 
 1. **Skill file format:** Should all 9 workflow skills use the same skill file template (header, instructions, step loop), or should each be fully custom?
 2. **Shared step functions:** Should common operations (branch creation, PR creation, deploy) be extracted into a shared utility skill that other skills call?
-3. **Workflow telemetry:** Should workflow runs be logged to a structured file (JSON) for later analysis of time-per-step, token cost, escalation frequency?
+3. **Workflow telemetry:** Should workflow runs be logged to a structured file (JSON) for later analysis of time-per-step, token cost, escalation frequency? — **Answered (v2.33.0):** WF2 Step 16 now emits a structured per-run **run-record** (issue/type, change volume, tests, per-gate findings caught vs resolved, Step 11.5 security status, loop-backs, PR/CI/deploy outcome) appended to `<project>/docs/measurements/run_records.jsonl` via `hooks/work_summary.py` — the Tier-2 measurement telemetry substrate. See [run-records.md](run-records.md).
 4. **CI integration:** Should the GitHub Actions workflow (`test.yml`) be extended with workflow-specific test suites (e.g., security-specific tests for WF9)?
 5. **Tooling audits:** Should WF3-WF11 get individual tooling audits (like WF1/WF2), or is the consolidated tooling summary (Section 12) sufficient for implementation specs?

--- a/docs/run-records.md
+++ b/docs/run-records.md
@@ -1,0 +1,98 @@
+# Run-Records & Completion Summary (`hooks/work_summary.py`)
+
+The shared lib used by **WF2 Step 16** (Workflow Completion Summary) to do two
+jobs from one validated record:
+
+1. **Render the completion summary** — the standardized "WF2 COMPLETE" block the
+   skill used to hand-type. Rendering it from a structured record means its shape
+   no longer drifts run to run.
+2. **Emit a run-record** — one structured JSON line appended to a JSONL store
+   capturing what the run actually did: issue/type, change volume, tests, each
+   quality gate's *findings caught vs resolved*, the Step 11.5 security-scan
+   status, loop-backs, and the PR/CI/deploy outcome.
+
+Accumulated across runs, the store is the **Tier-2 measurement telemetry
+substrate**. The [Tier-1 impact report](measurements/2026-06-15-wf2-extraction-impact.md)
+proves reliability/consistency/maintainability from tests + git without running
+the workflow; Tier-2 (speed and output-quality) needs end-to-end A/B runs over a
+fixed corpus, and *those* runs are what each run-record measures. A gate's
+effectiveness ("how often does the design critique actually catch something")
+becomes a query over the store instead of a sentence the user reads once.
+
+## The run-record schema (v1)
+
+`schema_version` and `generated_at` are stamped by the tool; everything else is
+supplied by the workflow. Counts are non-negative integers; `resolved` may not
+exceed `findings`, `passing` may not exceed `total`, `used` may not exceed
+`budget`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `workflow` | string | e.g. `implement-feature` (renders as `WF2`), `fix-bug` (`WF3`). |
+| `workflow_version` | string | The `.claude-plugin/plugin.json` version — lets Tier-2 compare runs across skill versions. |
+| `issue` | object | `number` (int\|null), `type` (`feature`/`bug`/`chore`/`other`), `complexity` (`trivial`/`standard`/`complex`\|null). |
+| `changes` | object | `files_changed`, `commits` (ints); `insertions`, `deletions` (int\|null). |
+| `tests` | object | `added` (int); `passing`, `total` (int\|null). |
+| `gates` | array | Each `{step, name, findings, resolved, status}`; `status` ∈ `pass`/`fail`/`skipped`/`fast_path`. Step 11.5 is captured in `security_scan`, not here. |
+| `security_scan` | object | `ran` (bool), `blocking_resolved`, `advisory` (ints), `skipped` (list of strings). Mirrors the [Step 11.5 gate](security-scan.md). |
+| `loop_backs` | object | `used`, `budget` (ints). |
+| `outcome` | object | `pr_number` (int\|null), `pr_url` (string\|null), `merged` (bool\|null), `ci` (`passed`/`failed`/`not_configured`/`skipped`), `deploy` (`success`/`manual`/`failed`/`not_applicable`). |
+| `follow_ups` | array | Optional list of strings; defaults to `[]`. |
+
+Every documented key must be **present**; "nullable" means `null` is an allowed
+*value*, not that the key may be omitted — a dropped field is a telemetry gap (the
+aggregation can't tell it from a deliberate null), so it fails validation.
+
+Validation is hand-rolled (no runtime `jsonschema` dependency) and adversarially
+unit-tested — notably it rejects `bool` where an int is expected, since `bool` is
+a subclass of `int` in Python and a naive check would let `findings: true`
+corrupt the substrate.
+
+## The store
+
+One JSON line per run, appended to:
+
+```
+<project-root>/docs/measurements/run_records.jsonl
+```
+
+Override with `--store <path>` or the `RAWGENTIC_RUN_RECORD_STORE` env var (env
+is configurable from v1). The default is committed and per-project, so the
+telemetry is versioned and reproducible alongside the code it measures.
+
+## Fail-closed for the store, best-effort for the human
+
+- **Fail closed on the store.** A record that fails validation is **never**
+  persisted — the substrate stays pristine and a downstream aggregation can trust
+  every line.
+- **Best-effort for the summary.** `render_summary` never raises; even a record
+  that failed validation (or is partial) still produces the "WF2 COMPLETE" block,
+  so a telemetry-schema nit never denies the user their Step 16 output.
+- The CLI signals the difference via its exit code, so the skill can react.
+
+## CLI
+
+```bash
+python3 hooks/work_summary.py summarize \
+  --record-file /tmp/wf2-run-record.json \
+  --project-root <activeProject.path> \
+  [--store <path>] [--json] [--no-persist]
+```
+
+stdout is the completion summary (or, with `--json`, the normalized record).
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Record valid: summary rendered and (unless `--no-persist`) appended to the store. |
+| `1` | Record invalid: summary still rendered, errors on stderr, record **not** persisted. The skill records the telemetry gap. |
+| `2` | Usage error or unreadable/non-JSON record file. |
+
+## How WF2 wires it (Step 16)
+
+The skill assembles the run-record from the data gathered across the workflow,
+writes it to `/tmp/wf2-run-record.json`, and shells out to the CLI. The tool's
+stdout **is** the completion summary, so the skill presents it as-is rather than
+re-typing it. A drift-guard test
+(`tests/hooks/test_work_summary.py::TestWorkSummarySkillWiring`) asserts the skill
+keeps invoking `work_summary.py summarize`, so the wiring can't silently rot.

--- a/hooks/work_summary.py
+++ b/hooks/work_summary.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""WF completion summary + per-run structured run-record (Tier-2 telemetry).
+
+WF2 (implement-feature) Step 16 used to hand-type a free-text completion summary,
+which means its shape drifted run-to-run and nothing about the run was captured
+for later analysis. This lib does two jobs from one validated record:
+
+1. **render_summary** — deterministically renders the SAME human "WF COMPLETE"
+   block the skill used to type by hand, so Step 16 output is consistent.
+2. **the run-record** — a structured JSON line (issue/type, changes, tests,
+   per-gate findings *caught vs resolved*, Step 11.5 security-scan status,
+   loop-backs, PR/CI/deploy outcome) appended to a store. Accumulated across
+   ~100 runs this is the substrate the Tier-2 A/B harness aggregates to measure
+   the agentic workflow's effectiveness (docs/measurements names it explicitly).
+
+Design mirrors hooks/security_scan.py: the logic is PURE functions
+(validate_record, normalize_record, render_summary) carrying all behavior and
+exhaustively unit-tested; the I/O is thin/injected (the clock is passed into
+normalize_record; the store path resolves from flag>env>default). The store is
+env-configurable from v1 via RAWGENTIC_RUN_RECORD_STORE; the default is
+<project-root>/docs/measurements/run_records.jsonl (committed, reproducible).
+
+Failure philosophy: fail-closed for the STORE (a record that fails validation is
+never persisted — the telemetry substrate stays pristine), but render the human
+summary best-effort regardless, so a malformed-record bug never denies the user
+their Step 16 output. main() exits 1 in that case so the skill surfaces the gap.
+"""
+import argparse
+import copy
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+# The store accumulates one JSON line per workflow run. Env-overridable from v1;
+# default is the project's committed measurements dir (reproducible telemetry).
+STORE_ENV = "RAWGENTIC_RUN_RECORD_STORE"
+DEFAULT_STORE_RELPATH = ("docs", "measurements", "run_records.jsonl")
+
+# Required top-level fields. follow_ups is optional (defaults to []).
+REQUIRED_TOP = ("workflow", "workflow_version", "issue", "changes", "tests",
+                "gates", "security_scan", "loop_backs", "outcome")
+
+ISSUE_TYPES = {"feature", "bug", "chore", "other"}
+COMPLEXITIES = {"trivial", "standard", "complex"}  # None also allowed
+GATE_STATUSES = {"pass", "fail", "skipped", "fast_path"}
+CI_STATUSES = {"passed", "failed", "not_configured", "skipped"}
+DEPLOY_STATUSES = {"success", "manual", "failed", "not_applicable"}
+
+# Human-summary header label per workflow; falls back to the upper-cased name.
+_WF_LABELS = {"implement-feature": "WF2", "fix-bug": "WF3"}
+
+
+class WorkSummaryError(ValueError):
+    """A run-record file could not be read or parsed. Surfaced as a usage error
+    (the skill must supply a readable JSON record), never a silent empty run."""
+
+
+def _is_int(x) -> bool:
+    """True only for a real int. bool is a subclass of int in Python, so a naive
+    isinstance(x, int) would accept `findings: true` and corrupt the substrate —
+    reject bool explicitly."""
+    return isinstance(x, int) and not isinstance(x, bool)
+
+
+def _is_str(x) -> bool:
+    return isinstance(x, str)
+
+
+def _as_dict(x) -> dict:
+    """Coerce to a dict for best-effort rendering. render_summary runs on
+    UNVALIDATED records (main's rc=1 path), so a wrong-typed section (a string or
+    list where an object is expected) must degrade to {} rather than raise."""
+    return x if isinstance(x, dict) else {}
+
+
+def _as_list(x) -> list:
+    """Coerce to a list for best-effort rendering — a non-list (incl. a string,
+    which is iterable but not the intended shape) degrades to [] rather than
+    iterating its characters or raising."""
+    return x if isinstance(x, list) else []
+
+
+def _require_present(obj, section, keys, errs) -> None:
+    """Append an error for any of `keys` ABSENT from obj. A *nullable* field means
+    `null` is an allowed VALUE, not that the key may be omitted — tolerating
+    absence would let a producer silently drop a field, making the Tier-2
+    substrate unable to tell a deliberate null from a dropped one. (Non-nullable
+    keys are already required implicitly: their value check fails on the None that
+    `.get` returns for an absent key.)"""
+    for k in keys:
+        if k not in obj:
+            errs.append(f"{section}.{k} is required (use null if not applicable)")
+
+
+# --- validate_record (pure) ------------------------------------------------
+
+def validate_record(record) -> list:
+    """Return a list of human-readable validation errors ([] == valid).
+
+    Hand-rolled (matching capabilities_lib's style) so the hook carries no
+    runtime jsonschema dependency. Enforces required fields, types (rejecting
+    bool-as-int), enum membership, and cross-field integrity (resolved<=findings,
+    passing<=total, used<=budget, non-negative counts) — the integrity the
+    downstream Tier-2 aggregation will rely on."""
+    if not isinstance(record, dict):
+        return ["record must be a JSON object"]
+
+    errs = []
+    for key in REQUIRED_TOP:
+        if key not in record:
+            errs.append(f"missing required field: {key}")
+
+    for key in ("workflow", "workflow_version"):
+        if key in record and not (_is_str(record[key]) and record[key].strip()):
+            errs.append(f"{key} must be a non-empty string")
+
+    if "issue" in record:
+        issue = record["issue"]
+        if not isinstance(issue, dict):
+            errs.append("issue must be an object")
+        else:
+            _require_present(issue, "issue", ("number", "complexity"), errs)
+            num = issue.get("number")
+            if num is not None and not _is_int(num):
+                errs.append("issue.number must be an integer or null")
+            if issue.get("type") not in ISSUE_TYPES:
+                errs.append(f"issue.type must be one of {sorted(ISSUE_TYPES)}")
+            comp = issue.get("complexity")
+            if comp is not None and comp not in COMPLEXITIES:
+                errs.append(
+                    f"issue.complexity must be one of {sorted(COMPLEXITIES)} or null")
+
+    if "changes" in record:
+        changes = record["changes"]
+        if not isinstance(changes, dict):
+            errs.append("changes must be an object")
+        else:
+            _require_present(changes, "changes", ("insertions", "deletions"), errs)
+            for f in ("files_changed", "commits"):
+                v = changes.get(f)
+                if not _is_int(v) or v < 0:
+                    errs.append(f"changes.{f} must be a non-negative integer")
+            for f in ("insertions", "deletions"):
+                v = changes.get(f)
+                if v is not None and (not _is_int(v) or v < 0):
+                    errs.append(f"changes.{f} must be a non-negative integer or null")
+
+    if "tests" in record:
+        tests = record["tests"]
+        if not isinstance(tests, dict):
+            errs.append("tests must be an object")
+        else:
+            _require_present(tests, "tests", ("passing", "total"), errs)
+            added = tests.get("added")
+            if not _is_int(added) or added < 0:
+                errs.append("tests.added must be a non-negative integer")
+            for f in ("passing", "total"):
+                v = tests.get(f)
+                if v is not None and (not _is_int(v) or v < 0):
+                    errs.append(f"tests.{f} must be a non-negative integer or null")
+            p, t = tests.get("passing"), tests.get("total")
+            if _is_int(p) and _is_int(t) and p > t:
+                errs.append("tests.passing cannot exceed tests.total")
+
+    if "gates" in record:
+        gates = record["gates"]
+        if not isinstance(gates, list):
+            errs.append("gates must be a list")
+        else:
+            for i, g in enumerate(gates):
+                if not isinstance(g, dict):
+                    errs.append(f"gates[{i}] must be an object")
+                    continue
+                if not _is_str(g.get("step")):
+                    errs.append(f"gates[{i}].step must be a string")
+                if not _is_str(g.get("name")):
+                    errs.append(f"gates[{i}].name must be a string")
+                fnd, rsv = g.get("findings"), g.get("resolved")
+                if not _is_int(fnd) or fnd < 0:
+                    errs.append(f"gates[{i}].findings must be a non-negative integer")
+                if not _is_int(rsv) or rsv < 0:
+                    errs.append(f"gates[{i}].resolved must be a non-negative integer")
+                if g.get("status") not in GATE_STATUSES:
+                    errs.append(
+                        f"gates[{i}].status must be one of {sorted(GATE_STATUSES)}")
+                if _is_int(fnd) and _is_int(rsv) and rsv > fnd:
+                    errs.append(f"gates[{i}].resolved cannot exceed gates[{i}].findings")
+
+    if "security_scan" in record:
+        sec = record["security_scan"]
+        if not isinstance(sec, dict):
+            errs.append("security_scan must be an object")
+        else:
+            if not isinstance(sec.get("ran"), bool):
+                errs.append("security_scan.ran must be a boolean")
+            for f in ("blocking_resolved", "advisory"):
+                v = sec.get(f)
+                if not _is_int(v) or v < 0:
+                    errs.append(f"security_scan.{f} must be a non-negative integer")
+            skipped = sec.get("skipped")
+            if not isinstance(skipped, list) or not all(_is_str(s) for s in skipped):
+                errs.append("security_scan.skipped must be a list of strings")
+
+    if "loop_backs" in record:
+        lb = record["loop_backs"]
+        if not isinstance(lb, dict):
+            errs.append("loop_backs must be an object")
+        else:
+            used, budget = lb.get("used"), lb.get("budget")
+            for name, v in (("used", used), ("budget", budget)):
+                if not _is_int(v) or v < 0:
+                    errs.append(f"loop_backs.{name} must be a non-negative integer")
+            if _is_int(used) and _is_int(budget) and used > budget:
+                errs.append("loop_backs.used cannot exceed loop_backs.budget")
+
+    if "outcome" in record:
+        out = record["outcome"]
+        if not isinstance(out, dict):
+            errs.append("outcome must be an object")
+        else:
+            _require_present(out, "outcome", ("pr_number", "pr_url", "merged"), errs)
+            pn = out.get("pr_number")
+            if pn is not None and not _is_int(pn):
+                errs.append("outcome.pr_number must be an integer or null")
+            pu = out.get("pr_url")
+            if pu is not None and not _is_str(pu):
+                errs.append("outcome.pr_url must be a string or null")
+            mg = out.get("merged")
+            if mg is not None and not isinstance(mg, bool):
+                errs.append("outcome.merged must be a boolean or null")
+            if out.get("ci") not in CI_STATUSES:
+                errs.append(f"outcome.ci must be one of {sorted(CI_STATUSES)}")
+            if out.get("deploy") not in DEPLOY_STATUSES:
+                errs.append(f"outcome.deploy must be one of {sorted(DEPLOY_STATUSES)}")
+
+    if "follow_ups" in record:
+        fu = record["follow_ups"]
+        if not isinstance(fu, list) or not all(_is_str(s) for s in fu):
+            errs.append("follow_ups must be a list of strings")
+
+    return errs
+
+
+# --- normalize_record (pure) -----------------------------------------------
+
+def normalize_record(record, *, now, schema_version=SCHEMA_VERSION) -> dict:
+    """Return a copy stamped with schema_version + generated_at and with optional
+    fields defaulted. `now` is passed in (not read from the clock here) so the
+    function stays pure and deterministic in tests. Only ever called on a record
+    that already passed validate_record, so it can assume a dict."""
+    out = copy.deepcopy(record)
+    out["schema_version"] = schema_version
+    out["generated_at"] = now
+    out.setdefault("follow_ups", [])
+    return out
+
+
+# --- render_summary (pure, best-effort) ------------------------------------
+
+def render_summary(record) -> str:
+    """Render the human "WF COMPLETE" block. Best-effort and total: never raises
+    on a partial/invalid/non-dict record, so the user always gets Step 16 output
+    even when the record failed validation."""
+    r = _as_dict(record)
+    wf = r.get("workflow") or "workflow"
+    label = _WF_LABELS.get(wf, str(wf).upper())
+    issue = _as_dict(r.get("issue"))
+    tests = _as_dict(r.get("tests"))
+    gates = _as_list(r.get("gates"))
+    sec = _as_dict(r.get("security_scan"))
+    lb = _as_dict(r.get("loop_backs"))
+    out = _as_dict(r.get("outcome"))
+    follow = _as_list(r.get("follow_ups"))
+
+    header = f"{label} COMPLETE"
+    lines = [header, "=" * len(header), ""]
+
+    pr_num, pr_url = out.get("pr_number"), out.get("pr_url")
+    if pr_url and pr_num is not None:
+        pr_str = f"{pr_url} (PR #{pr_num})"
+    elif pr_url:
+        pr_str = pr_url
+    elif pr_num is not None:
+        pr_str = f"PR #{pr_num}"
+    else:
+        pr_str = "(no PR)"
+    lines.append(f"GitHub PR: {pr_str}")
+
+    inum, itype = issue.get("number"), issue.get("type", "?")
+    lines.append(
+        f"GitHub Issue: #{inum} ({itype})" if inum is not None
+        else f"GitHub Issue: (none, {itype})")
+    lines.append("")
+
+    lines.append("Quality Gates:")
+    for g in gates:
+        if not isinstance(g, dict):
+            continue
+        lines.append(
+            f"- Step {g.get('step', '?')} ({g.get('name', '?')}): "
+            f"{g.get('findings', '?')} findings, {g.get('resolved', '?')} resolved "
+            f"[{g.get('status', '?')}]")
+    skipped = [str(s) for s in _as_list(sec.get("skipped"))]
+    lines.append(
+        f"- Step 11.5 (Security Scan): {sec.get('blocking_resolved', '?')} "
+        f"blocking resolved / {sec.get('advisory', '?')} advisory / "
+        f"skipped: {', '.join(skipped) if skipped else 'none'}")
+    lines.append("")
+
+    lines.append("Verification:")
+    passing, total = tests.get("passing"), tests.get("total")
+    if passing is not None and total is not None:
+        lines.append(f"- Tests: {tests.get('added', 0)} added, {passing}/{total} passing")
+    else:
+        lines.append(f"- Tests: {tests.get('added', 0)} added")
+    lines.append(f"- CI: {out.get('ci', 'n/a')}")
+    lines.append(f"- Deploy: {out.get('deploy', 'n/a')}")
+    lines.append("")
+
+    lines.append(f"Loop-backs used: {lb.get('used', '?')} / {lb.get('budget', '?')}")
+
+    if follow:
+        lines.append("")
+        lines.append("Follow-up items:")
+        lines.extend(f"- {item}" for item in follow)
+
+    return "\n".join(lines)
+
+
+# --- I/O (thin) ------------------------------------------------------------
+
+def resolve_store_path(store_arg, env, project_root) -> str:
+    """Store path precedence: --store flag > RAWGENTIC_RUN_RECORD_STORE env >
+    default <project-root>/docs/measurements/run_records.jsonl."""
+    if store_arg:
+        return store_arg
+    env_val = (env or {}).get(STORE_ENV)
+    if env_val:
+        return env_val
+    return str(Path(project_root, *DEFAULT_STORE_RELPATH))
+
+
+def load_record_file(path) -> dict:
+    """Read + JSON-parse the run-record file. Fail-closed: an unreadable or
+    non-JSON file raises WorkSummaryError rather than producing an empty run."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+    except (OSError, ValueError) as exc:   # ValueError: embedded NUL in path
+        raise WorkSummaryError(f"cannot read record file {path}: {exc}")
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise WorkSummaryError(f"record file {path} is not valid JSON: {exc}")
+
+
+def persist_record(record, store_path) -> None:
+    """Append one compact JSON line (one record per line) to the JSONL store,
+    creating the parent directory if needed."""
+    p = Path(store_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --- CLI -------------------------------------------------------------------
+
+def main(argv=None) -> int:
+    """CLI entry point.
+
+    Subcommand:
+      summarize  validate the run-record at --record-file, render the human
+                 completion summary (or the normalized record with --json), and —
+                 if valid — append the record to the store.
+
+    Exit codes:
+      0  valid record: summary rendered and (unless --no-persist) persisted
+      1  invalid record: summary still rendered, errors on stderr, NOT persisted
+      2  usage error / unreadable record file
+    """
+    parser = argparse.ArgumentParser(prog="work_summary")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p = sub.add_parser(
+        "summarize",
+        help="render the WF completion summary + emit/persist the run-record")
+    p.add_argument("--record-file", required=True,
+                   help="path to the JSON run-record assembled by the workflow")
+    p.add_argument("--project-root", required=True,
+                   help="active project root (for the default store path)")
+    p.add_argument("--store", default=None,
+                   help=f"run-record store path (overrides ${STORE_ENV} and "
+                        f"the default <project-root>/{'/'.join(DEFAULT_STORE_RELPATH)})")
+    p.add_argument("--json", action="store_true",
+                   help="emit the normalized record as JSON instead of human text")
+    p.add_argument("--no-persist", action="store_true",
+                   help="render only; do not append the record to the store")
+    args = parser.parse_args(argv)
+
+    if args.cmd == "summarize":
+        try:
+            raw = load_record_file(args.record_file)
+        except WorkSummaryError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+
+        errors = validate_record(raw)
+        if errors:
+            # Best-effort render so the user keeps Step 16 output, but never
+            # persist an invalid record. Exit 1 so the skill surfaces the gap.
+            print(json.dumps(raw, separators=(",", ":")) if args.json
+                  else render_summary(raw))
+            print("run-record validation failed (NOT persisted):", file=sys.stderr)
+            for e in errors:
+                print(f"  - {e}", file=sys.stderr)
+            return 1
+
+        record = normalize_record(raw, now=_now())
+        print(json.dumps(record, separators=(",", ":")) if args.json
+              else render_summary(record))
+        if not args.no_persist:
+            store = resolve_store_path(args.store, os.environ, args.project_root)
+            try:
+                persist_record(record, store)
+            except OSError as exc:
+                print(f"failed to persist run-record to {store}: {exc}",
+                      file=sys.stderr)
+                return 1
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -1307,42 +1307,83 @@ Post-deploy verification result (or skip confirmation).
 
 ### Instructions
 
+The completion summary is no longer hand-typed — its shape used to drift run to
+run, and nothing about the run was captured for later analysis. Instead, assemble
+a structured **run-record** from the data gathered across this workflow and drive
+the summary through `hooks/work_summary.py`, which renders the standardized "WF2
+COMPLETE" block AND appends the record to a JSONL store. Accumulated across runs
+the store is the Tier-2 measurement telemetry substrate (per
+`docs/measurements/`), so every gate's findings-caught-vs-resolved becomes a
+measurable signal — not just a sentence the user reads once.
+
 1. Update session notes with WF2 results.
 
-2. Present completion summary (adapted to capabilities):
+2. **Assemble the run-record** from the workflow so far and write it to
+   `/tmp/wf2-run-record.json` (use the Write tool, or a `cat > … <<'JSON'`
+   heredoc). Every key below must be **present**; "nullable" means `null` is an
+   allowed value, NOT that the key may be omitted (a dropped field is a telemetry
+   gap, not a null). Counts are non-negative integers and `resolved` may not
+   exceed `findings`:
 
-```
-WF2 COMPLETE
-=============
+   ```json
+   {
+     "workflow": "implement-feature",
+     "workflow_version": "<.claude-plugin/plugin.json version>",
+     "issue": {"number": <issue # | null>, "type": "feature|bug|chore|other",
+               "complexity": "trivial|standard|complex|null"},
+     "changes": {"files_changed": N, "insertions": N|null, "deletions": N|null,
+                 "commits": N},
+     "tests": {"added": N, "passing": N|null, "total": N|null},
+     "gates": [
+       {"step": "4",  "name": "Design Critique",       "findings": N, "resolved": N, "status": "pass|fail|skipped|fast_path"},
+       {"step": "6",  "name": "Plan Drift",            "findings": N, "resolved": N, "status": "..."},
+       {"step": "9",  "name": "Implementation Drift",  "findings": N, "resolved": N, "status": "..."},
+       {"step": "11", "name": "Code Review",           "findings": N, "resolved": N, "status": "..."},
+       {"step": "15", "name": "Post-Deploy",           "findings": N, "resolved": N, "status": "..."}
+     ],
+     "security_scan": {"ran": true|false, "blocking_resolved": N, "advisory": N,
+                       "skipped": ["<kind>", ...]},
+     "loop_backs": {"used": N, "budget": 3},
+     "outcome": {"pr_number": N|null, "pr_url": "<url>"|null, "merged": true|false|null,
+                 "ci": "passed|failed|not_configured|skipped",
+                 "deploy": "success|manual|failed|not_applicable"},
+     "follow_ups": ["<any item requiring future attention>", ...]
+   }
+   ```
+   The `gates` array carries whichever gates actually ran (Step 11.5 is captured
+   in `security_scan`, not as a gate row). Use `status: "fast_path"` for a gate
+   the fast path replaced, `"skipped"` for one that didn't apply.
 
-GitHub PR: [URL] (PR #NNN)
-GitHub Issue: [URL] (Issue #NNN — Closes #NNN)
+3. **Render + persist.** Carry `activeProject.path` in as a literal (shell vars
+   do not persist across Bash tool calls):
+   ```bash
+   python3 hooks/work_summary.py summarize \
+     --record-file /tmp/wf2-run-record.json \
+     --project-root <activeProject.path>
+   rc=$?
+   ```
+   The tool's stdout **is** the completion summary — present it to the user as-is
+   (do not re-type it). It also appends the record to
+   `<activeProject.path>/docs/measurements/run_records.jsonl` (override with
+   `--store` or `$RAWGENTIC_RUN_RECORD_STORE`).
 
-Quality Gates:
-- Step 4 (Design): [full critique / fast path reflect] — N findings
-- Step 6 (Plan Drift): N findings
-- Step 9 (Implementation Drift): N findings
-- Step 10 (Memorize): [N insights saved / skipped]
-- Step 11 (Code Review): N findings (all Critical/High resolved)
-- Step 11.5 (Security Scan): [N blocking resolved / N advisory / skipped: <kinds or "none">]
-- Step 15 (Post-Deploy): [pass / skipped / deferred]
+4. **Handle the exit code:**
+   - `rc == 0`: record valid and persisted. Done.
+   - `rc == 1`: the summary still rendered (the user keeps Step 16 output) but the
+     record FAILED validation and was **not** persisted — a telemetry gap. The
+     stderr lists exactly which fields are wrong; fix `/tmp/wf2-run-record.json`
+     and re-run so the substrate stays complete. If it genuinely can't be fixed,
+     record the gap in session notes rather than ignoring it.
+   - `rc == 2`: usage error / unreadable record file — fix the invocation.
 
-Verification:                              # Adapt based on capabilities
-- Tests: [N passed / not applicable]
-- Verifications: [N passed / details]
-- CI: [passed / not configured]
-- Deploy: [success / manual / not applicable]
-
-Loop-backs used: N / 3 (global budget)
-
-Follow-up items:
-- [any items requiring future attention]
-```
+Log a marker in `claude_docs/session_notes.md`:
+`### WF2 Step 16: Completion summary + run-record — DONE (persisted: yes/no)`
 
 Do NOT suggest auto-transitioning to WF1 or restarting WF2.
 
 ### Output
-Completion summary. WF2 terminates.
+Standardized completion summary (rendered by `work_summary.py`) + a persisted
+run-record. WF2 terminates.
 
 ---
 
@@ -1359,6 +1400,7 @@ Before declaring WF2 complete, verify the following. Items marked (conditional) 
 8. [ ] (conditional: architecture changed) CLAUDE.md updated
 9. [ ] All Critical/High code review findings resolved
 10. [ ] Security scan (Step 11.5) ran; all blocking findings resolved (or, if no scanners were installed, the skips are recorded in session notes + PR body)
+11. [ ] Completion summary rendered via `work_summary.py` (Step 16) and the run-record persisted (rc 0) — or, if validation failed (rc 1), the telemetry gap is recorded in session notes
 
 If ANY applicable item fails, complete it before declaring "WF2 complete."
 </completion-gate>

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.32.0"
+    assert plugin["version"] == "2.33.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_work_summary.py
+++ b/tests/hooks/test_work_summary.py
@@ -1,0 +1,590 @@
+"""Tests for hooks/work_summary.py — the WF2 Step 16 completion summary + the
+per-run structured run-record (the Tier-2 telemetry substrate).
+
+Step 16 of implement-feature (WF2) used to hand-type a free-text completion
+summary. This lib renders that SAME summary deterministically AND emits a
+structured run-record (issue/type, changes, tests, per-gate findings caught vs
+resolved, Step 11.5 security-scan status, loop-backs, PR/CI/deploy outcome) so
+the effectiveness of the agentic workflow becomes measurable across runs — the
+substrate the Tier-2 A/B harness aggregates (docs/measurements names it
+explicitly). One run, one JSON line appended to the store.
+
+Design mirrors hooks/security_scan.py: the logic is PURE functions
+(validate_record, normalize_record, render_summary) exhaustively unit-tested
+here, and the I/O (clock, store path, append) is injected/thin so the gate
+behavior is deterministic in tests. Validation is fail-closed for the *store*
+(a malformed record is never persisted) but the human summary still renders
+best-effort, so the user never loses their Step 16 output to a telemetry nit.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+SUMMARY_CLI = HOOKS_DIR / "work_summary.py"
+SKILLS_DIR = Path(__file__).resolve().parent.parent.parent / "skills"
+
+NOW = "2026-06-15T18:00:00Z"
+
+
+def _valid_record() -> dict:
+    """A complete, schema-valid run-record (modeled on PR #91's own run). Each
+    call returns a fresh dict so a test can mutate it freely."""
+    return {
+        "workflow": "implement-feature",
+        "workflow_version": "2.33.0",
+        "issue": {"number": 91, "type": "feature", "complexity": "standard"},
+        "changes": {"files_changed": 4, "insertions": 896, "deletions": 7,
+                    "commits": 3},
+        "tests": {"added": 40, "passing": 895, "total": 895},
+        "gates": [
+            {"step": "4", "name": "Design Critique", "findings": 3,
+             "resolved": 3, "status": "pass"},
+            {"step": "6", "name": "Plan Drift", "findings": 0, "resolved": 0,
+             "status": "pass"},
+            {"step": "11", "name": "Code Review", "findings": 5, "resolved": 5,
+             "status": "pass"},
+        ],
+        "security_scan": {"ran": True, "blocking_resolved": 0, "advisory": 2,
+                          "skipped": ["iac"]},
+        "loop_backs": {"used": 1, "budget": 3},
+        "outcome": {"pr_number": 91,
+                    "pr_url": "https://github.com/3D-Stories/rawgentic/pull/91",
+                    "merged": True, "ci": "passed", "deploy": "not_applicable"},
+        "follow_ups": ["wire work_summary into WF3 Step"],
+    }
+
+
+# --- validate_record: happy path -------------------------------------------
+
+class TestValidateHappyPath:
+    def test_full_valid_record_has_no_errors(self):
+        from work_summary import validate_record
+        assert validate_record(_valid_record()) == []
+
+    @pytest.mark.parametrize("path,value", [
+        (("issue", "number"), None),         # unknown/no issue -> null
+        (("issue", "complexity"), None),     # complexity optional
+        (("changes", "insertions"), None),   # diff volume may be unknown
+        (("changes", "deletions"), None),
+        (("tests", "passing"), None),        # tests may not have been counted
+        (("tests", "total"), None),
+        (("outcome", "pr_number"), None),
+        (("outcome", "pr_url"), None),
+        (("outcome", "merged"), None),
+    ])
+    def test_nullable_fields_accept_null(self, path, value):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec[path[0]][path[1]] = value
+        assert validate_record(rec) == [], f"{path} should accept null"
+
+    def test_follow_ups_optional(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        del rec["follow_ups"]
+        assert validate_record(rec) == []
+
+    def test_empty_gates_list_is_valid(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["gates"] = []
+        assert validate_record(rec) == []
+
+
+# --- validate_record: fail-closed ------------------------------------------
+
+class TestValidateFailClosed:
+    def test_non_dict_record_is_error(self):
+        from work_summary import validate_record
+        assert validate_record(["not", "a", "dict"]) != []
+        assert validate_record(None) != []
+
+    @pytest.mark.parametrize("key", [
+        "workflow", "workflow_version", "issue", "changes", "tests", "gates",
+        "security_scan", "loop_backs", "outcome",
+    ])
+    def test_missing_required_top_key_is_error(self, key):
+        from work_summary import validate_record
+        rec = _valid_record()
+        del rec[key]
+        errs = validate_record(rec)
+        assert any(key in e for e in errs), f"missing {key} not reported: {errs}"
+
+    @pytest.mark.parametrize("section", ["issue", "changes", "tests",
+                                         "security_scan", "loop_backs", "outcome"])
+    def test_section_must_be_object(self, section):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec[section] = "not-an-object"
+        assert validate_record(rec) != []
+
+    def test_gates_must_be_list(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["gates"] = {"not": "a list"}
+        assert validate_record(rec) != []
+
+    @pytest.mark.parametrize("bad", ["", None, 5])
+    def test_workflow_must_be_nonempty_str(self, bad):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["workflow"] = bad
+        assert validate_record(rec) != []
+
+    @pytest.mark.parametrize("field,bad", [
+        ("type", "epic"),         # not in {feature,bug,chore,other}
+        ("type", None),           # type is required (issue.number is the nullable one)
+        ("complexity", "epic"),   # not a known complexity
+    ])
+    def test_issue_enum_violations(self, field, bad):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["issue"][field] = bad
+        assert validate_record(rec) != []
+
+    @pytest.mark.parametrize("status", ["pass", "fail", "skipped", "fast_path"])
+    def test_gate_status_enum_accepts_known(self, status):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["gates"][0]["status"] = status
+        assert validate_record(rec) == []
+
+    def test_gate_status_enum_rejects_unknown(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["gates"][0]["status"] = "kinda-passed"
+        assert validate_record(rec) != []
+
+    @pytest.mark.parametrize("ci", ["passed", "failed", "not_configured", "skipped"])
+    def test_ci_enum_accepts_known(self, ci):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["outcome"]["ci"] = ci
+        assert validate_record(rec) == []
+
+    def test_ci_enum_rejects_unknown(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["outcome"]["ci"] = "green"
+        assert validate_record(rec) != []
+
+    @pytest.mark.parametrize("dep", ["success", "manual", "failed", "not_applicable"])
+    def test_deploy_enum_accepts_known(self, dep):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["outcome"]["deploy"] = dep
+        assert validate_record(rec) == []
+
+    def test_deploy_enum_rejects_unknown(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["outcome"]["deploy"] = "shipped"
+        assert validate_record(rec) != []
+
+
+# --- validate_record: numeric integrity (the telemetry-quality heart) -------
+
+class TestValidateNumericIntegrity:
+    def test_bool_is_not_accepted_as_int(self):
+        """bool is a subclass of int in Python — a naive isinstance(x, int)
+        would let `findings: true` corrupt the substrate. Must be rejected."""
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["changes"]["files_changed"] = True
+        assert validate_record(rec) != []
+
+    @pytest.mark.parametrize("path", [
+        ("changes", "files_changed"), ("changes", "commits"),
+        ("tests", "added"),
+    ])
+    def test_negative_counts_are_errors(self, path):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec[path[0]][path[1]] = -1
+        assert validate_record(rec) != []
+
+    def test_gate_resolved_cannot_exceed_findings(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["gates"][0] = {"step": "4", "name": "x", "findings": 2,
+                           "resolved": 5, "status": "pass"}
+        assert validate_record(rec) != []
+
+    def test_tests_passing_cannot_exceed_total(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["tests"] = {"added": 1, "passing": 10, "total": 5}
+        assert validate_record(rec) != []
+
+    def test_loop_backs_used_cannot_exceed_budget(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["loop_backs"] = {"used": 9, "budget": 3}
+        assert validate_record(rec) != []
+
+    @pytest.mark.parametrize("section,key", [
+        ("issue", "number"), ("issue", "complexity"),
+        ("changes", "insertions"), ("changes", "deletions"),
+        ("tests", "passing"), ("tests", "total"),
+        ("outcome", "pr_number"), ("outcome", "pr_url"), ("outcome", "merged"),
+    ])
+    def test_absent_nullable_subfield_is_error_not_treated_as_null(self, section, key):
+        """A nullable field means `null` is an ALLOWED VALUE — not that the key
+        may be ABSENT. Tolerating absence lets a producer silently drop a field,
+        so Tier-2 can't distinguish a deliberate null from a dropped field. The
+        key must be present (value may be null)."""
+        from work_summary import validate_record
+        rec = _valid_record()
+        del rec[section][key]
+        errs = validate_record(rec)
+        assert any(key in e for e in errs), (
+            f"absent {section}.{key} should be an error, got {errs}")
+        # and present-with-null stays valid (regression guard)
+        rec[section][key] = None
+        assert validate_record(rec) == []
+
+    def test_security_skipped_must_be_list_of_str(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["security_scan"]["skipped"] = "iac"   # bare string, not a list
+        assert validate_record(rec) != []
+        rec["security_scan"]["skipped"] = [1, 2]   # list of non-str
+        assert validate_record(rec) != []
+
+    def test_security_ran_must_be_bool(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["security_scan"]["ran"] = "yes"
+        assert validate_record(rec) != []
+
+    def test_gate_missing_subfield_is_error(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["gates"][0] = {"step": "4", "name": "x"}  # no findings/resolved/status
+        assert validate_record(rec) != []
+
+    def test_gate_item_must_be_object(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["gates"] = ["not-an-object"]
+        assert validate_record(rec) != []
+
+
+# --- normalize_record ------------------------------------------------------
+
+class TestNormalize:
+    def test_stamps_schema_version_and_generated_at(self):
+        from work_summary import normalize_record, SCHEMA_VERSION
+        out = normalize_record(_valid_record(), now=NOW)
+        assert out["schema_version"] == SCHEMA_VERSION
+        assert out["generated_at"] == NOW
+
+    def test_does_not_mutate_input(self):
+        from work_summary import normalize_record
+        rec = _valid_record()
+        normalize_record(rec, now=NOW)
+        assert "schema_version" not in rec
+        assert "generated_at" not in rec
+
+    def test_fills_follow_ups_default(self):
+        from work_summary import normalize_record
+        rec = _valid_record()
+        del rec["follow_ups"]
+        out = normalize_record(rec, now=NOW)
+        assert out["follow_ups"] == []
+
+    def test_preserves_all_provided_fields(self):
+        from work_summary import normalize_record
+        out = normalize_record(_valid_record(), now=NOW)
+        assert out["issue"]["number"] == 91
+        assert out["outcome"]["ci"] == "passed"
+        assert len(out["gates"]) == 3
+
+    def test_explicit_schema_version_override(self):
+        from work_summary import normalize_record
+        out = normalize_record(_valid_record(), now=NOW, schema_version=99)
+        assert out["schema_version"] == 99
+
+
+# --- render_summary --------------------------------------------------------
+
+class TestRenderSummary:
+    def test_contains_wf2_header_for_implement_feature(self):
+        from work_summary import render_summary
+        text = render_summary(_valid_record())
+        assert "WF2 COMPLETE" in text
+
+    def test_contains_pr_issue_and_outcome(self):
+        from work_summary import render_summary
+        text = render_summary(_valid_record())
+        assert "pull/91" in text
+        assert "#91" in text
+        assert "passed" in text                  # ci
+        assert "not_applicable" in text          # deploy
+
+    def test_lists_each_gate(self):
+        from work_summary import render_summary
+        text = render_summary(_valid_record())
+        assert "Design Critique" in text
+        assert "Code Review" in text
+
+    def test_security_scan_line_present(self):
+        from work_summary import render_summary
+        text = render_summary(_valid_record())
+        assert "Security Scan" in text or "11.5" in text
+        assert "iac" in text                     # the skipped kind is surfaced
+
+    def test_security_skipped_none_when_empty(self):
+        from work_summary import render_summary
+        rec = _valid_record()
+        rec["security_scan"]["skipped"] = []
+        text = render_summary(rec)
+        assert "none" in text.lower()
+
+    def test_loop_backs_rendered(self):
+        from work_summary import render_summary
+        text = render_summary(_valid_record())
+        assert "1 / 3" in text or "1/3" in text
+
+    def test_follow_ups_rendered(self):
+        from work_summary import render_summary
+        text = render_summary(_valid_record())
+        assert "wire work_summary into WF3 Step" in text
+
+    def test_renders_best_effort_on_partial_record(self):
+        """The human summary must never crash on a record that fails validation
+        (missing optionals / nulls) — the user always gets their Step 16 output."""
+        from work_summary import render_summary
+        partial = {"workflow": "implement-feature",
+                   "issue": {"number": None, "type": "bug"},
+                   "outcome": {"pr_url": None}}
+        text = render_summary(partial)        # must not raise
+        assert isinstance(text, str) and text
+
+    def test_renders_on_empty_dict(self):
+        from work_summary import render_summary
+        assert isinstance(render_summary({}), str)
+
+    @pytest.mark.parametrize("bad", [
+        {"gates": 5},                 # non-iterable where a list is expected
+        {"gates": "abc"},             # string is iterable but items aren't dicts
+        {"issue": "x"},               # str where an object is expected
+        {"outcome": [1, 2]},          # list where an object is expected
+        {"tests": 5},
+        {"security_scan": "nope"},
+        {"loop_backs": 9},
+        {"follow_ups": 7},            # non-iterable follow_ups
+        {"follow_ups": "oneitem"},    # would iterate characters if not guarded
+    ])
+    def test_never_raises_on_wrong_typed_sections(self, bad):
+        """render_summary is called on UNVALIDATED records in main's rc=1 path,
+        so a wrong-typed section must degrade to a default, never raise — else a
+        malformed record crashes the tool instead of rendering + exiting 1."""
+        from work_summary import render_summary
+        text = render_summary(bad)
+        assert isinstance(text, str) and text
+
+
+# --- resolve_store_path ----------------------------------------------------
+
+class TestResolveStorePath:
+    def test_flag_wins(self, tmp_path):
+        from work_summary import resolve_store_path
+        p = resolve_store_path("/explicit/store.jsonl", env={}, project_root=str(tmp_path))
+        assert p == "/explicit/store.jsonl"
+
+    def test_env_used_when_no_flag(self, tmp_path):
+        from work_summary import resolve_store_path
+        env = {"RAWGENTIC_RUN_RECORD_STORE": "/from/env.jsonl"}
+        p = resolve_store_path(None, env=env, project_root=str(tmp_path))
+        assert p == "/from/env.jsonl"
+
+    def test_flag_beats_env(self, tmp_path):
+        from work_summary import resolve_store_path
+        env = {"RAWGENTIC_RUN_RECORD_STORE": "/from/env.jsonl"}
+        p = resolve_store_path("/flag.jsonl", env=env, project_root=str(tmp_path))
+        assert p == "/flag.jsonl"
+
+    def test_default_is_project_measurements(self, tmp_path):
+        from work_summary import resolve_store_path
+        p = resolve_store_path(None, env={}, project_root=str(tmp_path))
+        assert p == str(tmp_path / "docs" / "measurements" / "run_records.jsonl")
+
+
+# --- load_record_file ------------------------------------------------------
+
+class TestLoadRecordFile:
+    def test_reads_valid_json(self, tmp_path):
+        from work_summary import load_record_file
+        f = tmp_path / "rec.json"
+        f.write_text(json.dumps(_valid_record()))
+        assert load_record_file(str(f))["issue"]["number"] == 91
+
+    def test_missing_file_raises(self, tmp_path):
+        from work_summary import load_record_file, WorkSummaryError
+        with pytest.raises(WorkSummaryError):
+            load_record_file(str(tmp_path / "nope.json"))
+
+    def test_malformed_json_raises(self, tmp_path):
+        from work_summary import load_record_file, WorkSummaryError
+        f = tmp_path / "bad.json"
+        f.write_text("{not valid json")
+        with pytest.raises(WorkSummaryError):
+            load_record_file(str(f))
+
+
+# --- persist_record --------------------------------------------------------
+
+class TestPersistRecord:
+    def test_appends_single_json_line(self, tmp_path):
+        from work_summary import persist_record
+        store = tmp_path / "sub" / "run_records.jsonl"   # parent missing on purpose
+        persist_record({"a": 1}, str(store))
+        lines = store.read_text().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0]) == {"a": 1}
+
+    def test_appends_without_overwriting(self, tmp_path):
+        from work_summary import persist_record
+        store = tmp_path / "run_records.jsonl"
+        persist_record({"n": 1}, str(store))
+        persist_record({"n": 2}, str(store))
+        lines = store.read_text().splitlines()
+        assert [json.loads(l)["n"] for l in lines] == [1, 2]
+
+    def test_each_line_is_independent_json(self, tmp_path):
+        from work_summary import persist_record
+        store = tmp_path / "run_records.jsonl"
+        persist_record(_valid_record(), str(store))
+        persist_record(_valid_record(), str(store))
+        for line in store.read_text().splitlines():
+            json.loads(line)   # must not raise
+
+
+# --- main (CLI) ------------------------------------------------------------
+
+def _write_record(tmp_path, record, name="rec.json"):
+    f = tmp_path / name
+    f.write_text(json.dumps(record))
+    return str(f)
+
+
+class TestMainCLI:
+    def test_valid_record_persists_and_renders(self, tmp_path, capsys):
+        from work_summary import main
+        store = tmp_path / "store.jsonl"
+        rc = main(["summarize", "--record-file", _write_record(tmp_path, _valid_record()),
+                   "--project-root", str(tmp_path), "--store", str(store)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "WF2 COMPLETE" in out
+        assert store.exists()
+        stored = json.loads(store.read_text().splitlines()[0])
+        assert stored["schema_version"] >= 1
+        assert "generated_at" in stored
+
+    def test_json_flag_emits_normalized_record(self, tmp_path, capsys):
+        from work_summary import main
+        store = tmp_path / "store.jsonl"
+        rc = main(["summarize", "--record-file", _write_record(tmp_path, _valid_record()),
+                   "--project-root", str(tmp_path), "--store", str(store), "--json"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        emitted = json.loads(out)             # stdout is parseable JSON
+        assert emitted["schema_version"] >= 1
+        assert emitted["issue"]["number"] == 91
+
+    def test_no_persist_skips_store(self, tmp_path, capsys):
+        from work_summary import main
+        store = tmp_path / "store.jsonl"
+        rc = main(["summarize", "--record-file", _write_record(tmp_path, _valid_record()),
+                   "--project-root", str(tmp_path), "--store", str(store), "--no-persist"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "WF2 COMPLETE" in out
+        assert not store.exists()
+
+    def test_invalid_record_renders_skips_persist_exits_1(self, tmp_path, capsys):
+        """The chosen failure mode: render the summary (user keeps Step 16),
+        do NOT persist (store stays clean), exit 1 (skill surfaces the gap)."""
+        from work_summary import main
+        store = tmp_path / "store.jsonl"
+        bad = _valid_record()
+        bad["outcome"]["ci"] = "green"          # invalid enum
+        rc = main(["summarize", "--record-file", _write_record(tmp_path, bad),
+                   "--project-root", str(tmp_path), "--store", str(store)])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "WF2 COMPLETE" in captured.out   # rendered anyway
+        assert captured.err                      # errors surfaced to stderr
+        assert not store.exists()                # NOT persisted
+
+    def test_wrong_typed_section_still_renders_and_exits_1(self, tmp_path, capsys):
+        """A record whose section has the wrong TYPE (not just a bad value) must
+        not crash main — it still renders best-effort, skips persist, exits 1."""
+        from work_summary import main
+        store = tmp_path / "store.jsonl"
+        bad = _valid_record()
+        bad["gates"] = 5                         # non-iterable; would crash a naive render
+        rc = main(["summarize", "--record-file", _write_record(tmp_path, bad),
+                   "--project-root", str(tmp_path), "--store", str(store)])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "COMPLETE" in captured.out
+        assert not store.exists()
+
+    def test_default_store_is_project_measurements(self, tmp_path, capsys):
+        from work_summary import main
+        rc = main(["summarize", "--record-file", _write_record(tmp_path, _valid_record()),
+                   "--project-root", str(tmp_path)])
+        assert rc == 0
+        default = tmp_path / "docs" / "measurements" / "run_records.jsonl"
+        assert default.exists()
+
+    def test_missing_record_file_errors(self, tmp_path, capsys):
+        from work_summary import main
+        rc = main(["summarize", "--record-file", str(tmp_path / "nope.json"),
+                   "--project-root", str(tmp_path)])
+        assert rc != 0
+
+    def test_no_subcommand_is_usage_error(self):
+        from work_summary import main
+        with pytest.raises(SystemExit) as exc:
+            main([])
+        assert exc.value.code == 2
+
+
+# --- CLI subprocess smoke (the skill shells out to this exact invocation) ----
+
+class TestCLISubprocessSmoke:
+    def test_real_invocation_renders_and_persists(self, tmp_path):
+        import subprocess
+        rec_file = _write_record(tmp_path, _valid_record())
+        store = tmp_path / "store.jsonl"
+        r = subprocess.run(
+            ["python3", str(SUMMARY_CLI), "summarize", "--record-file", rec_file,
+             "--project-root", str(tmp_path), "--store", str(store)],
+            capture_output=True, text=True, timeout=15)
+        assert r.returncode == 0, r.stderr
+        assert "WF2 COMPLETE" in r.stdout
+        assert store.exists()
+
+
+# --- Step 16 skill-wiring drift guard --------------------------------------
+
+class TestWorkSummarySkillWiring:
+    """Drift guard: WF2's Step 16 must drive the completion summary through this
+    CLI, not hand-type the block (which is exactly the inconsistency the
+    run-record removes). If the subcommand is renamed, update skill + guard."""
+
+    def test_implement_feature_invokes_work_summary_cli(self):
+        content = (SKILLS_DIR / "implement-feature" / "SKILL.md").read_text()
+        assert "work_summary.py summarize" in content, (
+            "implement-feature/SKILL.md Step 16 must invoke "
+            "`work_summary.py summarize`; if you renamed it, update this guard."
+        )


### PR DESCRIPTION
## Summary

WF2 **Step 16** used to hand-type its completion summary, so the shape drifted run-to-run and nothing about the run was captured for later analysis. This adds **`hooks/work_summary.py`**, which from one validated record:

1. **Renders** the standardized "WF2 COMPLETE" block (no more hand-typing → no drift).
2. **Emits a structured per-run run-record** — issue/type, change volume, tests, each quality gate's *findings caught vs resolved*, the Step 11.5 security-scan status, loop-backs, and PR/CI/deploy outcome — appended as one JSON line to `<project>/docs/measurements/run_records.jsonl`.

Accumulated across runs, the store is the **Tier-2 measurement telemetry substrate** the impact report and `consolidation.md` open-question #3 both named explicitly. Each gate's effectiveness ("how often does the design critique actually catch something") becomes a query over the store instead of a sentence the user reads once.

Also folds in **`fetch-depth: 0`** on `actions/checkout` so the Tier-1 metrics smoke test (`test_wf2_impact_metrics.py::TestCollectSmoke`) stops skipping under CI's shallow checkout.

## Design Decisions

- **Architecture mirrors `hooks/security_scan.py`:** pure functions (`validate_record` / `normalize_record` / `render_summary`) carry all logic and are exhaustively unit-tested; I/O is thin/injected (the clock is passed into `normalize_record`; the store path resolves flag → env → default).
- **Fail-closed for the STORE, best-effort for the human:** a record that fails validation is **never persisted** (the substrate stays pristine), but the summary still renders (a schema nit never costs the user their Step 16 output). The CLI exits `1` so the skill surfaces the telemetry gap; `0` = valid+persisted; `2` = usage/unreadable.
- **Store default `<project>/docs/measurements/run_records.jsonl`** (committed, reproducible), env-overridable via `RAWGENTIC_RUN_RECORD_STORE` from v1.
- **Hand-rolled validation** (no runtime `jsonschema` dep, matching `capabilities_lib`) — rejects bool-as-int, negatives, enum violations, cross-field violations (`resolved>findings`, `passing>total`, `used>budget`), and absent nullable keys (a dropped field is a telemetry gap, not a silent null).
- Wired into Step 16 with a **drift-guard test** so the skill can't silently stop calling the CLI.

## Verification

- **113** `work_summary` tests; **full suite 1107 passing** locally.
- **Real-validated** end-to-end (not just unit tests): the valid path (renders + persists with stamped `schema_version`/`generated_at`), the invalid path (renders, **does not** persist, exits 1), `--json`, `--no-persist`, missing-file (exit 2), and a wrong-typed-section record (renders best-effort, exits 1, no crash).
- `TestCollectSmoke` confirmed running (not skipped) with full history → `fetch-depth: 0` makes CI behave like local.

## Quality Gate Summary

- **Cross-model review (Codex / gpt-5.5):**
  - 2 × High — `render_summary` raised on wrong-typed sections (violating its "never raises" contract on the unvalidated rc=1 path). **Fixed** (`_as_dict`/`_as_list` coercion + safe `skipped` join) — independently found and confirmed by the reviewer.
  - 3 × Medium — 1 dismissed by the reviewer itself ("no concrete defect"); the other two were the same finding: an *absent* nullable key was tolerated as `null`, a drift from the documented schema. **Fixed** (require key presence; `null` allowed as a value).
  - 1 × Low — Step 16 enum spacing nit. **Fixed.**
- Docs updated: `README.md`, new `docs/run-records.md`, `docs/consolidation.md` (#3 marked answered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
