### PR TITLE
feat(session-start): per-project handoff scoped to the bound project

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ output). See [run-records.md](docs/run-records.md).
 2. **Ambiguity Circuit Breaker** — STOP and ask user when findings conflict
 3. **Finding Auto-Application** — Apply ALL quality gate findings automatically
 4. **Workflow Resumption** — Checkpoint artifacts for mid-workflow recovery
-5. **Session Notes** — Continuous documentation in `claude_docs/session_notes/<project>.md` (auto-created by setup/new-project, auto-registered by WAL hooks). The size handler trims notes exceeding 800 lines to the most recent 200 on startup and each context compaction.
+5. **Session Notes** — Continuous documentation in `claude_docs/session_notes/<project>.md` (auto-created by setup/new-project, auto-registered by WAL hooks). The size handler trims notes exceeding 800 lines to the most recent 200 on startup and each context compaction. A per-project **handoff** (`claude_docs/session_notes/<project>.handoff.md`) is injected by `session-start` for the bound project on startup/resume/clear and surfaced as the write target — so handoffs stay scoped per project instead of sharing the workspace-level remember-plugin handoff (see [session-notes.md](docs/session-notes.md#per-project-handoff)).
 6. **Commit Convention** — `<type>(scope): <description>` matching branch prefix
 7. **Branch from default** — All branches from `origin/<defaultBranch>` (read from config)
 8. **Squash merge** — All PRs use `gh pr merge --squash`

--- a/docs/session-notes.md
+++ b/docs/session-notes.md
@@ -51,6 +51,34 @@ working on.
 The session ID is persisted to `claude_docs/.current_session_id` by both hooks
 so `/rawgentic:switch` can read it (env vars are not available to skills).
 
+## Per-Project Handoff
+
+A **handoff** is a short "where I left off / what's next" briefing carried from
+one session to the next. Because every rawgentic-workspace session shares one
+`CLAUDE_PROJECT_DIR` (the workspace root), the generic `remember` plugin's
+workspace-level handoff (`.remember/remember.md`) cannot distinguish the bound
+project — switching projects would mix handoffs. rawgentic therefore keeps a
+**per-bound-project** handoff:
+
+- **File:** `claude_docs/session_notes/<project>.handoff.md` (one per project,
+  alongside the project's `<project>.md` notes).
+- **Injected by:** the `session-start` hook (SECTION 2e) on the fresh-context
+  events — `startup`, `resume`, and `clear` — for the **bound** project only
+  (resolved from the session registry). Skipped on `compact` (which already
+  preserves context). The hook also surfaces the file as the **write target** so
+  the next handoff lands in the right place, superseding the workspace-level
+  remember-plugin handoff for rawgentic-bound sessions.
+- **Persistent, not consumed-on-read.** Unlike the remember plugin (which clears
+  its handoff after injecting it), this file is left in place and simply
+  overwritten when a new handoff is written — so a crash before the next handoff
+  is recorded never loses the briefing.
+- **Size cap:** injection is bounded by `RAWGENTIC_HANDOFF_MAX_CHARS` (default
+  `8000`); longer handoffs are truncated in-context with a pointer to the full
+  file.
+
+Write the next handoff by overwriting `claude_docs/session_notes/<project>.handoff.md`
+with the current state and next actions.
+
 ## Session Lifecycle
 
 1. **Session starts.** `session-start` fires, trims oversized notes (see

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -465,6 +465,54 @@ if parts:
 _do_archive_context 2>/dev/null || true
 
 # =========================================================================
+# SECTION 2e: Per-Project Handoff (startup/resume/clear, bound sessions)
+# =========================================================================
+# rawgentic-workspace projects all share one CLAUDE_PROJECT_DIR (the workspace
+# root), so the generic remember plugin's workspace-level handoff
+# (.remember/remember.md) cannot separate them. Give each BOUND project its own
+# handoff at claude_docs/session_notes/<project>.handoff.md: inject it as a
+# briefing on the fresh-context events (startup/resume/clear, NOT compact —
+# compact preserves context) and surface it as the write target. It is
+# PERSISTENT (not consumed-on-read like the remember plugin), so a crash before
+# the next handoff is written never loses it; it is overwritten on next write.
+# Size is capped (RAWGENTIC_HANDOFF_MAX_CHARS, default 8000) to bound injection.
+_do_project_handoff() {
+    case "$EVENT_TYPE" in startup|resume|clear) ;; *) return 0 ;; esac
+    [ -n "$_registry_project" ] || return 0
+    [ -n "$CLAUDE_DOCS" ] || return 0
+
+    # Path-safety: the project name comes from the (locally-written) session
+    # registry and is used as a file-path component. Reject anything that isn't a
+    # plain project name — no path separators, no traversal, no leading dot/dash —
+    # so a corrupt/tampered registry can never read outside session_notes/.
+    case "$_registry_project" in
+        .*|-*|*..*|*[!A-Za-z0-9._-]*) return 0 ;;
+    esac
+
+    local handoff_file="$CLAUDE_DOCS/session_notes/${_registry_project}.handoff.md"
+    local note="this per-project handoff supersedes the workspace-level remember-plugin handoff"
+
+    # Fold the read into the guard so an existing-but-unreadable file falls
+    # through to the write-target hint rather than silently emitting nothing.
+    local content
+    if [ -f "$handoff_file" ] && [ -s "$handoff_file" ] && content=$(cat "$handoff_file" 2>/dev/null); then
+        local max="${RAWGENTIC_HANDOFF_MAX_CHARS:-8000}"
+        case "$max" in ''|*[!0-9]*) max=8000 ;; esac
+        if [ "${#content}" -gt "$max" ]; then
+            content="${content:0:$max}
+
+[handoff truncated to ${max} chars — full text in ${handoff_file}]"
+        fi
+        CONTEXT_PARTS+=("RAWGENTIC HANDOFF — ${_registry_project} (from ${handoff_file}; ${note} — overwrite this file with the next handoff):
+
+${content}")
+    else
+        CONTEXT_PARTS+=("RAWGENTIC HANDOFF — ${_registry_project}: no readable handoff yet. Write the next handoff for this project to \`${handoff_file}\` (per-project; ${note}).")
+    fi
+}
+_do_project_handoff 2>/dev/null || true
+
+# =========================================================================
 # SECTION 2c: Security Pattern Staleness Check (startup/resume only)
 # =========================================================================
 _do_security_staleness_check() {

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.34.0"
+    assert plugin["version"] == "2.35.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_session_start.py
+++ b/tests/hooks/test_session_start.py
@@ -483,3 +483,109 @@ class TestSizeHandler:
         content = notes_file.read_text()
         # Should be untrimmed (resume doesn't trigger size handler)
         assert content == large_content
+
+
+class TestPerProjectHandoff:
+    """Per-project handoff: rawgentic-workspace projects share one
+    CLAUDE_PROJECT_DIR, so the generic remember plugin can't separate their
+    handoffs. The session-start hook gives each BOUND project its own handoff at
+    claude_docs/session_notes/<project>.handoff.md — injected as a briefing and
+    surfaced as the write target. Persistent (not consumed-on-read)."""
+
+    def _bound(self):
+        return [{"session_id": "test-sess", "project": "testproj",
+                 "project_path": "./projects/testproj"}]
+
+    def _ctx(self, stdout):
+        out = parse_hook_output(stdout)
+        return out.get("hookSpecificOutput", {}).get("additionalContext", "") if out else ""
+
+    def test_injects_handoff_content_for_bound_project(self, make_workspace):
+        ws = make_workspace(registry_entries=self._bound())
+        (ws.notes_dir / "testproj.handoff.md").write_text("# Handoff\nNEXT: ship the thing")
+        stdout, _, rc = _run_session_start(ws.root)
+        assert rc == 0
+        assert "NEXT: ship the thing" in self._ctx(stdout)
+
+    def test_surfaces_write_target_even_with_no_handoff_yet(self, make_workspace):
+        ws = make_workspace(registry_entries=self._bound())
+        stdout, _, rc = _run_session_start(ws.root)
+        assert rc == 0
+        assert "testproj.handoff.md" in self._ctx(stdout)
+
+    def test_no_handoff_when_session_not_bound(self, make_workspace):
+        # registry binds a DIFFERENT session id → our session is unbound
+        ws = make_workspace(registry_entries=[
+            {"session_id": "someone-else", "project": "testproj",
+             "project_path": "./projects/testproj"}])
+        (ws.notes_dir / "testproj.handoff.md").write_text("SHOULD NOT APPEAR")
+        stdout, _, rc = _run_session_start(ws.root, session_id="test-sess")
+        ctx = self._ctx(stdout)
+        assert "SHOULD NOT APPEAR" not in ctx
+        assert "handoff.md" not in ctx
+
+    def test_not_injected_on_compact(self, make_workspace):
+        ws = make_workspace(registry_entries=self._bound())
+        (ws.notes_dir / "testproj.handoff.md").write_text("COMPACT-BODY-XYZ")
+        stdout, _, rc = _run_session_start(ws.root, event_type="compact")
+        assert "COMPACT-BODY-XYZ" not in self._ctx(stdout)
+
+    @pytest.mark.parametrize("event", ["startup", "resume", "clear"])
+    def test_injected_on_fresh_context_events(self, make_workspace, event):
+        ws = make_workspace(registry_entries=self._bound())
+        (ws.notes_dir / "testproj.handoff.md").write_text(f"BRIEF-{event}")
+        stdout, _, rc = _run_session_start(ws.root, event_type=event)
+        assert f"BRIEF-{event}" in self._ctx(stdout)
+
+    def test_handoff_is_persistent_not_consumed(self, make_workspace):
+        ws = make_workspace(registry_entries=self._bound())
+        f = ws.notes_dir / "testproj.handoff.md"
+        f.write_text("PERSIST ME")
+        _run_session_start(ws.root)
+        assert f.read_text() == "PERSIST ME"  # not cleared on read
+
+    def test_oversized_handoff_is_truncated(self, make_workspace):
+        ws = make_workspace(registry_entries=self._bound())
+        (ws.notes_dir / "testproj.handoff.md").write_text("X" * 5000)
+        stdout, _, rc = _run_session_start(
+            ws.root, env_override={"RAWGENTIC_HANDOFF_MAX_CHARS": "100"})
+        ctx = self._ctx(stdout)
+        assert "truncated" in ctx.lower()
+        assert "X" * 5000 not in ctx
+
+    def test_missing_handoff_file_no_crash(self, make_workspace):
+        ws = make_workspace(registry_entries=self._bound())
+        stdout, stderr, rc = _run_session_start(ws.root)
+        assert rc == 0
+        assert "testproj.handoff.md" in self._ctx(stdout)
+
+    def test_rejects_unsafe_project_name(self, make_workspace):
+        """A corrupt/tampered registry binding a path-traversal project name must
+        not become a file-path component — the handoff section is skipped, no
+        crash, nothing injected."""
+        ws = make_workspace(registry_entries=[
+            {"session_id": "test-sess", "project": "../../etc",
+             "project_path": "x"}])
+        stdout, stderr, rc = _run_session_start(ws.root)
+        assert rc == 0
+        assert "RAWGENTIC HANDOFF" not in self._ctx(stdout)
+
+    def test_unreadable_handoff_falls_back_to_write_target(self, make_workspace):
+        """An existing-but-unreadable handoff must still surface the write target
+        (not silently emit nothing) and never leak/crash."""
+        if os.geteuid() == 0:
+            pytest.skip("root bypasses file permissions")
+        ws = make_workspace(registry_entries=self._bound())
+        f = ws.notes_dir / "testproj.handoff.md"
+        f.write_text("SECRET UNREADABLE BODY")
+        f.chmod(0o000)
+        try:
+            # resume (not startup) → skips the startup-only claude_docs
+            # migration, isolating this to SECTION 2e's read path.
+            stdout, stderr, rc = _run_session_start(ws.root, event_type="resume")
+        finally:
+            f.chmod(0o644)
+        ctx = self._ctx(stdout)
+        assert rc == 0
+        assert "SECRET UNREADABLE BODY" not in ctx
+        assert "testproj.handoff.md" in ctx


### PR DESCRIPTION
## Summary

Makes session handoffs **per-bound-project** for rawgentic. Every rawgentic-workspace session shares one `CLAUDE_PROJECT_DIR` (the workspace root), so the generic `remember` plugin's workspace-level handoff (`.remember/remember.md`) can't tell which project you're bound to — `/switch`-ing projects mixes handoffs into one file. New **SECTION 2e** in the `session-start` hook gives each bound project its own handoff at `claude_docs/session_notes/<project>.handoff.md`, alongside the existing per-project `<project>.md` notes.

## Behavior

- **Injected** for the bound project (resolved from the session registry) on the fresh-context events — `startup` / `resume` / `clear` — and **skipped on `compact`** (which already preserves context). Also surfaced as the **write target**, superseding the workspace-level remember-plugin handoff for rawgentic-bound sessions.
- **Persistent, not consumed-on-read.** Unlike the remember plugin (which clears its handoff after injecting), this file is left in place and overwritten on the next write — so a crash before a new handoff is recorded never loses it.
- **Size-capped** by `RAWGENTIC_HANDOFF_MAX_CHARS` (default 8000, env-configurable per the project's v1-configurability convention); longer handoffs are truncated in-context with a pointer to the full file.

## Design Decisions

- Mirrors the existing SECTION 2b archive-injection pattern (gated on `startup|resume|clear` + bound `$_registry_project` + `CONTEXT_PARTS`), so it slots into the hook's established structure.
- Persistent over clear-on-read because rawgentic handoffs are written manually (not by an auto-save like the remember plugin), so clearing would risk silent loss.

## Verification

- **12** new `TestPerProjectHandoff` tests; **full suite 1137 passing** locally. Covers: injection when present, write-target surfaced when absent, not-bound → nothing, not-injected-on-compact, injected on startup/resume/clear, persistent (not consumed), truncation, missing file, **path-traversal rejection**, and **unreadable-file fallback**.
- Eyeballed a real hook invocation: the handoff injects with the write-target note (and works through the claude_docs migration path).

## Quality Gate Summary

- **Cross-model review (Codex / gpt-5.5)** on the bash:
  - High — registry-supplied project name used as a path component unsanitized. **Fixed** (reject traversal / separators / leading dot-or-dash before path use).
  - Low — an existing-but-unreadable handoff emitted nothing. **Fixed** (falls back to the write-target hint).
  - Critical (`set -u` on unset vars) — **verified false positive**: `EVENT_TYPE`, `_registry_project`, and `CLAUDE_DOCS` are all pre-initialized; confirmed by a real unbound-session run (rc 0, no stderr).
  - Declined with reason: multibyte truncation (documented *char* cap), persistent re-injection (deliberate; wording says "overwrite"), coexistence (cosmetic).
- Docs: `docs/session-notes.md` (new "Per-Project Handoff" section) + README invariant #5. Version → **v2.35.0**.

## Note

Takes effect for live sessions after the plugin cache is reinstalled (pending from the prior PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
