### PR TITLE
fix(security-scan): make the gate cwd-independent for all scanners (#101)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.36.0",
+  "version": "2.36.1",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/.rawgentic/review-state/fix-101-security-scan-cwd-independent.json
+++ b/.rawgentic/review-state/fix-101-security-scan-cwd-independent.json
@@ -1,0 +1,6 @@
+{
+  "branch": "fix/101-security-scan-cwd-independent",
+  "last_review_log_status": "applied",
+  "schema_version": 1,
+  "ts": "2026-06-16T04:12:58Z"
+}

--- a/README.md
+++ b/README.md
@@ -697,6 +697,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v2.36.1 (2026-06-16)
+- **Step 11.5 / WF9 security gate is now cwd-independent for every scanner.** `security_scan.py`'s `run_scan` normalizes `--project-root` to an absolute path and threads it as each scanner's working directory (`cwd`). Previously the scanners inherited the gate *process's* cwd, so semgrep's diff mode (`--baseline-commit`) couldn't resolve the baseline ref when the gate was invoked from any dir other than the repo root — it exited `rc=2` and (fail-closed) blocked the whole gate with zero findings. Same class of latent cwd-dependence the `.trivyignore` `--ignorefile` change fixed for trivy in v2.36.0; now generalized to all scanners. See `docs/security-scan.md`. (#101)
+
 ### v2.36.0 (2026-06-16)
 - **Step 11.5 / WF9 gate now honors a project-local `.trivyignore`.** `security_scan.py` passes `trivy config --ignorefile <project-root>/.trivyignore` when that file exists, so a committed, reviewed IaC-misconfig suppression is honored deterministically regardless of the gate's working directory. Previously the gate set no `--ignorefile`, and trivy reads `.trivyignore` only from its *own* cwd (not the scan target), so project suppressions were silently ignored. Anchored to the declared `--project-root`; absent → command byte-for-byte unchanged. See `docs/security-scan.md`. (#99)
 

--- a/docs/security-scan.md
+++ b/docs/security-scan.md
@@ -67,6 +67,22 @@ project owner's deliberate, auditable choice — matching trivy's intended model
 Record the rationale beside each ID (and ideally in a `docs/` posture note) so a
 future reader sees *why* a finding is suppressed.
 
+## Working directory (cwd-independence)
+
+The gate is **cwd-independent for every scanner**: `run_scan` normalizes
+`--project-root` to an absolute path once and runs each scanner with that
+directory as its working directory (`cwd`). This matters because some tools
+resolve git state against their *process cwd*, not the scan target — most
+notably semgrep's diff mode (`--baseline-commit <ref>`), which exits `rc=2` and
+(fail-closed) blocks the whole gate with zero findings if it can't resolve the
+baseline ref from the current directory. Threading `cwd=<project-root>` means
+the gate gives identical results whether you invoke it from the repo root or
+from the plugin's `hooks/` directory.
+
+This generalizes the `.trivyignore` `--ignorefile` fix above (which made *trivy*
+cwd-robust): now every scanner — gitleaks, the SCA tools, semgrep, and trivy —
+runs from the declared `--project-root` regardless of the caller's cwd.
+
 ## CLI
 
 ```bash

--- a/hooks/security_scan.py
+++ b/hooks/security_scan.py
@@ -471,8 +471,8 @@ def run_scan(project_root, *, project_type="unknown", has_docker=False,
     # changed cwd). semgrep in particular resolves `--baseline-commit` against its
     # process cwd, not the target, so without this it exits rc=2 — fail-closing the
     # whole gate with zero findings — whenever the gate is invoked from any dir
-    # other than the repo root. Same class of latent cwd-dependence #100 fixed for
-    # trivy's .trivyignore.
+    # other than the repo root. Same class of latent cwd-dependence v2.36.0 fixed
+    # for trivy's .trivyignore.
     project_root = os.path.abspath(project_root)
 
     # Resolve availability against the union of every candidate tool.

--- a/hooks/security_scan.py
+++ b/hooks/security_scan.py
@@ -447,6 +447,9 @@ def decide_gate(findings, errors=(), block_severities=None) -> dict:
 # --- orchestrator ----------------------------------------------------------
 
 def _default_runner(cmd, **kwargs):
+    # **kwargs forwards run_scan's cwd=project_root (and anything else) straight to
+    # subprocess.run, so every scanner runs from the project root regardless of the
+    # gate's own working directory (#101).
     return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
 
 
@@ -461,6 +464,16 @@ def run_scan(project_root, *, project_type="unknown", has_docker=False,
     which = which or shutil.which
     runner = runner or _default_runner
     env = os.environ if env is None else env
+    # Normalize to an absolute path ONCE so the gate is cwd-independent for every
+    # scanner (#101): this same value is both the scan TARGET handed to each
+    # builder below AND the subprocess `cwd` threaded into the runner, so the two
+    # can never disagree (a relative target would otherwise be re-rooted against a
+    # changed cwd). semgrep in particular resolves `--baseline-commit` against its
+    # process cwd, not the target, so without this it exits rc=2 — fail-closing the
+    # whole gate with zero findings — whenever the gate is invoked from any dir
+    # other than the repo root. Same class of latent cwd-dependence #100 fixed for
+    # trivy's .trivyignore.
+    project_root = os.path.abspath(project_root)
 
     # Resolve availability against the union of every candidate tool.
     candidate_tools = {c["tool"] for s in SCANNERS for c in s["candidates"]}
@@ -478,7 +491,11 @@ def run_scan(project_root, *, project_type="unknown", has_docker=False,
                 "reason": f"{scanner['tool']}: no scannable target in project"})
             continue
         try:
-            proc = runner(cmd)
+            # Run each scanner from the (absolute) project root so its git /
+            # baseline resolution happens against the target repo, not the caller's
+            # cwd (#101). _default_runner forwards cwd to subprocess.run via
+            # **kwargs; injected test runners accept (and may assert on) it too.
+            proc = runner(cmd, cwd=project_root)
         except (OSError, subprocess.SubprocessError) as exc:
             errors.append({"scanner": scanner["tool"],
                            "message": f"failed to run: {exc}"})

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.36.0"
+    assert plugin["version"] == "2.36.1"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_security_scan.py
+++ b/tests/hooks/test_security_scan.py
@@ -911,3 +911,92 @@ class TestSessionStartBootstrap:
         assert "scanners-bootstrapped" in t  # run-once marker
         # must not block the hook: fire-and-forget
         assert "nohup" in t
+
+
+# --- #101: scanners must be cwd-independent (run from project_root) ---------
+
+class TestRunScanCwdIndependence:
+    """#101: every scanner must run with cwd == abspath(project_root).
+
+    semgrep resolves ``--baseline-commit`` against its *process cwd*, not the scan
+    target, so when the gate is invoked from any cwd other than the repo root it
+    exits rc=2 and fail-closes the WHOLE gate with zero findings (the #101 symptom
+    — the same class of latent cwd-dependence that #100 fixed for trivy's
+    ``.trivyignore``). The fix normalizes ``project_root`` to an absolute path once
+    and threads it as the subprocess ``cwd`` for ALL scanners, so the target and
+    the cwd stay consistent regardless of the caller's directory.
+
+    These tests simulate cwd-dependence through the injected ``runner`` (the
+    suite's no-real-tools philosophy) rather than chdir'ing the test process, so
+    they are deterministic and need neither semgrep nor a git repo installed.
+    """
+
+    @staticmethod
+    def _clean_runner(calls):
+        clean = {
+            "gitleaks": "[]",
+            "osv-scanner": '{"results": []}',
+            "semgrep": '{"results": [], "errors": []}',
+        }
+
+        def runner(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return _proc(0, clean.get(cmd[0], "[]"))
+
+        return runner
+
+    def test_runner_receives_abspath_project_root_as_cwd(self):
+        from security_scan import run_scan
+        calls = []
+        run_scan("/proj", project_type="node", has_docker=False,
+                 base_ref="origin/main",
+                 which=_which_from({"gitleaks", "osv-scanner", "semgrep"}),
+                 runner=self._clean_runner(calls), env={})
+        assert calls, "expected at least one scanner to run"
+        assert all(kw.get("cwd") == os.path.abspath("/proj") for _, kw in calls), \
+            ("every scanner must run with cwd=abspath(project_root); got "
+             f"{[kw.get('cwd') for _, kw in calls]}")
+
+    def test_relative_project_root_is_normalized_to_absolute(self):
+        # The user-chosen design: a *relative* --project-root must be normalized to
+        # an absolute path so the threaded cwd is valid from any caller cwd AND the
+        # scan target stays consistent with it (a relative target would otherwise
+        # be re-rooted against the new cwd).
+        from security_scan import run_scan
+        calls = []
+        run_scan("relative/sub", project_type="node", has_docker=False,
+                 base_ref="origin/main",
+                 which=_which_from({"gitleaks", "semgrep"}),
+                 runner=self._clean_runner(calls), env={})
+        expected = os.path.abspath("relative/sub")
+        assert calls
+        assert all(os.path.isabs(kw.get("cwd") or "") for _, kw in calls), \
+            "a relative --project-root must be normalized to an absolute cwd"
+        assert all(kw.get("cwd") == expected for _, kw in calls)
+        # target handed to each builder is the same normalized absolute path
+        assert all(expected in cmd for cmd, _ in calls), \
+            f"expected absolute target {expected} in every scanner cmd"
+
+    def test_semgrep_not_failclosed_when_cwd_is_threaded(self):
+        # Behavioral regression mirroring the #101 repro: a cwd-sensitive semgrep
+        # exits rc=2 unless invoked from the repo root. With cwd threaded it
+        # resolves the baseline and the gate is clean; without it the gate
+        # fail-closes on a phantom scanner error.
+        from security_scan import run_scan
+        abs_root = os.path.abspath("/proj")
+
+        def runner(cmd, **kwargs):
+            if cmd[0] == "semgrep":
+                if kwargs.get("cwd") == abs_root:
+                    return _proc(0, '{"results": [], "errors": []}')
+                return _proc(2, "", stderr="fatal: bad revision 'origin/main'")
+            return _proc(0, "[]")
+
+        result = run_scan("/proj", project_type="node", has_docker=False,
+                          base_ref="origin/main",
+                          which=_which_from({"gitleaks", "semgrep"}),
+                          runner=runner, env={})
+        assert all(e["scanner"] != "semgrep" for e in result["gate"]["errors"]), \
+            ("semgrep must not fail-close once cwd is threaded; "
+             f"errors={result['gate']['errors']}")
+        assert result["gate"]["blocked"] is False


### PR DESCRIPTION
## Summary

Make the tool-based security gate (`hooks/security_scan.py`) **cwd-independent for every scanner**. `run_scan` now normalizes `--project-root` to an absolute path once and threads it as each scanner's working directory (`cwd`).

Previously the scanners inherited the gate *process's* cwd, so semgrep's diff mode (`--baseline-commit`) couldn't resolve the baseline ref when the gate was invoked from any dir other than the repo root — it exited `rc=2` and (fail-closed) blocked the whole **Step 11.5 / WF9** gate with **zero findings**. This presented as a semgrep problem but was a cwd problem. Same class of latent cwd-dependence the `.trivyignore` `--ignorefile` change fixed for trivy in v2.36.0; now generalized to all scanners.

Closes #101

## Design Decisions

- **Normalize `project_root` to an absolute path once** (the chosen approach over threading the raw value): this keeps the scan *target* handed to each builder and the subprocess `cwd` consistent, so even a relative `--project-root` is robust — a relative target would otherwise be re-rooted against the changed cwd. The real WF2/WF9 invocation already passes an absolute `<activeProject.path>`, so `abspath` is a no-op there.
- `_default_runner` already forwarded `**kwargs` to `subprocess.run`, so **no signature change**; a bad/nonexistent root still fail-closes via the existing `except (OSError, subprocess.SubprocessError)`.

## Verification

- **3 new regression tests** (`TestRunScanCwdIndependence`): cwd-threading contract, relative→abspath normalization, and a behavioral repro of the `rc=2` fail-close via a cwd-aware injected runner (no real semgrep/git/chdir needed — matches the suite's dependency-injection philosophy). All 3 **RED on the unfixed code, GREEN after**.
- **Full suite: 1150 passed.**
- **End-to-end:** ran the *real* gate from a foreign cwd (`/tmp`) **and** the repo root against this repo with **semgrep 1.166.0** → PASS, `errors: []`, no semgrep error (would have exited rc=2/BLOCKED before the fix).

## Quality Gate Summary

- Design critique (Step 4): fast-path reflect (`simple_change`) — 0 blocking findings
- Plan drift check (Step 6): 0 findings
- Per-task review (Step 8a, high-risk task): 2 reviewers + adversarial verify — 0 findings
- Implementation drift check (Step 9): caught + fixed a version drift-guard (`test_plugin_version_bumped`)
- Code review (Step 11): 3-agent + adversarial verify — 1 Low advisory (cross-ref) resolved, **0 Critical/High**
- Security scan (Step 11.5): **0 blocking, 0 advisory, 0 errors**; skipped: `iac` (no Docker), `sca` (osv-scanner: no dependency manifests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
