### PR TITLE
feat(wf2,wf3): suggest doing trivial work directly instead of the full workflow

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.36.1",
+  "version": "2.37.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -697,6 +697,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v2.37.0 (2026-06-16)
+- **WF2 / WF3 now suggest doing *trivial* work directly instead of running the full workflow.** A new `<trivial-work-check>` fires at Step 2: when a change is genuinely trivial (~1 file, ≤~10 lines, mechanical, no new logic), the orchestrator pauses and recommends doing it directly (quick edit + targeted test + PR) versus continuing the full 16-/14-step workflow — a human-in-the-loop suggestion, never automatic routing and never a hard gate. Headless auto-continues the workflow. Distinct from the existing fast path (which makes *non-trivial-but-simple* changes cheaper *inside* the workflow). Reconciles `docs/consolidation.md` D2, whose "no penalty for a bigger workflow on a small task" rationale didn't hold once multi-agent reviews were in play.
+
 ### v2.36.1 (2026-06-16)
 - **Step 11.5 / WF9 security gate is now cwd-independent for every scanner.** `security_scan.py`'s `run_scan` normalizes `--project-root` to an absolute path and threads it as each scanner's working directory (`cwd`). Previously the scanners inherited the gate *process's* cwd, so semgrep's diff mode (`--baseline-commit`) couldn't resolve the baseline ref when the gate was invoked from any dir other than the repo root — it exited `rc=2` and (fail-closed) blocked the whole gate with zero findings. Same class of latent cwd-dependence the `.trivyignore` `--ignorefile` change fixed for trivy in v2.36.0; now generalized to all scanners. See `docs/security-scan.md`. (#101)
 

--- a/docs/consolidation.md
+++ b/docs/consolidation.md
@@ -444,11 +444,13 @@ The architecture diagram shows:
 
 **Rationale:** Each workflow's skill file is a self-contained markdown document. Claude Code reads the entire skill file into context when invoked. Making workflows reference a separate "base.md" file would require an extra file read and make the skill harder to understand in isolation. Duplication across skill files is acceptable because: (a) the duplicated parts are simple (branch creation, PR creation), (b) each workflow may need slight variations, and (c) skill files are maintained by Claude, not humans.
 
-### D2: No Downward Escalation
+### D2: No Automatic Downward Escalation — but a trivial-work suggestion
 
-**Decision:** Workflows do NOT automatically downgrade (e.g., WF2 → WF3 when the feature turns out to be a simple bug fix).
+**Decision:** Workflows do NOT automatically downgrade or re-route (e.g., WF2 → WF3 when the feature turns out to be a simple bug fix). They DO, at Step 2, surface a one-time **suggestion** to do genuinely *trivial* work directly (see `<trivial-work-check>` in WF2/WF3) — a human-in-the-loop recommendation that the user accepts or declines, never automatic routing.
 
-**Rationale:** Downward escalation adds complexity for marginal benefit. If a user starts WF2 and the implementation is simple, WF2's fast path already handles it (skip full critique, use reflect). The user can also simply complete WF2 — there's no penalty for using a "bigger" workflow on a small task (just a few extra quality gates that take seconds). Upward escalation (WF3 → WF2) is important because it prevents underestimating complexity; downward escalation is not because overestimating has low cost.
+**Rationale:** Automatic downward *routing* adds machinery (re-entry, state hand-off, mis-route risk) for marginal benefit. Upward escalation (WF3 → WF2) earns that cost because underestimating complexity is dangerous; automatic downward routing does not.
+
+The original rationale here claimed "there's no penalty for using a bigger workflow on a small task (just a few extra quality gates that take seconds)." That was **wrong for *trivial* work**: the design critique, plan/drift gates, and especially the multi-agent code reviews cost minutes and significant tokens — disproportionate for a typo or a one-line fix, and markedly worse under aggressive review settings. The trivial-work check splits the difference: **no** auto-routing, but the orchestrator points out when the full workflow is overkill and lets the user choose to do it directly. The fast path (reflect vs. critique) still handles *non-trivial-but-simple* changes from inside the workflow.
 
 ### D3: WF3 Remains Separate from WF2
 

--- a/skills/fix-bug/SKILL.md
+++ b/skills/fix-bug/SKILL.md
@@ -109,6 +109,7 @@ as normal (STOP and wait for terminal input). If in headless mode, follow this p
 
 AUTO-RESOLVE interactions (no user input needed in headless mode):
 - Step 1: Accept bug confirmation for WF1-created issues
+- Step 2: Trivial-work suggestion — continue the full workflow (no interactive user for a "do it directly" hand-off)
 - Step 6: Always stash dirty directory (post brief issue comment with stash ref)
 - Step 6: Always resume existing branch
 
@@ -211,6 +212,40 @@ WF3 accepts bug reports of any complexity. However:
 - If the user disagrees, they can override and stay in WF3.
 </complexity-override>
 
+<trivial-work-check>
+The low-end mirror of `<complexity-override>`. Some bug fixes are **trivial** — a typo,
+a one-line off-by-one, a comment, a config/constant tweak — where even WF3's 14 steps
+are more ceremony than the fix warrants. This surfaces that BEFORE the workflow invests
+in root-cause analysis and review.
+
+**Trigger (evaluated in Step 2, after complexity classification):** set
+`trivial_work = true` only when the fix is ~1 file (occasionally 2), roughly ≤ 10 changed
+lines, mechanical, with no new logic and low reversal cost. (Reproduce-first still applies
+*in spirit* — a one-line regression test is cheap and worth it — but the full step
+machinery is not.)
+
+This is a **suggestion, never a hard gate** — the orchestrator must NOT bail on its own,
+and continuing the full workflow is always a valid choice.
+
+**When `trivial_work == true` (interactive):** STOP and present, concisely:
+```
+Step 2 → TRIVIAL bug detected (<N files, ~M lines, <one-line why>).
+The full WF3 (14 steps) is likely overkill. Proceed how?
+  (a) Do it directly — reproduce test + minimal fix + branch + PR  [recommended]
+  (b) Continue the full WF3 workflow
+```
+Wait for the choice.
+- **(a) Do it directly:** LEAVE the workflow. Still write the failing reproduction test
+  first (it is cheap and reproduce-first is the heart of WF3), apply the minimal fix, run
+  the suite, bump the version + update docs per the project's pre-PR checklist, open a PR
+  — but SKIP the reflect gate (Step 4), the code-review step, and the run-record ceremony.
+  If you do emit a run-record, set `complexity: "trivial"`.
+- **(b) Continue:** proceed to Step 3 (Root Cause Analysis) as normal.
+
+**[Headless: AUTO-RESOLVE — continue the full workflow; log `### WF3 Step 2 —
+trivial-work suggestion (auto-continued in headless)`.]**
+</trivial-work-check>
+
 <ambiguity-circuit-breaker>
 Inherited from WF2 (identical behavior): Apply ALL findings from quality gates automatically. If any finding is ambiguous, conflicting, or requires judgment — STOP and present to user for resolution before proceeding. User has final authority (P11). **[Headless: QUESTION — post comment with all ambiguous/conflicting findings and resolution options, suspend.]**
 </ambiguity-circuit-breaker>
@@ -287,6 +322,10 @@ Wait for user confirmation before proceeding to Step 2. **[Headless: AUTO-RESOLV
    - `moderate_bug`: 4-10 files, root cause requires investigation, may need migration
    - `complex_bug`: 10+ files, cross-service, unclear root cause → **prompt upgrade to WF2**
 5. **Related issues check:** `gh issue list --repo capabilities.repo --search "<keywords>" --limit 10`
+6. **Trivial-work check (may surface to user):** Apply `<trivial-work-check>`. If the fix
+   is `trivial_work == true`, present the "do it directly vs. continue the full workflow"
+   suggestion and WAIT for the user's choice before proceeding to Step 3 (headless:
+   auto-continue).
 
 ### Output
 
@@ -303,6 +342,7 @@ Bug analysis (internal working artifact):
 - Cannot reproduce from description → ask user for more details. **[Headless: QUESTION — post comment with reproduction attempt details, suspend.]**
 - Bug is in a dependency, not our code → document and suggest upstream report
 - Classified as `complex_bug` → prompt upgrade to WF2 (user can override)
+- Classified as `trivial_work` → suggest doing it directly (user can continue WF3); see `<trivial-work-check>`
 
 ---
 

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -99,6 +99,12 @@ Conditional steps (skip ONLY when their condition is not met):
 - "Context window is running low" — checkpoint in session notes and resume, do not skip
 
 If you catch yourself about to skip a mandatory step, STOP and acknowledge: "I was about to skip Step N which is mandatory. Proceeding with the full step."
+
+**The ONE sanctioned way to not run these steps** is the pre-implementation
+`<trivial-work-check>` at Step 2: if the user explicitly chooses "do it directly," you
+are declining to run WF2 *at all* (no code has been written yet) — that is NOT skipping
+a mandatory step mid-run. Once you proceed past Step 2 into the workflow, every step
+above is non-negotiable.
 </mandatory-steps>
 
 <config-loading>
@@ -160,6 +166,7 @@ AUTO-RESOLVE interactions (no user input needed in headless mode):
 - Step 1: Accept capabilities for WF1-created issues
 - Step 5: Remove excess tasks on scope creep (document in session notes)
 - Step 5: Risk ratio `warn` band — log to session notes, continue
+- Step 2: Trivial-work suggestion — continue the full workflow (no interactive user for a "do it directly" hand-off)
 - Step 7: Always stash dirty directory
 - Step 7: Always resume existing branch
 - Step 8: Rewrite failing RED test (up to 2 attempts)
@@ -434,6 +441,50 @@ Two fast path variants reduce Step 4 from full critique to lightweight reflect:
 Neither fast path applies to complex_feature -- those always get full /reflexion:critique.
 </fast-path-detection>
 
+<trivial-work-check>
+Some changes are below even `simple_change` — genuinely **trivial**: a typo, a
+comment, a one-line guard, a version/string/constant tweak, a doc-only edit. Running
+the full 16-step workflow (and especially the multi-agent reviews) on these costs far
+more than the change is worth. This check surfaces that BEFORE the workflow invests in
+design, planning, and review.
+
+**Trigger (evaluated in Step 2, after complexity classification):** set
+`trivial_work = true` only when ALL hold:
+- 1 file (occasionally 2), and roughly ≤ 10 changed lines
+- no new logic / control flow / public surface, no new dependency, no migration
+- mechanical or cosmetic, low reversal cost (a wrong edit is trivially reverted)
+- nothing that warrants its own test *design* (a one-line regression test is fine; the
+  change does not need TDD ceremony to get right)
+
+This is a **suggestion, never a hard gate** — the orchestrator must NOT bail on its own,
+and continuing the full workflow is always a valid choice.
+
+**When `trivial_work == true` (interactive):** STOP and present, concisely:
+```
+Step 2 → TRIVIAL detected (<N files, ~M lines, <one-line why>).
+The full WF2 (16 steps) is likely overkill for this. Proceed how?
+  (a) Do it directly now — quick edit + a targeted test + branch + PR  [recommended]
+  (b) Continue the full WF2 workflow
+```
+Wait for the choice.
+- **(a) Do it directly:** LEAVE the workflow. Make the change with the project's
+  baseline hygiene only — branch off the default branch, add a targeted test if one is
+  warranted, run the suite, bump the version + update docs per the project's pre-PR
+  checklist, open a PR — but SKIP the design critique (Step 4), plan + drift gates
+  (Steps 5–6, 9), per-task + 3-agent reviews (Steps 8a, 11), and the run-record
+  ceremony (Step 16). If you do emit a run-record, set `complexity: "trivial"`.
+- **(b) Continue:** proceed to Step 3 as normal (valid when the user wants the full
+  audit trail regardless of size).
+
+**[Headless: AUTO-RESOLVE — continue the full workflow. There is no interactive user to
+take over a "do it directly" hand-off, and continuing is the conservative default. Log
+`### WF2 Step 2 — trivial-work suggestion (auto-continued in headless)`.]**
+
+This is distinct from `<fast-path-detection>`: the fast path makes a *non-trivial* change
+cheaper (reflect vs. critique) while staying in the workflow; the trivial-work check asks
+whether running the workflow is warranted *at all*.
+</trivial-work-check>
+
 <ambiguity-circuit-breaker>
 Active at ALL quality gates (Steps 4, 6, 9, 11, 15). Triggers when:
 - Any finding has ambiguity_flag == "ambiguous"
@@ -549,6 +600,12 @@ This enables workflow resumption if context is lost.
    - If `simple_change`: `fast_path_eligible = true`
    - If `standard_feature` AND `is_wf1_created`: `fast_path_eligible = true`
    - Otherwise: `fast_path_eligible = false`
+
+9. **Trivial-work check (the one Step 2 step that may surface to the user):** Apply
+   `<trivial-work-check>`. If the change is `trivial_work == true`, present the
+   "do it directly vs. continue the full workflow" suggestion and WAIT for the user's
+   choice before proceeding to Step 3 (headless: auto-continue). The analysis from
+   items 1–8 still feeds Step 3 silently; only this suggestion interacts with the user.
 
 ### Output
 Codebase analysis with complexity classification, fast path eligibility, and (for infrastructure projects) live environment probe results. Do NOT present to user — feeds into Step 3.

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.36.1"
+    assert plugin["version"] == "2.37.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_bmad_detection.py
+++ b/tests/hooks/test_bmad_detection.py
@@ -138,8 +138,8 @@ class TestHeadlessInteractionBlock:
 
     # Expected [Headless annotation counts per skill
     EXPECTED_COUNTS = {
-        "implement-feature": 26,  # 17 base + 1 disabled-skill cleanup + 7 P15 (#73): Step 5 warn/halt/decompose + 8a ambiguity/dispatch-failure/design-flaw/headless-suspend + Step 11 deferred-High + 1 Step 11.5 security-scan block
-        "fix-bug": 11,            # 10 interaction points + 1 disabled-skill cleanup
+        "implement-feature": 27,  # 17 base + 1 disabled-skill cleanup + 7 P15 (#73): Step 5 warn/halt/decompose + 8a ambiguity/dispatch-failure/design-flaw/headless-suspend + Step 11 deferred-High + 1 Step 11.5 security-scan block + 1 Step 2 trivial-work suggestion
+        "fix-bug": 12,            # 10 interaction points + 1 disabled-skill cleanup + 1 Step 2 trivial-work suggestion
     }
 
     @pytest.mark.parametrize("skill_name", HEADLESS_SKILLS)

--- a/tests/test_trivial_work_check.py
+++ b/tests/test_trivial_work_check.py
@@ -1,0 +1,86 @@
+"""Drift guards for the trivial-work check added to WF2 (implement-feature) and
+WF3 (fix-bug).
+
+The check fires at Step 2: when a change is genuinely trivial (~1 file, ~<=10
+lines, mechanical), the orchestrator surfaces a one-time SUGGESTION to do it
+directly instead of running the full workflow — a human-in-the-loop recommendation
+("Pause & recommend"), never automatic routing and never a hard gate. These assert
+the block, its Step 2 trigger, the headless auto-continue behavior, the
+mandatory-steps carve-out (WF2), and the consolidation D2 reconciliation all stay
+present, so a later edit can't silently drop them.
+
+Companion to tests/test_wf2_parallelism.py and
+tests/hooks/test_adversarial_review_registration.py.
+"""
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WF2 = REPO_ROOT / "skills" / "implement-feature" / "SKILL.md"
+WF3 = REPO_ROOT / "skills" / "fix-bug" / "SKILL.md"
+CONSOLIDATION = REPO_ROOT / "docs" / "consolidation.md"
+
+
+def _section(text: str, header: str, next_header: str) -> str:
+    start = text.index(header)
+    end = text.index(next_header, start)
+    return text[start:end]
+
+
+@pytest.mark.parametrize("skill_path", [WF2, WF3], ids=["wf2", "wf3"])
+def test_trivial_work_check_block_present(skill_path):
+    text = skill_path.read_text(encoding="utf-8")
+    assert "<trivial-work-check>" in text
+    assert "</trivial-work-check>" in text
+    block = _section(text, "<trivial-work-check>", "</trivial-work-check>")
+    # It is a suggestion, never a hard gate, and must not bail autonomously.
+    assert "suggestion, never a hard gate" in block
+    assert "must NOT bail on its own" in block
+    # It offers the two-option choice (do directly / continue) and recommends direct.
+    assert "do it directly" in block.lower()
+    assert "[recommended]" in block.lower()
+    # Trivial threshold is spelled out, not vibes.
+    assert "1 file" in block and "10 " in block
+
+
+@pytest.mark.parametrize("skill_path", [WF2, WF3], ids=["wf2", "wf3"])
+def test_step2_triggers_trivial_work_check(skill_path):
+    text = skill_path.read_text(encoding="utf-8")
+    step2 = _section(text, "## Step 2", "## Step 3")
+    assert "trivial-work-check" in step2.lower()
+
+
+@pytest.mark.parametrize("skill_path", [WF2, WF3], ids=["wf2", "wf3"])
+def test_headless_auto_continues_trivial_suggestion(skill_path):
+    text = skill_path.read_text(encoding="utf-8")
+    auto = _section(text, "AUTO-RESOLVE interactions", "QUESTION interactions")
+    assert "trivial" in auto.lower()
+    # Headless must CONTINUE the full workflow (no interactive user to hand off to),
+    # not bail to a direct edit.
+    assert "continue" in auto.lower()
+
+
+def test_wf2_mandatory_steps_carveout_for_trivial_exit():
+    """The trivial-work exit must be reconciled with <mandatory-steps>, so a future
+    orchestrator doesn't read it as 'skipping a mandatory step'."""
+    text = WF2.read_text(encoding="utf-8")
+    mand = _section(text, "<mandatory-steps>", "</mandatory-steps>")
+    assert "trivial-work-check" in mand
+    # flatten whitespace so the match is robust to markdown line-wrapping
+    mand_flat = " ".join(mand.split())
+    assert "NOT skipping a mandatory step mid-run" in mand_flat
+
+
+def test_consolidation_d2_reconciled():
+    """docs/consolidation.md D2 previously claimed there was 'no penalty' for using a
+    bigger workflow on a small task; that must be corrected to acknowledge the
+    trivial-work suggestion (the old claim may survive only as an explicitly-corrected
+    quote, not as standing rationale)."""
+    text = CONSOLIDATION.read_text(encoding="utf-8")
+    d2 = _section(text, "### D2:", "### D3:")
+    assert "trivial-work-check" in d2
+    assert "suggestion" in d2.lower()
+    # the stale "no penalty / a few seconds" claim must now be framed as wrong, not
+    # presented as the current rationale.
+    assert "wrong for" in d2.lower()


### PR DESCRIPTION
## Summary

Adds a **`<trivial-work-check>`** to WF2 (`implement-feature`) and WF3 (`fix-bug`). At Step 2, when a change is genuinely **trivial** (~1 file, ≤~10 lines, mechanical, no new logic, low reversal cost), the orchestrator **pauses and recommends doing it directly** (quick edit + targeted test + PR) instead of running the full 16-/14-step workflow.

- **Human-in-the-loop suggestion** — the user chooses; never automatic routing, never a hard gate.
- **Headless** auto-continues the full workflow (no interactive user to take over a "do it directly" hand-off).
- **Distinct from the fast path:** `<fast-path-detection>` makes a *non-trivial-but-simple* change cheaper (reflect vs. critique) *inside* the workflow; this check questions whether the workflow is warranted *at all*.

Motivation: a 2-line fix recently ran the full WF2 + multi-agent reviews (~15 min, ~350k tokens) — disproportionate for the change. This surfaces the overkill before the workflow invests in it.

## Behavior (the "Pause & recommend" choice)

```
Step 2 → TRIVIAL detected (1 file, ~6 lines, mechanical).
The full WF2 (16 steps) is likely overkill for this. Proceed how?
  (a) Do it directly now — quick edit + a targeted test + branch + PR  [recommended]
  (b) Continue the full WF2 workflow
```

## Consistency reconciliations (caught while implementing)

- **`<mandatory-steps>` (WF2):** added a carve-out clarifying the trivial exit is *declining to run WF2 at all* (no code written yet) — NOT skipping a mandatory step mid-run.
- **`docs/consolidation.md` D2 ("No Downward Escalation"):** its rationale claimed *"there's no penalty for using a bigger workflow on a small task (just a few extra quality gates that take seconds)."* That was wrong once multi-agent reviews were in play. D2 now distinguishes automatic *routing* (still rejected) from this *suggestion* (added), and corrects the cost claim.

## Verification

- New drift guard `tests/test_trivial_work_check.py` (8 tests): block presence + threshold spelled out, Step 2 trigger, headless auto-continue, mandatory-steps carve-out, D2 reconciliation.
- Bumped the existing `[Headless]` annotation-count guard (26→27, 11→12) and the version guard (→2.37.0).
- **Full suite: 1158 passed.**

## Pre-PR checklist
- Version bumped: 2.36.1 → **2.37.0** (minor — additive feature)
- README changelog updated; `docs/consolidation.md` updated
- Tests pass: `pytest tests/ -v` → 1158 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
