### PR TITLE
fix(binding): use per-session $CLAUDE_CODE_SESSION_ID, not shared file

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.35.1",
+  "version": "2.35.2",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ pytest tests/ -v
 pytest tests/hooks/test_wal_guard.py -v
 ```
 
-**~1,125 tests** across the hook + skill-helper modules. See [docs/testing.md](docs/testing.md) for full details.
+**~1,140 tests** across the hook + skill-helper modules. See [docs/testing.md](docs/testing.md) for full details.
 
 **CI:** GitHub Actions runs `pytest tests/ -v` on all PRs to `main` (`.github/workflows/ci.yml`). SDLC workflows also run tests automatically when `.rawgentic.json` has a `testing` section configured.
 
@@ -696,6 +696,9 @@ For major changes, please open an issue first to discuss the approach.
 
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
+
+### v2.35.2 (2026-06-15)
+- **Fix concurrent-session binding race.** `/rawgentic:switch`, `/rawgentic:new-project`, and the security-guard WAL logger now identify the session from the per-process env var `$CLAUDE_CODE_SESSION_ID` instead of the **shared** `claude_docs/.current_session_id` file (which every session overwrites on every prompt). Previously, with two concurrent sessions, a switch in one could write a registry line tagged with the *other* session's id and bind the wrong project — and `tail -1` resolution made it stick. The shared file is now a last-resort fallback only. (#98)
 
 ### v2.35.1 (2026-06-15)
 - **README Prerequisites overhaul.** Split into **Required** (added the missing **Python 3.10+** + Git/jq checks) and **Optional** (reflexion, superpowers, Codex CLI, security scanners) — each optional add-on now states the capability it unlocks and what you lose without it. (#97)

--- a/docs/wal-guide.md
+++ b/docs/wal-guide.md
@@ -165,3 +165,22 @@ automatically. Manual fix: `jq -c '.' file.jsonl > /tmp/clean.jsonl && mv
 **WAL file growing large** -- Rotation triggers at >5000 lines during
 session-start. Between sessions the file is untouched; it will be pruned at
 the next startup.
+
+**Two concurrent sessions bind to each other's project** -- Project binding is
+keyed on the session id. Hooks read the authoritative `session_id` from their
+stdin payload, but LLM-driven skills (`/rawgentic:switch`, `/rawgentic:new-project`)
+have no stdin and must self-identify. They read the per-process env var
+`$CLAUDE_CODE_SESSION_ID` (unique per session, concurrency-safe). They must
+**not** rely on `claude_docs/.current_session_id`, which is shared and
+overwritten by every session on every prompt — under concurrent sessions it can
+name the wrong session, writing a registry line that hijacks another session's
+binding (and `tail -1` resolution makes it sticky). The shared file remains only
+as a fallback for Claude Code builds that don't set the env var. To unstick a
+mis-bound live session without reinstalling, append an authoritative line from
+**that** session's terminal:
+```bash
+P=<project>
+printf '{"session_id":"%s","project":"%s","project_path":"./projects/%s","started":"%s","cwd":"%s"}\n' \
+  "$CLAUDE_CODE_SESSION_ID" "$P" "$P" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PWD" \
+  >> claude_docs/session_registry.jsonl
+```

--- a/hooks/security-guard.py
+++ b/hooks/security-guard.py
@@ -111,11 +111,13 @@ def _warn(message):
     print(json.dumps({"systemMessage": message}), file=sys.stdout)
 
 
-def _log_headless_guard_block(findings, rel_path, workspace_root):
+def _log_headless_guard_block(findings, rel_path, workspace_root, session_id=None):
     """Log security guard blocks to WAL when in headless mode.
 
     In bypassPermissions mode, guards are the last defense. Blocks MUST
     be auditable via the WAL so the orchestrator can detect them.
+
+    ``session_id`` should be the authoritative id from the hook's stdin payload.
     """
     try:
         from datetime import datetime, timezone
@@ -142,14 +144,24 @@ def _log_headless_guard_block(findings, rel_path, workspace_root):
             except (json.JSONDecodeError, OSError):
                 pass
 
-        # Read session registry to find the project
+        # Read session registry to find the project.
+        # Session-id source precedence (most → least authoritative):
+        #   1. explicit stdin session_id (passed by main from the hook payload)
+        #   2. $CLAUDE_CODE_SESSION_ID — per-process env var, concurrency-safe
+        #   3. .current_session_id file — SHARED across sessions; last resort only.
+        #      That file is overwritten by every session on every prompt, so under
+        #      concurrent sessions it can name the wrong session.
         registry_path = os.path.join(claude_docs, "session_registry.jsonl")
-        session_id_path = os.path.join(claude_docs, ".current_session_id")
 
-        session_id = "unknown"
-        if os.path.isfile(session_id_path):
-            with open(session_id_path) as f:
-                session_id = f.read().strip()
+        sid = (session_id or "").strip()
+        if not sid:
+            sid = os.environ.get("CLAUDE_CODE_SESSION_ID", "").strip()
+        if not sid:
+            session_id_path = os.path.join(claude_docs, ".current_session_id")
+            if os.path.isfile(session_id_path):
+                with open(session_id_path) as f:
+                    sid = f.read().strip()
+        session_id = sid or "unknown"
 
         project = "unknown"
         if os.path.isfile(registry_path):
@@ -249,7 +261,9 @@ def main():
     # Headless mode audit: log guard blocks to WAL for visibility
     # In bypassPermissions mode, guards are the last defense — blocks MUST be auditable
     if os.environ.get("RAWGENTIC_HEADLESS") == "1":
-        _log_headless_guard_block(remaining, rel_path, workspace_root)
+        _log_headless_guard_block(
+            remaining, rel_path, workspace_root, input_data.get("session_id")
+        )
 
     deny_output = format_deny(remaining, rel_path)
     print(json.dumps(deny_output), file=sys.stdout)

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -164,6 +164,14 @@ Read `.rawgentic_workspace.json`, then:
    ```json
    {"session_id":"<your session_id>","project":"<name>","project_path":"<path>","started":"<current ISO 8601 timestamp>","cwd":"<WORKSPACE_ROOT>"}
    ```
+   **For `<your session_id>` use the per-session env var `$CLAUDE_CODE_SESSION_ID`** (correct and unique even with concurrent sessions) — do this in a single Bash call so the id is captured atomically:
+   ```bash
+   SID="${CLAUDE_CODE_SESSION_ID:-$(cat claude_docs/.current_session_id 2>/dev/null)}"
+   printf '{"session_id":"%s","project":"%s","project_path":"%s","started":"%s","cwd":"%s"}\n' \
+     "$SID" "<name>" "<path>" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "<WORKSPACE_ROOT>" \
+     >> claude_docs/session_registry.jsonl
+   ```
+   **Do NOT** read `claude_docs/.current_session_id` as the primary source — it is shared across all sessions and overwritten on every prompt, so under concurrent sessions it can name the wrong session. (The legacy name `$CLAUDE_SESSION_ID` is not set; use `$CLAUDE_CODE_SESSION_ID`.)
 4. **Initialize session notes file:** If `claude_docs/session_notes/<name>.md` does not exist, create it with:
    ```markdown
    # Session Notes -- <name>

--- a/skills/switch/SKILL.md
+++ b/skills/switch/SKILL.md
@@ -90,7 +90,20 @@ Read `.rawgentic_workspace.json`, then:
    ```
    Create the file and `claude_docs/session_notes/` directory if they don't exist.
 
-   **How to get your session ID:** Read the file `claude_docs/.current_session_id` using Bash (`cat claude_docs/.current_session_id`). This file is written by the session-start and wal-context hooks on every prompt. **Do NOT use `$CLAUDE_SESSION_ID`** — it is not available as an environment variable. **Do NOT invent a session ID** — always read it from this file.
+   **How to get your session ID — use the per-session env var, NOT the shared file:**
+
+   Read it from `$CLAUDE_CODE_SESSION_ID`, which is set per Claude Code process (so it is unique and correct even when multiple sessions run **concurrently**). Always read and write the registry line in a **single Bash call** so the id is captured atomically:
+
+   ```bash
+   SID="${CLAUDE_CODE_SESSION_ID}"
+   # Fallback only for older Claude Code that doesn't set the env var:
+   [ -n "$SID" ] || SID="$(cat claude_docs/.current_session_id 2>/dev/null)"
+   printf '{"session_id":"%s","project":"%s","project_path":"%s","started":"%s","cwd":"%s"}\n' \
+     "$SID" "<target project name>" "<target project path>" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "<workspace root>" \
+     >> claude_docs/session_registry.jsonl
+   ```
+
+   **Do NOT** read `claude_docs/.current_session_id` as the primary source: that file is **shared across all sessions** and is overwritten by every session on every prompt, so under concurrent sessions it can return *another* session's id and bind the wrong session. (Note: the legacy name `$CLAUDE_SESSION_ID` is **not** set — the correct variable is `$CLAUDE_CODE_SESSION_ID`.) **Do NOT invent a session ID.**
 
 Report:
 ```

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.35.1"
+    assert plugin["version"] == "2.35.2"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_session_binding.py
+++ b/tests/hooks/test_session_binding.py
@@ -1,0 +1,135 @@
+"""Concurrent-session binding-race fix.
+
+Root cause: LLM-driven skills (`switch`, `new-project`) and the security-guard
+WAL logger identified "my session" by reading the *shared* file
+`claude_docs/.current_session_id`, which every session overwrites on every
+prompt. With two concurrent sessions, that file holds whichever session most
+recently submitted a prompt — so a switch in session B could write a registry
+line tagged with session A's id and bind the wrong session. `tail -1`
+resolution then made the mis-binding sticky.
+
+Fix: identify the session from the per-process env var `CLAUDE_CODE_SESSION_ID`
+(the correct name — `CLAUDE_SESSION_ID` is unset), with the shared file kept
+only as a last-resort fallback. The hooks already use the authoritative stdin
+`session_id`; the security-guard logger now prefers that too.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+SKILLS_DIR = REPO_ROOT / "skills"
+sys.path.insert(0, str(HOOKS_DIR))
+
+
+def _load_security_guard():
+    """Import the hyphenated security-guard.py as a module (it is __main__-guarded)."""
+    spec = importlib.util.spec_from_file_location(
+        "security_guard_main_mod", HOOKS_DIR / "security-guard.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- security-guard WAL logger: session-id precedence --------------------------
+
+SID_A = "sess-aaa-1111"
+SID_B = "sess-bbb-2222"
+
+
+def _two_project_ws(make_workspace):
+    """Workspace with two active projects and a registry mapping each session id
+    to a distinct project. Writes `.current_session_id` = SID_A (the *wrong* one)."""
+    ws = make_workspace(
+        projects=[
+            {"name": "projA", "path": "./projects/projA", "active": True,
+             "lastUsed": "2026-01-01T00:00:00Z", "configured": True},
+            {"name": "projB", "path": "./projects/projB", "active": True,
+             "lastUsed": "2026-01-01T00:00:00Z", "configured": True},
+        ],
+        registry_entries=[
+            {"session_id": SID_A, "project": "projA",
+             "project_path": "./projects/projA", "started": "2026-01-01T00:00:00Z",
+             "cwd": "/x"},
+            {"session_id": SID_B, "project": "projB",
+             "project_path": "./projects/projB", "started": "2026-01-01T00:00:01Z",
+             "cwd": "/x"},
+        ],
+    )
+    # The shared file points at the WRONG session — the bug's trigger condition.
+    (ws.claude_docs / ".current_session_id").write_text(SID_A)
+    return ws
+
+
+def test_log_uses_explicit_stdin_session_id_over_shared_file(make_workspace, monkeypatch):
+    """An explicit (stdin) session id must win over the shared .current_session_id file."""
+    mod = _load_security_guard()
+    ws = _two_project_ws(make_workspace)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+
+    mod._log_headless_guard_block(
+        [{"name": "some-rule"}], "foo.py", str(ws.root), session_id=SID_B
+    )
+
+    wal_b = ws.claude_docs / "wal" / "projB.jsonl"
+    wal_a = ws.claude_docs / "wal" / "projA.jsonl"
+    assert wal_b.exists(), "block must be logged under the correct (stdin) project"
+    assert not wal_a.exists(), "must NOT log under the shared-file's stale project"
+    entry = json.loads(wal_b.read_text().strip())
+    assert entry["session"] == SID_B
+    assert entry["phase"] == "GUARD_BLOCK"
+
+
+def test_log_falls_back_to_env_var_when_no_explicit_id(make_workspace, monkeypatch):
+    """With no explicit id, the per-session env var beats the shared file."""
+    mod = _load_security_guard()
+    ws = _two_project_ws(make_workspace)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID_B)
+
+    mod._log_headless_guard_block([{"name": "r"}], "foo.py", str(ws.root))
+
+    assert (ws.claude_docs / "wal" / "projB.jsonl").exists()
+    assert not (ws.claude_docs / "wal" / "projA.jsonl").exists()
+
+
+def test_log_falls_back_to_shared_file_when_no_id_and_no_env(make_workspace, monkeypatch):
+    """Backward compat: with neither explicit id nor env var, the file is still used."""
+    mod = _load_security_guard()
+    ws = _two_project_ws(make_workspace)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+
+    mod._log_headless_guard_block([{"name": "r"}], "foo.py", str(ws.root))
+
+    # File says SID_A -> projA
+    assert (ws.claude_docs / "wal" / "projA.jsonl").exists()
+    assert not (ws.claude_docs / "wal" / "projB.jsonl").exists()
+
+
+# --- SKILL drift guards: switch + new-project must use the env var -------------
+
+def test_switch_skill_uses_env_var_for_session_id():
+    text = (SKILLS_DIR / "switch" / "SKILL.md").read_text()
+    assert "$CLAUDE_CODE_SESSION_ID" in text, \
+        "switch skill must source the session id from $CLAUDE_CODE_SESSION_ID"
+    # Must explain WHY the shared file is unsafe (concurrency).
+    assert "concurrent" in text.lower()
+    # Must NOT keep the old directive that the shared file is the source of truth.
+    assert "always read it from this file" not in text
+
+
+def test_switch_skill_documents_correct_env_var_name():
+    """The legacy name CLAUDE_SESSION_ID is unset; the correct one is CLAUDE_CODE_SESSION_ID."""
+    text = (SKILLS_DIR / "switch" / "SKILL.md").read_text()
+    # The bare wrong name must not appear without the CODE_ infix as the recommended source.
+    assert "CLAUDE_CODE_SESSION_ID" in text
+
+
+def test_new_project_skill_uses_env_var_for_session_id():
+    text = (SKILLS_DIR / "new-project" / "SKILL.md").read_text()
+    assert "$CLAUDE_CODE_SESSION_ID" in text, \
+        "new-project skill must source the session id from $CLAUDE_CODE_SESSION_ID"


### PR DESCRIPTION
## Problem

Two concurrent Claude Code sessions on different projects kept binding to **each other's** project.

Binding is keyed on session id. The hooks (`wal-context`, `wal-bind-guard`, `session-start`) read the authoritative `session_id` from their stdin payload — correct and concurrency-safe. But the **LLM-driven skills** `/rawgentic:switch` and `/rawgentic:new-project` have no stdin, so they self-identified by reading the **shared** file `claude_docs/.current_session_id`. That file is overwritten by *every* session on *every* prompt (`wal-context`, `session-start`).

With two live sessions A and B, in the window between session B submitting `/rawgentic:switch` and the skill's Bash reading the file, session A can submit a prompt and clobber the file to A's id. The skill then appends a registry line tagging **A's** id with **B's** target project. Resolution (`grep $id | tail -1`) sends A to B's project — and because the bad line is *last*, the mis-binding is sticky until the victim switches again (which can re-race). `security-guard.py`'s headless WAL logger had the same shared-file flaw (mis-attributed the audit log's project).

The skill instructions even ruled out an env var — but checked the **wrong name**: `CLAUDE_SESSION_ID` is unset, while `CLAUDE_CODE_SESSION_ID` is set and is per-process (hence per-session).

## Fix

Identify the session from `$CLAUDE_CODE_SESSION_ID`. Precedence: explicit stdin id → env var → shared file (fallback only, for older Claude Code).

- **`hooks/security-guard.py`** — thread the stdin `session_id` into `_log_headless_guard_block`; env var then file as fallbacks.
- **`skills/switch/SKILL.md`, `skills/new-project/SKILL.md`** — register via `$CLAUDE_CODE_SESSION_ID` in a single atomic Bash call; document that the shared file is unsafe under concurrency.
- **`docs/wal-guide.md`** — troubleshooting entry + a recipe to unstick a mis-bound live session without reinstalling.

## Tests

`tests/hooks/test_session_binding.py` (6 new, TDD RED→GREEN):
- logger uses the explicit stdin id over the shared file;
- logger falls back to the env var, then to the file;
- `switch` + `new-project` skill drift guards (must reference `$CLAUDE_CODE_SESSION_ID`, must not keep the old "always read it from this file" directive).

Full suite: **1143 passed** locally.

## Note

The running plugin is the cached v2.35.0 build, so this fix takes effect only after a plugin reinstall in a fresh session. Until then, the `docs/wal-guide.md` one-liner unsticks live sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)