### PR TITLE
feat(fix-bug): wire WF3 Step 14 into work_summary run-record + completion summary

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -515,16 +515,18 @@ runs are unchanged unless explicitly opted in via `adversarialReview` in
 
 ### Run-Record Telemetry (Tier-2 substrate)
 
-WF2 Step 16 no longer hand-types its completion summary. Instead it assembles a
-structured **run-record** — issue/type, change volume, tests, each quality gate's
-*findings caught vs resolved*, the Step 11.5 security-scan status, loop-backs, and
-the PR/CI/deploy outcome — and drives `hooks/work_summary.py`, which renders the
-standardized "WF2 COMPLETE" block **and** appends the record as one JSON line to
+WF2 Step 16 and WF3 (fix-bug) Step 14 no longer hand-type their completion
+summaries. Instead each assembles a structured **run-record** — issue/type, change
+volume, tests, each quality gate's *findings caught vs resolved*, security-scan
+status, loop-backs, and the PR/CI/deploy outcome — and drives
+`hooks/work_summary.py`, which renders the standardized "WF*N* COMPLETE" block
+**and** appends the record as one JSON line to
 `<project>/docs/measurements/run_records.jsonl` (override via `--store` or
-`RAWGENTIC_RUN_RECORD_STORE`). Accumulated across runs the store is the telemetry
-substrate the Tier-2 A/B measurement harness aggregates. The store is
+`RAWGENTIC_RUN_RECORD_STORE`). The fields are a **uniform core** so the Tier-2 A/B
+measurement harness can aggregate across workflows, plus an optional `extra` list
+for workflow-specific lines (e.g. WF3's Root Cause / Fix). The store is
 **fail-closed** (a record failing validation is never persisted) while the human
-summary renders best-effort (a schema nit never costs the user their Step 16
+summary renders best-effort (a schema nit never costs the user their completion
 output). See [run-records.md](docs/run-records.md).
 
 ### Shared Invariants

--- a/docs/run-records.md
+++ b/docs/run-records.md
@@ -1,7 +1,7 @@
 # Run-Records & Completion Summary (`hooks/work_summary.py`)
 
-The shared lib used by **WF2 Step 16** (Workflow Completion Summary) to do two
-jobs from one validated record:
+The shared lib used by **WF2 Step 16** and **WF3 (fix-bug) Step 14** (Workflow
+Completion Summary) to do two jobs from one validated record:
 
 1. **Render the completion summary** — the standardized "WF2 COMPLETE" block the
    skill used to hand-type. Rendering it from a structured record means its shape
@@ -38,6 +38,18 @@ exceed `findings`, `passing` may not exceed `total`, `used` may not exceed
 | `loop_backs` | object | `used`, `budget` (ints). |
 | `outcome` | object | `pr_number` (int\|null), `pr_url` (string\|null), `merged` (bool\|null), `ci` (`passed`/`failed`/`not_configured`/`skipped`), `deploy` (`success`/`manual`/`failed`/`not_applicable`). |
 | `follow_ups` | array | Optional list of strings; defaults to `[]`. |
+| `extra` | array | Optional ordered `{label, value}` (both strings) pairs for **workflow-specific** human lines that ride along in the render without bloating the uniform core (e.g. WF3's `Root Cause` / `Fix`). Defaults to `[]`. |
+
+The fields above the line are the **uniform core** every workflow emits, so
+Tier-2 can aggregate across workflows; `extra` is the escape hatch for
+workflow-specific context that doesn't need to be an aggregation column.
+
+**Cross-workflow:** WF2 (`workflow: "implement-feature"` → renders `WF2`) runs a
+Step 11.5 security scan, so `security_scan.ran` is `true` and the scan line shows
+the blocking/advisory/skipped breakdown. WF3 (`workflow: "fix-bug"` → `WF3`) has
+no security scan, so it sets `security_scan.ran: false` and the render shows
+`Security Scan: not run` rather than referencing a Step 11.5 that never ran. WF3
+carries `Root Cause` / `Fix` in `extra` and uses a loop-back budget of 2.
 
 Every documented key must be **present**; "nullable" means `null` is an allowed
 *value*, not that the key may be omitted — a dropped field is a telemetry gap (the
@@ -88,11 +100,14 @@ Exit codes:
 | `1` | Record invalid: summary still rendered, errors on stderr, record **not** persisted. The skill records the telemetry gap. |
 | `2` | Usage error or unreadable/non-JSON record file. |
 
-## How WF2 wires it (Step 16)
+## How the workflows wire it in
 
-The skill assembles the run-record from the data gathered across the workflow,
-writes it to `/tmp/wf2-run-record.json`, and shells out to the CLI. The tool's
-stdout **is** the completion summary, so the skill presents it as-is rather than
-re-typing it. A drift-guard test
-(`tests/hooks/test_work_summary.py::TestWorkSummarySkillWiring`) asserts the skill
-keeps invoking `work_summary.py summarize`, so the wiring can't silently rot.
+Each completion step (WF2 Step 16 → `/tmp/wf2-run-record.json`; WF3 Step 14 →
+`/tmp/wf3-run-record.json`) assembles the run-record from the data gathered across
+the workflow and shells out to the CLI. The tool's stdout **is** the completion
+summary, so the skill presents it as-is rather than re-typing it. A drift-guard
+test (`tests/hooks/test_work_summary.py::TestWorkSummarySkillWiring`,
+parametrized over `implement-feature` and `fix-bug`) asserts each skill keeps
+invoking `work_summary.py summarize`, so the wiring can't silently rot. Adding a
+new workflow to the substrate is just: emit the uniform core (+ any `extra`
+lines), call the CLI, and add the skill to that parametrized guard.

--- a/hooks/work_summary.py
+++ b/hooks/work_summary.py
@@ -189,6 +189,11 @@ def validate_record(record) -> list:
                         f"gates[{i}].status must be one of {sorted(GATE_STATUSES)}")
                 if _is_int(fnd) and _is_int(rsv) and rsv > fnd:
                     errs.append(f"gates[{i}].resolved cannot exceed gates[{i}].findings")
+            steps = [g.get("step") for g in gates if isinstance(g, dict)]
+            dups = sorted({s for s in steps if _is_str(s) and steps.count(s) > 1})
+            if dups:
+                errs.append(f"gates have duplicate step id(s) {dups}; each gate "
+                            f"must have a distinct step (Tier-2 keys on step)")
 
     if "security_scan" in record:
         sec = record["security_scan"]
@@ -204,6 +209,14 @@ def validate_record(record) -> list:
             skipped = sec.get("skipped")
             if not isinstance(skipped, list) or not all(_is_str(s) for s in skipped):
                 errs.append("security_scan.skipped must be a list of strings")
+            # A scan that did NOT run cannot have resolved findings or skipped
+            # scanners. render shows only "not run" for ran=false, so accepting
+            # nonzero data here would hide it AND be self-contradictory telemetry.
+            if sec.get("ran") is False and (
+                    sec.get("blocking_resolved") or sec.get("advisory")
+                    or sec.get("skipped")):
+                errs.append("security_scan: ran=false requires blocking_resolved=0, "
+                            "advisory=0, and empty skipped")
 
     if "loop_backs" in record:
         lb = record["loop_backs"]
@@ -242,6 +255,23 @@ def validate_record(record) -> list:
         if not isinstance(fu, list) or not all(_is_str(s) for s in fu):
             errs.append("follow_ups must be a list of strings")
 
+    # `extra` carries ordered, workflow-specific labeled lines (e.g. WF3's Root
+    # Cause / Fix) that ride along in the human render without bloating the
+    # uniform core schema that Tier-2 aggregates across workflows. Optional.
+    if "extra" in record:
+        ex = record["extra"]
+        if not isinstance(ex, list):
+            errs.append("extra must be a list of {label, value} objects")
+        else:
+            for i, item in enumerate(ex):
+                if not isinstance(item, dict):
+                    errs.append(f"extra[{i}] must be an object")
+                    continue
+                if not (_is_str(item.get("label")) and item["label"].strip()):
+                    errs.append(f"extra[{i}].label must be a non-empty string")
+                if not _is_str(item.get("value")):
+                    errs.append(f"extra[{i}].value must be a string")
+
     return errs
 
 
@@ -256,6 +286,7 @@ def normalize_record(record, *, now, schema_version=SCHEMA_VERSION) -> dict:
     out["schema_version"] = schema_version
     out["generated_at"] = now
     out.setdefault("follow_ups", [])
+    out.setdefault("extra", [])
     return out
 
 
@@ -275,6 +306,7 @@ def render_summary(record) -> str:
     lb = _as_dict(r.get("loop_backs"))
     out = _as_dict(r.get("outcome"))
     follow = _as_list(r.get("follow_ups"))
+    extra = _as_list(r.get("extra"))
 
     header = f"{label} COMPLETE"
     lines = [header, "=" * len(header), ""]
@@ -294,6 +326,13 @@ def render_summary(record) -> str:
     lines.append(
         f"GitHub Issue: #{inum} ({itype})" if inum is not None
         else f"GitHub Issue: (none, {itype})")
+    for item in extra:
+        if isinstance(item, dict):
+            label, value = item.get("label"), item.get("value")
+            # best-effort: skip a malformed pair rather than leak "None:" or a
+            # dict/list repr into the human summary (render runs unvalidated).
+            if isinstance(label, str) and isinstance(value, str):
+                lines.append(f"{label}: {value}")
     lines.append("")
 
     lines.append("Quality Gates:")
@@ -304,11 +343,16 @@ def render_summary(record) -> str:
             f"- Step {g.get('step', '?')} ({g.get('name', '?')}): "
             f"{g.get('findings', '?')} findings, {g.get('resolved', '?')} resolved "
             f"[{g.get('status', '?')}]")
-    skipped = [str(s) for s in _as_list(sec.get("skipped"))]
-    lines.append(
-        f"- Step 11.5 (Security Scan): {sec.get('blocking_resolved', '?')} "
-        f"blocking resolved / {sec.get('advisory', '?')} advisory / "
-        f"skipped: {', '.join(skipped) if skipped else 'none'}")
+    if sec.get("ran"):
+        skipped = [str(s) for s in _as_list(sec.get("skipped"))]
+        lines.append(
+            f"- Step 11.5 (Security Scan): {sec.get('blocking_resolved', '?')} "
+            f"blocking resolved / {sec.get('advisory', '?')} advisory / "
+            f"skipped: {', '.join(skipped) if skipped else 'none'}")
+    else:
+        # A workflow with no tool-based security scan (e.g. WF3) — don't
+        # reference a Step 11.5 that never happened.
+        lines.append("- Security Scan: not run")
     lines.append("")
 
     lines.append("Verification:")

--- a/skills/fix-bug/SKILL.md
+++ b/skills/fix-bug/SKILL.md
@@ -632,35 +632,80 @@ Deployment verified OR rollback needed.
 
 ### Instructions
 
+The completion summary is no longer hand-typed. Assemble a structured
+**run-record** and drive the summary through `hooks/work_summary.py` — the same
+Tier-2 telemetry substrate WF2 Step 16 uses (see `docs/run-records.md`), so WF3's
+completion output is consistent and every run is measurable, not just a sentence
+read once.
+
 1. Update `claude_docs/session_notes.md` with fix summary.
 2. Close GitHub issue with closing comment:
    ```bash
    gh issue close <number> --repo capabilities.repo \
      --comment "Fixed in PR #<pr-number>. Root cause: <brief>. Fix: <brief>."
    ```
-3. Present completion summary to user:
+3. **Assemble the run-record** and write it to `/tmp/wf3-run-record.json` (use the
+   Write tool, or a `cat > … <<'JSON'` heredoc). Every key below must be
+   **present**; "nullable" means `null` is an allowed value, NOT that the key may
+   be omitted (a dropped field is a telemetry gap). Counts are non-negative
+   integers and `resolved` may not exceed `findings`:
 
-```
-WF3 COMPLETE
-=============
+   ```json
+   {
+     "workflow": "fix-bug",
+     "workflow_version": "<.claude-plugin/plugin.json version>",
+     "issue": {"number": <bug issue #>, "type": "bug",
+               "complexity": "trivial|standard|complex|null"},
+     "changes": {"files_changed": N, "insertions": N|null, "deletions": N|null,
+                 "commits": N},
+     "tests": {"added": N, "passing": N|null, "total": N|null},
+     "gates": [
+       {"step": "4", "name": "Lightweight Reflect", "findings": N, "resolved": N, "status": "pass|fail|skipped|fast_path"},
+       {"step": "9", "name": "Code Review",         "findings": N, "resolved": N, "status": "..."}
+     ],
+     "security_scan": {"ran": false, "blocking_resolved": 0, "advisory": 0, "skipped": []},
+     "loop_backs": {"used": N, "budget": 2},
+     "outcome": {"pr_number": N|null, "pr_url": "<url>"|null, "merged": true|false|null,
+                 "ci": "passed|failed|not_configured|skipped",
+                 "deploy": "success|manual|failed|not_applicable"},
+     "extra": [
+       {"label": "Root Cause", "value": "<one-line root cause>"},
+       {"label": "Fix",        "value": "<one-line fix>"}
+     ],
+     "follow_ups": ["<any item requiring future attention>", ...]
+   }
+   ```
+   WF3 has **no** tool-based security scan (that is WF2 Step 11.5), so
+   `security_scan.ran` is `false` (with zero counts and empty `skipped`) and the
+   render shows "Security Scan: not run". `extra` carries the Root Cause / Fix
+   lines WF3 has always shown. WF3's loop-back budget is **2**. Each gate's
+   `step` must be distinct; conditional memorization happens *within* Step 9
+   (Code Review), so record any memorized insights in `follow_ups` rather than as
+   a second step-9 gate.
 
-GitHub Issue: #<number> (CLOSED)
-PR: <URL> (#<pr-number>)
+4. **Render + persist** (carry `activeProject.path` in as a literal — shell vars
+   do not persist across Bash tool calls):
+   ```bash
+   python3 hooks/work_summary.py summarize \
+     --record-file /tmp/wf3-run-record.json \
+     --project-root <activeProject.path>
+   rc=$?
+   ```
+   The tool's stdout **is** the "WF3 COMPLETE" summary — present it to the user
+   as-is (do not re-type it). It also appends the record to
+   `<activeProject.path>/docs/measurements/run_records.jsonl` (override with
+   `--store` or `$RAWGENTIC_RUN_RECORD_STORE`).
 
-Root Cause: <one-line summary>
-Fix: <one-line summary>
+5. **Handle the exit code:**
+   - `rc == 0`: record valid and persisted. Done.
+   - `rc == 1`: the summary still rendered (the user keeps it) but the record
+     FAILED validation and was **not** persisted — a telemetry gap. The stderr
+     lists the bad fields; fix `/tmp/wf3-run-record.json` and re-run. If it
+     genuinely can't be fixed, record the gap in session notes.
+   - `rc == 2`: usage error / unreadable record file — fix the invocation.
 
-Quality Gates:
-- Reflect: [passed / looped back N times]
-- Code review: [2-agent focused review passed / N findings applied]
-- Memorized insights: [N insights saved / none]
-- CI: [passed]
-- Post-deploy: [verified]
-
-Loop-backs used: N / 2 (global cap)
-
-WF3 complete.
-```
+Log a marker in `claude_docs/session_notes.md`:
+`### WF3 Step 14: Completion summary + run-record — DONE (persisted: yes/no)`
 
 ### Failure Modes
 
@@ -676,6 +721,7 @@ Before declaring WF3 complete, verify ALL of the following. Print the checklist 
 5. [ ] Root cause documented in session notes
 6. [ ] Same-class bug scan completed
 7. [ ] E2E passed
+8. [ ] Completion summary rendered via `work_summary.py` (Step 14) and the run-record persisted (rc 0) — or, if validation failed (rc 1), the telemetry gap is recorded in session notes
 
 If ANY item fails, go back and complete it before declaring "WF3 complete."
 You may NOT output "WF3 complete" until all items pass.

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.33.0"
+    assert plugin["version"] == "2.34.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_work_summary.py
+++ b/tests/hooks/test_work_summary.py
@@ -89,6 +89,43 @@ class TestValidateHappyPath:
         del rec["follow_ups"]
         assert validate_record(rec) == []
 
+    def test_extra_optional_and_valid(self):
+        """`extra` carries ordered workflow-specific labeled lines (e.g. WF3's
+        Root Cause / Fix) — optional, defaults to absent."""
+        from work_summary import validate_record
+        rec = _valid_record()
+        assert validate_record(rec) == []          # absent is fine
+        rec["extra"] = [{"label": "Root Cause", "value": "off-by-one in retry"},
+                        {"label": "Fix", "value": "clamp index"}]
+        assert validate_record(rec) == []
+
+
+class TestValidateExtra:
+    def test_extra_must_be_list(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["extra"] = {"label": "x", "value": "y"}   # object, not a list
+        assert validate_record(rec) != []
+
+    def test_extra_item_must_be_object(self):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["extra"] = ["Root Cause: foo"]            # bare string, not {label,value}
+        assert validate_record(rec) != []
+
+    @pytest.mark.parametrize("item", [
+        {"value": "no label"},                        # missing label
+        {"label": "", "value": "empty label"},        # empty label
+        {"label": "ok"},                              # missing value
+        {"label": "ok", "value": 5},                  # non-string value
+        {"label": 5, "value": "x"},                   # non-string label
+    ])
+    def test_extra_item_field_violations(self, item):
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["extra"] = [item]
+        assert validate_record(rec) != []
+
     def test_empty_gates_list_is_valid(self):
         from work_summary import validate_record
         rec = _valid_record()
@@ -262,6 +299,34 @@ class TestValidateNumericIntegrity:
         rec["security_scan"]["ran"] = "yes"
         assert validate_record(rec) != []
 
+    @pytest.mark.parametrize("sec", [
+        {"ran": False, "blocking_resolved": 3, "advisory": 0, "skipped": []},
+        {"ran": False, "blocking_resolved": 0, "advisory": 2, "skipped": []},
+        {"ran": False, "blocking_resolved": 0, "advisory": 0, "skipped": ["x"]},
+    ])
+    def test_security_not_run_must_be_all_zero(self, sec):
+        """A scan that did not run (ran=false) cannot have resolved findings or
+        skipped scanners — the render would hide them ('not run') AND the
+        telemetry would be self-contradictory. The clean not-run shape is valid."""
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["security_scan"] = sec
+        assert validate_record(rec) != []
+        rec["security_scan"] = {"ran": False, "blocking_resolved": 0,
+                                "advisory": 0, "skipped": []}
+        assert validate_record(rec) == []
+
+    def test_duplicate_gate_step_is_error(self):
+        """Two gates sharing a step id would conflate in Tier-2 gate aggregation
+        (the WF3 footgun: a 'Memorize' row reusing Code Review's step 9)."""
+        from work_summary import validate_record
+        rec = _valid_record()
+        rec["gates"] = [
+            {"step": "9", "name": "Code Review", "findings": 0, "resolved": 0, "status": "pass"},
+            {"step": "9", "name": "Memorize", "findings": 0, "resolved": 0, "status": "pass"},
+        ]
+        assert validate_record(rec) != []
+
     def test_gate_missing_subfield_is_error(self):
         from work_summary import validate_record
         rec = _valid_record()
@@ -310,6 +375,11 @@ class TestNormalize:
         out = normalize_record(_valid_record(), now=NOW, schema_version=99)
         assert out["schema_version"] == 99
 
+    def test_fills_extra_default(self):
+        from work_summary import normalize_record
+        out = normalize_record(_valid_record(), now=NOW)
+        assert out["extra"] == []
+
 
 # --- render_summary --------------------------------------------------------
 
@@ -345,6 +415,44 @@ class TestRenderSummary:
         rec["security_scan"]["skipped"] = []
         text = render_summary(rec)
         assert "none" in text.lower()
+
+    def test_security_not_run_renders_cleanly(self):
+        """A workflow with no security scan (e.g. WF3) sets ran=false; the render
+        must not reference a Step 11.5 that didn't happen — it says 'not run'."""
+        from work_summary import render_summary
+        rec = _valid_record()
+        rec["workflow"] = "fix-bug"
+        rec["security_scan"] = {"ran": False, "blocking_resolved": 0,
+                                "advisory": 0, "skipped": []}
+        text = render_summary(rec)
+        assert "WF3 COMPLETE" in text
+        assert "not run" in text.lower()
+
+    def test_extra_lines_rendered(self):
+        from work_summary import render_summary
+        rec = _valid_record()
+        rec["extra"] = [{"label": "Root Cause", "value": "stale cache key"},
+                        {"label": "Fix", "value": "include tenant in key"}]
+        text = render_summary(rec)
+        assert "Root Cause: stale cache key" in text
+        assert "Fix: include tenant in key" in text
+
+    def test_extra_absent_renders_without_extra_lines(self):
+        from work_summary import render_summary
+        text = render_summary(_valid_record())
+        assert "Root Cause" not in text
+
+    def test_extra_nonstring_fields_skipped_in_render(self):
+        """Best-effort render runs on UNVALIDATED records: a malformed extra item
+        (null label / dict value) must not leak 'None:' or a dict repr."""
+        from work_summary import render_summary
+        rec = {"workflow": "fix-bug",
+               "extra": [{"label": None, "value": {"x": 1}},
+                         {"label": "Fix", "value": "ok"}]}
+        text = render_summary(rec)
+        assert "Fix: ok" in text
+        assert "None:" not in text
+        assert "{'x'" not in text
 
     def test_loop_backs_rendered(self):
         from work_summary import render_summary
@@ -578,13 +686,14 @@ class TestCLISubprocessSmoke:
 # --- Step 16 skill-wiring drift guard --------------------------------------
 
 class TestWorkSummarySkillWiring:
-    """Drift guard: WF2's Step 16 must drive the completion summary through this
-    CLI, not hand-type the block (which is exactly the inconsistency the
-    run-record removes). If the subcommand is renamed, update skill + guard."""
+    """Drift guard: every workflow with a completion step must drive its summary
+    through this CLI, not hand-type the block (the inconsistency the run-record
+    removes). If the subcommand is renamed, update the skills + this guard."""
 
-    def test_implement_feature_invokes_work_summary_cli(self):
-        content = (SKILLS_DIR / "implement-feature" / "SKILL.md").read_text()
+    @pytest.mark.parametrize("skill", ["implement-feature", "fix-bug"])
+    def test_skill_invokes_work_summary_cli(self, skill):
+        content = (SKILLS_DIR / skill / "SKILL.md").read_text()
         assert "work_summary.py summarize" in content, (
-            "implement-feature/SKILL.md Step 16 must invoke "
-            "`work_summary.py summarize`; if you renamed it, update this guard."
+            f"{skill}/SKILL.md completion step must invoke "
+            f"`work_summary.py summarize`; if you renamed it, update this guard."
         )


### PR DESCRIPTION
## Summary

Wires **WF3 (fix-bug) Step 14** into `hooks/work_summary.py` — the Tier-2 run-record telemetry substrate WF2 Step 16 already uses (#92). WF3's completion summary is no longer hand-typed: it assembles a structured run-record and the tool renders the standardized "WF3 COMPLETE" block **and** appends the record to `<project>/docs/measurements/run_records.jsonl`. Every bug-fix run is now measurable on the same substrate as feature runs.

## Design Decisions

- **Uniform core + `extra` escape hatch.** WF3 has content WF2 doesn't (Root Cause, Fix). Rather than bloat the core schema (the columns Tier-2 aggregates *across* workflows), I added an optional ordered `extra: [{label, value}]` list for workflow-specific human lines. WF2 omits it; WF3 carries Root Cause / Fix. Additive + backward-compatible → stays schema v1.
- **`security_scan.ran: false` for WF3.** WF3 has no Step 11.5 scan, so the render shows "Security Scan: not run" instead of referencing a step that never happened — and validation now enforces that a not-run scan has zero counts + empty `skipped` (no hidden/contradictory data).
- **Distinct gate `step` ids.** Tier-2 keys gate telemetry on `step`, so duplicate ids are rejected; WF3's conditional memorization (which lives *within* Step 9 Code Review) goes in `follow_ups`, not a second step-9 gate.
- The skill-wiring **drift guard is parametrized** over `implement-feature` and `fix-bug`, so neither can silently stop calling the CLI.

## Verification

- **131** `work_summary` tests (13 new); **full suite 1125 passing** locally.
- **Real-validated** a WF3 record end-to-end: renders "WF3 COMPLETE" with Root Cause / Fix (from `extra`), Step 4/9 gates, "Security Scan: not run", "Loop-backs 0 / 2"; persists with `extra` + `schema_version`; the contradictory `ran:false`-with-findings shape is rejected (rc 1).

## Quality Gate Summary

- **Cross-model review (Codex / gpt-5.5)** on the delta:
  - 1 × High — `ran:false` with nonzero counts validated but rendered as "not run" (hidden + self-contradictory). **Fixed** (require zero counts + empty skipped when not run).
  - 1 × Medium — WF3 prose suggested a duplicate step-9 "Memorize" gate; validation didn't catch duplicate steps. **Fixed both** (prose + reject duplicate gate `step`).
  - 1 × Low — best-effort render leaked `None:`/dict-repr for malformed `extra`. **Fixed** (skip non-string label/value).
  - 1 × Low — backward-compat: reviewer confirmed **no issue** (v2.33.0 records without `extra` still valid).
- Docs updated: `README.md`, `docs/run-records.md` (`extra` field, cross-workflow notes, generalized wiring section).
- Version bumped to **v2.34.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
