### PR TITLE
fix(security-scan): honor project-local .trivyignore via --ignorefile (#99)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.35.2",
+  "version": "2.36.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -697,6 +697,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v2.36.0 (2026-06-16)
+- **Step 11.5 / WF9 gate now honors a project-local `.trivyignore`.** `security_scan.py` passes `trivy config --ignorefile <project-root>/.trivyignore` when that file exists, so a committed, reviewed IaC-misconfig suppression is honored deterministically regardless of the gate's working directory. Previously the gate set no `--ignorefile`, and trivy reads `.trivyignore` only from its *own* cwd (not the scan target), so project suppressions were silently ignored. Anchored to the declared `--project-root`; absent → command byte-for-byte unchanged. See `docs/security-scan.md`. (#99)
+
 ### v2.35.2 (2026-06-15)
 - **Fix concurrent-session binding race.** `/rawgentic:switch`, `/rawgentic:new-project`, and the security-guard WAL logger now identify the session from the per-process env var `$CLAUDE_CODE_SESSION_ID` instead of the **shared** `claude_docs/.current_session_id` file (which every session overwrites on every prompt). Previously, with two concurrent sessions, a switch in one could write a registry line tagged with the *other* session's id and bind the wrong project — and `tail -1` resolution made it stick. The shared file is now a last-resort fallback only. (#98)
 

--- a/docs/security-scan.md
+++ b/docs/security-scan.md
@@ -42,6 +42,31 @@ so a lower setting only makes the gate stricter (e.g. `medium` blocks
 medium/high/critical) and can never accidentally let a high/critical through. An
 empty or unrecognized value falls back to the fail-closed default.
 
+## Suppressing IaC misconfigs (`.trivyignore`)
+
+A project can suppress specific trivy IaC misconfigs by committing a `.trivyignore`
+file at its **project root**, listing the trivy IDs to ignore — written exactly as
+trivy emits them in the JSON `Misconfigurations[].ID` field (on current trivy that
+is the hyphenated form, e.g. `DS-0002`; a mismatched token such as `DS0002` matches
+nothing and silently suppresses nothing), one per line, with `#` comments for the
+rationale. When `<project-root>/.trivyignore` exists (and is a file), the gate
+passes it to trivy as `--ignorefile <project-root>/.trivyignore`, so the suppression
+is honored **deterministically, regardless of the cwd the gate runs from**. (trivy
+only auto-discovers `.trivyignore` from its own working directory, which the gate
+does not control — so without the explicit `--ignorefile` a committed suppression
+would be silently ignored.)
+
+Only the plain-line `.trivyignore` is honored; trivy's structured `.trivyignore.yaml`
+variant is **not** passed by the gate (track it as an enhancement if a project needs
+the YAML form's `reason`/`expires` fields).
+
+The file is anchored to the **declared `--project-root`**, never an arbitrary path;
+when absent, the trivy command is byte-for-byte unchanged. Because the suppression
+lives in the repo, appears in the diff, and goes through code review, it is the
+project owner's deliberate, auditable choice — matching trivy's intended model.
+Record the rationale beside each ID (and ideally in a `docs/` posture note) so a
+future reader sees *why* a finding is suppressed.
+
 ## CLI
 
 ```bash

--- a/hooks/security_scan.py
+++ b/hooks/security_scan.py
@@ -298,7 +298,19 @@ def _build_semgrep(project_root, base_ref, full):
 
 
 def _build_trivy_config(project_root, base_ref, full):
-    return ["trivy", "config", "--quiet", "--format", "json", project_root]
+    # trivy reads .trivyignore ONLY from its process cwd, not the scan target,
+    # and the gate (_default_runner) runs trivy from an uncontrolled cwd — so a
+    # committed, reviewed project-local .trivyignore would be SILENTLY IGNORED
+    # without an explicit --ignorefile. Pass it when present (anchored to the
+    # DECLARED project_root, never an arbitrary path) so the gate honors the
+    # project's documented misconfig suppressions deterministically, regardless
+    # of cwd. Absent -> the command is byte-for-byte unchanged (today's behavior).
+    cmd = ["trivy", "config", "--quiet", "--format", "json"]
+    ignorefile = os.path.join(project_root, ".trivyignore")
+    if os.path.isfile(ignorefile):
+        cmd += ["--ignorefile", ignorefile]
+    cmd.append(project_root)
+    return cmd
 
 
 # Each scanner: a kind + ordered tool candidates. select_scanners picks the first

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.35.2"
+    assert plugin["version"] == "2.36.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_security_scan.py
+++ b/tests/hooks/test_security_scan.py
@@ -254,6 +254,50 @@ class TestParseTrivyConfig:
         assert "Dockerfile" in f["location"]
 
 
+# --- _build_trivy_config (honor a project-local .trivyignore) --------------
+
+class TestBuildTrivyConfig:
+    """trivy reads .trivyignore ONLY from its process CWD (not the scan target),
+    and the gate runs trivy from an uncontrolled CWD — so the command MUST pass
+    an explicit --ignorefile for a committed, reviewed project-local .trivyignore
+    to be honored at all. The ignorefile is anchored to the DECLARED project_root
+    (never an arbitrary path); when absent, the command is byte-for-byte
+    unchanged so today's behavior is preserved."""
+
+    def test_absent_trivyignore_passes_no_ignorefile(self, tmp_path):
+        from security_scan import _build_trivy_config
+        cmd = _build_trivy_config(str(tmp_path), "origin/main", False)
+        assert "--ignorefile" not in cmd
+        assert cmd == ["trivy", "config", "--quiet", "--format", "json",
+                       str(tmp_path)]
+
+    def test_present_trivyignore_adds_ignorefile_anchored_to_root(self, tmp_path):
+        from security_scan import _build_trivy_config
+        ti = tmp_path / ".trivyignore"
+        ti.write_text("DS-0002\n")
+        cmd = _build_trivy_config(str(tmp_path), "origin/main", False)
+        assert "--ignorefile" in cmd
+        i = cmd.index("--ignorefile")
+        # anchored to the DECLARED project_root, never an arbitrary location
+        assert cmd[i + 1] == str(ti)
+        # the positional scan target remains the project_root, and stays last
+        assert cmd[-1] == str(tmp_path)
+
+    def test_directory_named_trivyignore_is_not_treated_as_a_file(self, tmp_path):
+        from security_scan import _build_trivy_config
+        (tmp_path / ".trivyignore").mkdir()
+        cmd = _build_trivy_config(str(tmp_path), "origin/main", False)
+        assert "--ignorefile" not in cmd
+
+    def test_full_mode_also_honors_ignorefile(self, tmp_path):
+        # WF9 (--full / whole-tree) uses the same builder; a suppression must
+        # apply there too, not only in WF2's diff-scoped Step 11.5.
+        from security_scan import _build_trivy_config
+        (tmp_path / ".trivyignore").write_text("DS-0002\n")
+        cmd = _build_trivy_config(str(tmp_path), "origin/main", True)
+        assert "--ignorefile" in cmd
+
+
 # --- select_scanners -------------------------------------------------------
 
 class TestSelectScanners:


### PR DESCRIPTION
## Summary
The WF2 Step 11.5 / WF9 security gate could not honor a project-local `.trivyignore`.
`_build_trivy_config` ran `trivy config <root>` with **no `--ignorefile`**, and
`_default_runner` sets **no cwd** — but trivy reads `.trivyignore` only from its
*process* working directory (not the scan target), so a committed, reviewed IaC
suppression was **silently ignored** and a HIGH misconfig kept blocking the PR.

This makes `_build_trivy_config` append `--ignorefile <project_root>/.trivyignore`
when that path is a file, so the suppression is honored **deterministically,
regardless of the gate's cwd**.

Closes #99

## Design decisions
- **Anchored to the declared `--project-root`** (`os.path.join(project_root, ".trivyignore")`),
  never an arbitrary path → no traversal vector; the filename is a hardcoded literal.
- **`os.path.isfile()` guard is load-bearing**, not cosmetic: `--ignorefile` pointing at a
  missing path is a **fatal error on trivy 0.65+**, so an absent file must omit the flag.
  Absent → the command is **byte-for-byte unchanged** (today's behavior preserved).
- Trust model: suppressions live in the repo, appear in the diff, and pass code review —
  matching trivy's intended model and consistent with `RAWGENTIC_SECURITY_BLOCK_SEVERITIES`
  and `/rawgentic:add-exception`.
- Scope: plain-line `.trivyignore` only; the structured `.trivyignore.yaml` variant is
  documented as not-honored (future enhancement), to avoid a silent-suppression footgun.

## Verification
- **TDD** (RED→GREEN): added `TestBuildTrivyConfig` (4 cases): absent→no flag (full list
  equality); present→`--ignorefile` anchored to root + positional target stays last; a
  *directory* named `.trivyignore`→no flag; full/WF9 mode also honored.
- **Full suite: `pytest tests/ -v` → 1147 passed** (no regressions).
- **Integration-verified** on trivy 0.71.1: the exact produced command
  `trivy config --quiet --format json --ignorefile <root>/.trivyignore <root>` is accepted
  and clears the suppressed finding **from a scratch cwd**; the negative control (no
  `--ignorefile`) re-surfaces `DS-0002` — proving the flag is load-bearing.
- **Security scan (dogfood)** on this diff: gate PASS, 0 findings (gitleaks + semgrep ran
  clean; iac/sca skipped as expected for a non-docker library).

## Quality gate summary
- Code review (1 adversarial reviewer): **no blocking findings**; confirmed the isfile guard
  prevents a fatal-on-missing-file crash; applied 2 doc refinements (plain-only `.trivyignore`
  note; version-robust ID wording).
- Security scan: PASS (0 blocking, 0 advisory).
- Version bumped 2.35.2 → **2.36.0** (minor — new gate capability); README + `docs/security-scan.md` updated.

## Why now (cross-repo context)
Surfaced by the WF2 Step 4 adversarial critique while implementing **3dstories-studio #91**
(suppressing `DS-0002`, root-by-design). That studio `.trivyignore` would never have been
honored by the gate. This PR is the **durable fix** and a prerequisite for #91's standard-gate
acceptance (effective once merged + the plugin is reinstalled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
