### PR TITLE
feat(create-issue): slim WF1 from 9 steps to 5 (drop multi-agent critique)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Each add-on unlocks a specific capability. Rawgentic runs without them — you j
 
 | Add-on | Check | Install | What it unlocks — and what you lose without it |
 | ------ | ----- | ------- | ---------------------------------------------- |
-| **reflexion** plugin | `/reflexion:reflect` | `claude plugin add reflexion@context-engineering-kit` | The **quality-gate critique** in WF1/WF2/WF4/WF9/WF10 (`/reflexion:critique`) and the lightweight reflect in WF3. **Without it:** those gate steps can't run, so workflows lose their shift-left critique and proceed unreviewed. **Strongly recommended.** |
+| **reflexion** plugin | `/reflexion:reflect` | `claude plugin add reflexion@context-engineering-kit` | The **quality-gate critique** in WF2/WF4/WF9/WF10 (`/reflexion:critique`) and the lightweight reflect in WF3. **Without it:** those gate steps can't run, so workflows lose their shift-left critique and proceed unreviewed. **Strongly recommended.** |
 | **superpowers** plugin | `/superpowers:brainstorming` | `claude plugin add superpowers@claude-plugins-official` | Structured **brainstorming / design exploration** (WF12 test-strategy design; complex-feature design). **Without it:** rawgentic falls back to lighter inline brainstorming — still works, less rigorous. |
 | **Codex CLI** | `codex login status` | [install + authenticate ↓](#cross-model-review-data-handling-codex) | **Cross-model adversarial review** — an independent, *different-model* second opinion on a design/spec/plan/PRD via OpenAI: the WF5 `/rawgentic:adversarial-review` skill plus the opt-in cross-model gates in WF1–WF4. **Without it:** WF5 errors out and any opt-in cross-model gate is skipped; you still get the same-model reflexion critique. |
 | **Security scanners** (gitleaks, semgrep, osv-scanner, trivy) | `bash scripts/install-scanners.sh --check gitleaks semgrep osv-scanner trivy` | Auto-provisioned by `/rawgentic:setup` and once in the background on first plugin use (opt-out: `RAWGENTIC_SKIP_SCANNER_INSTALL=1`) | The **tool-based security scan** in WF2 Step 11.5 and WF9 (secrets / dependency-CVE / SAST / IaC misconfig). **Without them:** each missing scanner is a *visible skip* (never a silent pass) — the LLM security review still runs, but concrete known-pattern issues (leaked tokens, CVE'd deps) aren't caught. |
@@ -147,7 +147,7 @@ Each add-on unlocks a specific capability. Rawgentic runs without them — you j
 
 | Workflow                 | Skill                          | Steps | Use When                                            |
 | ------------------------ | ------------------------------ | ----- | --------------------------------------------------- |
-| Issue Creation           | `/rawgentic:create-issue`      | 9     | Planning a feature or reporting a bug               |
+| Issue Creation           | `/rawgentic:create-issue`      | 5     | Planning a feature or reporting a bug               |
 | Feature Implementation   | `/rawgentic:implement-feature` | 16    | Building a new feature from a GitHub issue          |
 | Bug Fix                  | `/rawgentic:fix-bug`           | 14    | Fixing a bug with reproduce-first TDD               |
 | Refactoring              | `/rawgentic:refactor`          | 14    | Restructuring code while preserving behavior        |
@@ -160,16 +160,20 @@ Each add-on unlocks a specific capability. Rawgentic runs without them — you j
 | Test Suite Creation      | `/rawgentic:create-tests`      | 14    | Bootstrap tests or fill coverage gaps across any language |
 
 <details>
-<summary><strong>Issue Creation (WF1)</strong> — 9 steps</summary>
+<summary><strong>Issue Creation (WF1)</strong> — 5 steps</summary>
 
-**Purpose:** Create well-structured GitHub issues through brainstorming, multi-agent critique, and user review.
+**Purpose:** Turn a raw feature/bug request into a clean, template-conformant GitHub issue on the right repo. A lean helper — no multi-agent critique; its quality bar (no hallucinated components, no fabricated criteria, bound an over-broad ask) is applied inline while drafting.
 
 **Invocation:** `/rawgentic:create-issue Add dark mode support to the dashboard`
 
 **Key Features:**
-- 3-judge critique panel (architecture, security, maintainability)
-- Ambiguity circuit breaker — stops and asks when findings conflict
+- Config-driven repo targeting (issue lands on the project's configured repo)
 - Duplicate detection via `gh issue list` before creation
+- Codebase grounding — referenced components are verified to exist (Serena MCP or Grep/Glob)
+- Conventional `feat(scope):` / `fix(scope):` titles, template conformance
+- Optional default-off cross-model adversarial review of the draft (opt-in per project)
+
+> Slimmed from a 9-step multi-agent workflow after head-to-head evals showed a current model produces an equivalent issue without the critique pipeline, at ~⅓ the time/tokens (see `skills/create-issue-workspace/`).
 </details>
 
 <details>
@@ -696,6 +700,9 @@ For major changes, please open an issue first to discuss the approach.
 
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
+
+### v2.38.0 (2026-06-16)
+- **WF1 (Issue Creation) slimmed from 9 steps to 5.** Removed the 3-judge critique panel, the ambiguity circuit-breaker step, loop-back iterations, and per-run memorization; kept config-based repo targeting, dedup, template conformance, codebase grounding, conventional titles, and the default-off cross-model adversarial-review opt-in. The judges' value — no hallucinated components, no fabricated acceptance criteria, bound an over-broad ask — is now a `<quality-bar>` applied inline while drafting. Head-to-head evals across 7 scenarios (incl. false-premise, vague, and over-broad hard cases) showed a current model produces an equivalent issue without the critique pipeline, at ~⅓ the time/tokens; the slim skill stays ≥ baseline quality (100% vs 96%) while recovering the conventional-title edge. Eval harness, transcripts, and analysis in `skills/create-issue-workspace/`. WF1 is no longer in the `/reflexion:critique` set. Description rewritten (prescriptive + near-miss guardrails) and a stale Serena-only codebase-verification reference made tool-agnostic.
 
 ### v2.37.0 (2026-06-16)
 - **WF2 / WF3 now suggest doing *trivial* work directly instead of running the full workflow.** A new `<trivial-work-check>` fires at Step 2: when a change is genuinely trivial (~1 file, ≤~10 lines, mechanical, no new logic), the orchestrator pauses and recommends doing it directly (quick edit + targeted test + PR) versus continuing the full 16-/14-step workflow — a human-in-the-loop suggestion, never automatic routing and never a hard gate. Headless auto-continues the workflow. Distinct from the existing fast path (which makes *non-trivial-but-simple* changes cheaper *inside* the workflow). Reconciles `docs/consolidation.md` D2, whose "no penalty for a bigger workflow on a small task" rationale didn't hold once multi-agent reviews were in play.

--- a/docs/design/workflow-issue-creation.md
+++ b/docs/design/workflow-issue-creation.md
@@ -1,3 +1,13 @@
+> **⚠️ Superseded (2026-06-16).** This v2.3 spec describes the original 9-step,
+> multi-agent-critique workflow. The shipped skill was slimmed to a lean 5-step
+> helper (template + dedup + config-targeting + codebase grounding + a default-off
+> adversarial-review opt-in) — the 3-judge critique, ambiguity circuit-breaker step,
+> loop-back, and per-run memorization were removed after head-to-head evals
+> (`skills/create-issue-workspace/iteration-{2,3,4}`) showed a current model produces
+> an equivalent issue without them, at ~⅓ the time/tokens. The quality bar those steps
+> enforced is now applied inline while drafting (see `skills/create-issue/SKILL.md`
+> `<quality-bar>`). This document is retained as historical design rationale.
+
 # Phase 3 Workflow: Feature/Bug Issue Creation (v2.3)
 
 **Date:** 2026-03-01 (revised)

--- a/skills/create-issue-workspace/iteration-2/ANALYSIS.md
+++ b/skills/create-issue-workspace/iteration-2/ANALYSIS.md
@@ -1,0 +1,54 @@
+# Iteration-2 Analyst Notes — rawgentic:create-issue
+
+## Headline
+Evals now **execute for real** (mock-gh liveness checks would fail any simulated
+walkthrough — the exact failure iteration-1 could not detect) and **discriminate**
+skill from baseline. With-skill = 100% pass on all 4 evals; baseline = 93% (varies
+86–100% across evals).
+
+## What actually discriminates (2 of 23 assertions)
+| Assertion | with-skill | baseline |
+|---|---|---|
+| feature: Conventional title `feat(scope): …` | PASS | **FAIL** (`Add WebSocket support…`) |
+| bug: Conventional title `fix(scope): …` | PASS | **FAIL** (`WebSocket connections dropped…`) |
+
+Every other assertion (repo targeting, dedup-before-create, in/out scope, risk,
+≥3 acceptance criteria, decoy-repo resolution, bug-template sections, `bug` label)
+**passes in BOTH configs.**
+
+## Why the gap is narrow (honest read)
+A capable model already does most of WF1's job *when given the issue templates and
+a structured config*:
+- It reads `.github/ISSUE_TEMPLATE/*` and fills scope/risk/AC sections.
+- It reasons that project `.rawgentic.json` outranks a root `CLAUDE.md` — even with
+  a plausible, unlabelled decoy repo (the iteration-1 weakness is fixed, and the
+  baseline still resolved it correctly).
+- It runs a dedup search and surfaces the existing #42 instead of duplicating.
+
+So on these scenarios the skill's *measurable* edge is concentrated in conventional
+commit-style titles. Its other value — the 3-judge critique catching subtle spec
+defects, the ambiguity circuit breaker, conditional memorization — is real but
+**not captured by programmatic assertions** and needs qualitative transcript review.
+
+## Cost of the skill (the tradeoff)
+| | with-skill | baseline | delta |
+|---|---|---|---|
+| Time | 245.2s ± 83.7s | 105.4s ± 14.1s | **+139.8s (~2.3×)** |
+| Tokens | 65,776 ± 6,674 | 42,532 ± 1,343 | **+23,244 (~55%)** |
+
+The skill is materially more expensive. For the common case (a clear, single issue),
+that cost buys conventional titles + process rigor. The skill's own text already
+hedges ("for simpler features or bug reports, proceed with inline brainstorming") —
+the data supports leaning harder on that lightweight path.
+
+## Harness caveats / next-iteration ideas
+- Runs are **1 per (eval,config)** (session-limit constraint), not 3. ±stddev shown
+  is variation *across the 4 evals*, not run-to-run. For variance analysis, re-run
+  3× when budget allows.
+- The Step-3 critique tells the agent to spawn 3 parallel judge subagents. Inside a
+  subagent that is both very expensive and the likely cause of the original
+  session-limit stalls; the reruns used inline critique. Worth deciding whether the
+  skill should fall back to inline judges when subagent-spawning is unavailable.
+- To capture the skill's real differentiators, future assertions could target:
+  spec-defect catches the baseline misses, circuit-breaker firing on a genuinely
+  ambiguous request, or out-of-scope discipline on a deliberately over-broad ask.

--- a/skills/create-issue-workspace/iteration-2/benchmark.json
+++ b/skills/create-issue-workspace/iteration-2/benchmark.json
@@ -1,0 +1,440 @@
+{
+  "metadata": {
+    "skill_name": "rawgentic:create-issue",
+    "skill_path": "<path/to/skill>",
+    "executor_model": "<model-name>",
+    "analyzer_model": "<model-name>",
+    "timestamp": "2026-06-16T05:32:11Z",
+    "evals_run": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "runs_per_configuration": 3
+  },
+  "runs": [
+    {
+      "eval_id": 1,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 8,
+        "failed": 0,
+        "total": 8,
+        "time_seconds": 253.1,
+        "tokens": 67239,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Targets the config repo octo-eval/sentinel-app",
+          "passed": true,
+          "evidence": "created repo = 'octo-eval/sentinel-app'"
+        },
+        {
+          "text": "Conventional title feat(scope): ...",
+          "passed": true,
+          "evidence": "title = 'feat(server): add WebSocket support for realtime updates'"
+        },
+        {
+          "text": "At least 3 numbered acceptance criteria",
+          "passed": true,
+          "evidence": "6 numbered items in body"
+        },
+        {
+          "text": "Explicit in-scope AND out-of-scope sections",
+          "passed": true,
+          "evidence": "in-scope=True out-of-scope=True"
+        },
+        {
+          "text": "Risk assessment present",
+          "passed": true,
+          "evidence": "'risk' in body = True"
+        },
+        {
+          "text": "Deduplication search ran before creation",
+          "passed": true,
+          "evidence": "issue-list-with-search logged = True"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 2,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 130.0,
+        "tokens": 56778,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Deduplication search ran",
+          "passed": true,
+          "evidence": "issue-list-with-search logged = True"
+        },
+        {
+          "text": "Existing matching issue (#42) surfaced to the user",
+          "passed": true,
+          "evidence": "'#42'/'42' in transcript = True"
+        },
+        {
+          "text": "Did not blindly create a duplicate",
+          "passed": true,
+          "evidence": "no new issue created (acknowledged existing) -- acceptable"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 3,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 267.6,
+        "tokens": 66217,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "3 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Uses config repo, not the CLAUDE.md decoy",
+          "passed": true,
+          "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"
+        },
+        {
+          "text": "Decoy repo never used in any gh call or issue body",
+          "passed": true,
+          "evidence": "decoy in calls=False, in body=False"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 4,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 7,
+        "failed": 0,
+        "total": 7,
+        "time_seconds": 329.9,
+        "tokens": 72870,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Conventional title fix(scope): ...",
+          "passed": true,
+          "evidence": "title = 'fix(server): keep idle WebSocket connections alive past 30s'"
+        },
+        {
+          "text": "Labeled 'bug'",
+          "passed": true,
+          "evidence": "labels = ['bug', 'server']"
+        },
+        {
+          "text": "Steps to reproduce present",
+          "passed": true,
+          "evidence": "'reproduc' in body = True"
+        },
+        {
+          "text": "Expected AND actual behavior documented",
+          "passed": true,
+          "evidence": "expected=True actual=True"
+        },
+        {
+          "text": "Environment details present",
+          "passed": true,
+          "evidence": "'environment' in body = True"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 1,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.875,
+        "passed": 7,
+        "failed": 1,
+        "total": 8,
+        "time_seconds": 91.5,
+        "tokens": 42293,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Targets the config repo octo-eval/sentinel-app",
+          "passed": true,
+          "evidence": "created repo = 'octo-eval/sentinel-app'"
+        },
+        {
+          "text": "Conventional title feat(scope): ...",
+          "passed": false,
+          "evidence": "title = 'Add WebSocket support for realtime updates in the API'"
+        },
+        {
+          "text": "At least 3 numbered acceptance criteria",
+          "passed": true,
+          "evidence": "5 numbered items in body"
+        },
+        {
+          "text": "Explicit in-scope AND out-of-scope sections",
+          "passed": true,
+          "evidence": "in-scope=True out-of-scope=True"
+        },
+        {
+          "text": "Risk assessment present",
+          "passed": true,
+          "evidence": "'risk' in body = True"
+        },
+        {
+          "text": "Deduplication search ran before creation",
+          "passed": true,
+          "evidence": "issue-list-with-search logged = True"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 2,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 99.1,
+        "tokens": 40980,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "4 gh call(s) logged"
+        },
+        {
+          "text": "Deduplication search ran",
+          "passed": true,
+          "evidence": "issue-list-with-search logged = True"
+        },
+        {
+          "text": "Existing matching issue (#42) surfaced to the user",
+          "passed": true,
+          "evidence": "'#42'/'42' in transcript = True"
+        },
+        {
+          "text": "Did not blindly create a duplicate",
+          "passed": true,
+          "evidence": "no new issue created (acknowledged existing) -- acceptable"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 3,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 124.4,
+        "tokens": 44246,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Uses config repo, not the CLAUDE.md decoy",
+          "passed": true,
+          "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"
+        },
+        {
+          "text": "Decoy repo never used in any gh call or issue body",
+          "passed": true,
+          "evidence": "decoy in calls=False, in body=False"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 4,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.8571,
+        "passed": 6,
+        "failed": 1,
+        "total": 7,
+        "time_seconds": 106.5,
+        "tokens": 42607,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "7 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Conventional title fix(scope): ...",
+          "passed": false,
+          "evidence": "title = 'WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)'"
+        },
+        {
+          "text": "Labeled 'bug'",
+          "passed": true,
+          "evidence": "labels = ['bug']"
+        },
+        {
+          "text": "Steps to reproduce present",
+          "passed": true,
+          "evidence": "'reproduc' in body = True"
+        },
+        {
+          "text": "Expected AND actual behavior documented",
+          "passed": true,
+          "evidence": "expected=True actual=True"
+        },
+        {
+          "text": "Environment details present",
+          "passed": true,
+          "evidence": "'environment' in body = True"
+        }
+      ],
+      "notes": []
+    }
+  ],
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {
+        "mean": 1.0,
+        "stddev": 0.0,
+        "min": 1.0,
+        "max": 1.0
+      },
+      "time_seconds": {
+        "mean": 245.15,
+        "stddev": 83.6845,
+        "min": 130.0,
+        "max": 329.9
+      },
+      "tokens": {
+        "mean": 65776.0,
+        "stddev": 6673.9216,
+        "min": 56778,
+        "max": 72870
+      }
+    },
+    "without_skill": {
+      "pass_rate": {
+        "mean": 0.933,
+        "stddev": 0.0777,
+        "min": 0.8571,
+        "max": 1.0
+      },
+      "time_seconds": {
+        "mean": 105.375,
+        "stddev": 14.0844,
+        "min": 91.5,
+        "max": 124.4
+      },
+      "tokens": {
+        "mean": 42531.5,
+        "stddev": 1342.7888,
+        "min": 40980,
+        "max": 44246
+      }
+    },
+    "delta": {
+      "pass_rate": "+0.07",
+      "time_seconds": "+139.8",
+      "tokens": "+23244"
+    }
+  },
+  "notes": []
+}

--- a/skills/create-issue-workspace/iteration-2/benchmark.md
+++ b/skills/create-issue-workspace/iteration-2/benchmark.md
@@ -1,0 +1,13 @@
+# Skill Benchmark: rawgentic:create-issue
+
+**Model**: <model-name>
+**Date**: 2026-06-16T05:32:11Z
+**Evals**: 1, 2, 3, 4 (3 runs each per configuration)
+
+## Summary
+
+| Metric | With Skill | Without Skill | Delta |
+|--------|------------|---------------|-------|
+| Pass Rate | 100% ± 0% | 93% ± 8% | +0.07 |
+| Time | 245.2s ± 83.7s | 105.4s ± 14.1s | +139.8s |
+| Tokens | 65776 ± 6674 | 42532 ± 1343 | +23244 |

--- a/skills/create-issue-workspace/iteration-2/bug-report/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-2/bug-report/eval_metadata.json
@@ -1,0 +1,17 @@
+{
+  "eval_id": 4,
+  "eval_name": "bug-report",
+  "scenario": "bug-report",
+  "prompt": "Report a bug: the server drops WebSocket connections after about 30 seconds of inactivity instead of keeping them alive. It happens reliably on the staging box.",
+  "fixture_with": "/tmp/ci-iter2/bug-report/with_skill/fixture",
+  "fixture_without": "/tmp/ci-iter2/bug-report/without_skill/fixture",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Issue was actually created via gh (not simulated)",
+    "Conventional title fix(scope): ...",
+    "Labeled 'bug'",
+    "Steps to reproduce present",
+    "Expected AND actual behavior documented",
+    "Environment details present"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-2/bug-report/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-2/bug-report/with_skill/grading.json
@@ -1,0 +1,50 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Conventional title fix(scope): ...",
+      "passed": true,
+      "evidence": "title = 'fix(server): keep idle WebSocket connections alive past 30s'"
+    },
+    {
+      "text": "Labeled 'bug'",
+      "passed": true,
+      "evidence": "labels = ['bug', 'server']"
+    },
+    {
+      "text": "Steps to reproduce present",
+      "passed": true,
+      "evidence": "'reproduc' in body = True"
+    },
+    {
+      "text": "Expected AND actual behavior documented",
+      "passed": true,
+      "evidence": "expected=True actual=True"
+    },
+    {
+      "text": "Environment details present",
+      "passed": true,
+      "evidence": "'environment' in body = True"
+    }
+  ],
+  "summary": {
+    "passed": 7,
+    "failed": 0,
+    "total": 7,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 72870,
+    "duration_ms": 329923,
+    "total_duration_seconds": 329.9
+  }
+}

--- a/skills/create-issue-workspace/iteration-2/bug-report/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-2/bug-report/with_skill/outputs/transcript.md
@@ -1,0 +1,353 @@
+# WF1 create-issue — Full Transcript (bug report)
+
+Skill under test: `rawgentic:create-issue` (WF1, 9-step issue creation workflow).
+Working directory: `/tmp/ci-iter2/bug-report/with_skill/fixture`
+Mock gh (absolute path): `/tmp/ci-iter2/bug-report/with_skill/fixture/bin/gh`
+Harness substitution: Step 3's 3 parallel judges performed INLINE (no subagents).
+
+## User request
+> Report a bug: the server drops WebSocket connections after about 30 seconds of
+> inactivity instead of keeping them alive. It happens reliably on the staging box.
+
+---
+
+## Working directory
+```
+$ cd /tmp/ci-iter2/bug-report/with_skill/fixture && pwd
+/tmp/ci-iter2/bug-report/with_skill/fixture
+```
+
+---
+
+## <config-loading>
+
+### Level 1 — conversation context
+No prior `/rawgentic:switch` in this session.
+
+### Level 2 — session registry
+`claude_docs/session_registry.jsonl` does not exist → fall through.
+
+### Level 3 — workspace default
+`.rawgentic_workspace.json`:
+```json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+```
+Exactly one active project → **sentinel-app**. Path `./projects/sentinel-app` resolves
+against the workspace root.
+
+### Step 1b — disabled-skill check
+`disabledSkills` is `[]` and the workspace has no `bmadDetected` field → proceed.
+
+### Capabilities derivation (one source of truth)
+```
+$ python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+{"config":{"version":1,"project":{"name":"sentinel-app","type":"web-service","description":"Realtime API service for the eval harness"},"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},"protectionLevel":"sandbox","techStack":["node","javascript"],"testing":{"frameworks":[{"name":"vitest","type":"unit","command":"npm test","testDir":"test"}]},"ci":{"provider":"github-actions","workflowDir":".github/workflows"},"documentation":{"primaryFiles":["README.md"],"format":"markdown"},"custom":{}},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+EXIT=0
+```
+
+### Resolved config / capabilities
+| field | value |
+|-------|-------|
+| repo | `octo-eval/sentinel-app` |
+| default_branch | `trunk` |
+| project_type | `web-service` |
+| techStack | node, javascript |
+| has_tests | true (`npm test`, vitest) |
+| has_ci | true (github-actions) |
+| has_deploy | false |
+| has_database | false |
+| has_docker | false |
+
+Gate checks:
+```
+$ grep -o "critiqueMethod" .rawgentic_workspace.json   # -> no match => default reflexion 3-judge
+$ python3 hooks/adversarial_review_lib.py is-enabled --workspace .rawgentic_workspace.json --project sentinel-app --skill create-issue
+disabled
+ADV_EXIT=1   # => Step 4 adversarial sub-step is a silent no-op
+```
+
+---
+
+## Step 1 — Receive User Intent
+
+Dedup check:
+```
+$ /tmp/ci-iter2/bug-report/with_skill/fixture/bin/gh issue list --repo octo-eval/sentinel-app --search "websocket connection drop inactivity timeout keepalive" --limit 10
+            # (empty output)
+EXIT=0
+```
+No existing issues → clean repo.
+
+**Classification presented to user:**
+```
+Issue Classification:
+- Type: bug
+- Summary: The server drops WebSocket connections after ~30s of inactivity instead of keeping them alive; reproduces reliably on the staging box.
+- Scope hints: WebSocket connection handling (src/server.js handleConnection), keepalive/heartbeat/ping-pong, idle timeout.
+- Existing issues found: none
+
+Proceeding to brainstorm. Confirm or correct this classification.
+```
+
+**User:** "Confirmed — this is a bug. Yes, proceed."
+Clarifying details supplied by user: expected = idle connections stay open; actual = drop after ~30s;
+reproduce = reliably on staging (open WS, idle ~30s, disconnect); environment = staging box.
+
+---
+
+## Step 2 — Brainstorm (internal artifact)
+
+Read: `bug_report.md` template, `.rawgentic.json`, `README.md`, `src/server.js`, `src/errorHandler.js`.
+
+Bug template structure:
+```
+## Description / ## Steps to Reproduce / ## Expected Behavior /
+## Actual Behavior / ## Environment / ## Error Logs   (labels: bug)
+```
+
+Component verification (Grep — Serena absent):
+```
+$ grep -rn "handleConnection" projects/sentinel-app/src
+projects/sentinel-app/src/server.js:3:export function handleConnection(socket) { /* ... */ }
+$ grep -rn "startServer" projects/sentinel-app/src
+projects/sentinel-app/src/server.js:2:export function startServer(port) { /* ... */ }
+$ grep -rniE "websocket|keepalive|keep-alive|heartbeat|ping|pong|timeout|setInterval" projects/sentinel-app/src
+NONE FOUND -> do not claim these symbols exist
+$ grep -rnE "export (function|const|class)" projects/sentinel-app/src
+projects/sentinel-app/src/errorHandler.js:2:export function handleError(err, req, res) { /* ... */ }
+projects/sentinel-app/src/server.js:2:export function startServer(port) { /* ... */ }
+projects/sentinel-app/src/server.js:3:export function handleConnection(socket) { /* ... */ }
+```
+Grounding result: `handleConnection` / `startServer` / `handleError` exist; there is **no**
+keepalive/heartbeat/ping/timeout logic anywhere in src → the bug is the ABSENCE of keepalive
+in `handleConnection`. The draft must describe it as missing, not broken.
+
+Draft title: `fix(server): keep idle WebSocket connections alive past 30s`. Affected component:
+`src/server.js` `handleConnection`.
+
+---
+
+## Step 3 — 3-judge critique (INLINE per harness rule)
+
+Judge-side rechecks:
+```
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "websocket" --limit 10 --state all
+            # (empty) EXIT=0  -> no dupes
+$ grep -o "security" projects/sentinel-app/.rawgentic.json
+            # no match -> no config.security standards to check
+```
+
+Findings (6 total):
+- #1 High / completeness — frame as observed behavior; exact close source (app vs proxy on staging)
+  to be confirmed during investigation. (clear)
+- #2 Medium / template_conformance — include the Error Logs section ("None provided"). (clear)
+- #3 Medium / accuracy — keepalive is MISSING in handleConnection; do not reference a non-existent
+  heartbeat function; affected component verified. (clear)
+- #4 Low / feasibility — 30s may come from app-level idle setting OR upstream proxy/LB; add risk note. (clear)
+- #5 High / accuracy — tighten AC1 with a measurable idle bound (remains open >= 5 min). (clear)
+- #6 Low / completeness — add AC: no regression in normal teardown / handleError. (clear)
+
+Debate round: no disagreements; findings complementary; no conflicts.
+Volume thresholds (independent per tier): Critical 0/5, High 2/5, Medium 2/10, Low 2/10
+→ **no loop-back** (loop_iteration = 0). Proceed to Step 4.
+
+---
+
+## Step 4 — Apply Critique Findings (circuit breaker)
+
+Sub-step 0 (adversarial review): `is-enabled` returned `disabled` (exit 1) → **skipped silently**
+(no temp file, no subprocess). Marker logged.
+`### WF1 Step 4 — Adversarial Review (skipped): is-enabled disabled for create-issue`
+
+Circuit breaker scan: 0 ambiguous, 0 conflicting, 0 judgment-call findings → **CLEAR PATH**.
+Notification to user: "Critique complete. 6 findings applied (0 Critical, 2 High, 2 Medium, 2 Low).
+All clear — no ambiguity detected."
+
+Amendments: #1 behavior framing · #2 Error Logs="None provided" · #3 keepalive-missing grounding ·
+#4 app-vs-infra risk note · #5 AC idle >= 5 min · #6 AC no teardown/handleError regression.
+
+---
+
+## Step 5 — Incorporate Amendments
+
+All 6 amendments applied. Verified: no internal contradictions, conforms to bug_report.md template,
+well under 2000 words. Refined spec produced.
+
+## Step 6 — Conditional Memorization (parallel w/ Step 7)
+
+Reviewed findings for reusable cross-project insight. All findings are issue-specific (this app's
+missing keepalive, testable idle bound, app-vs-infra timeout = general knowledge). No novel,
+generalizable insight → **memorization skipped** (no output), avoiding over-memorization.
+
+## Step 7 — User Review
+
+### DRAFT ISSUE SPECIFICATION (presented to user)
+```
+Title: fix(server): keep idle WebSocket connections alive past 30s
+Type: bug
+Labels: bug
+Complexity: S
+
+--- DESCRIPTION ---
+WebSocket connections handled in src/server.js (handleConnection) are dropped after
+roughly 30 seconds of inactivity instead of being kept alive. The connection handler
+has no heartbeat / ping-pong / keepalive mechanism, so idle sockets are closed once an
+idle timeout elapses. The exact source of the close (application-level idle timeout vs.
+an upstream proxy/load balancer on the staging box) is to be confirmed during
+investigation. Reproduces reliably on the staging environment.
+
+--- STEPS TO REPRODUCE ---
+1. Connect a WebSocket client to the staging server.
+2. Leave the connection idle (send no frames) for ~30 seconds.
+3. Observe the server close the connection.
+
+--- EXPECTED BEHAVIOR ---
+Idle WebSocket connections remain open well beyond 30s (heartbeat/ping-pong, or a
+configurable/disabled idle timeout).
+
+--- ACTUAL BEHAVIOR ---
+The connection is dropped after ~30 seconds of inactivity.
+
+--- ENVIRONMENT ---
+Staging box (octo-eval/sentinel-app; web-service, node/javascript).
+
+--- ERROR LOGS ---
+None provided.
+
+--- ACCEPTANCE CRITERIA ---
+1. An idle WebSocket connection remains open for at least 5 minutes without client
+   traffic. [Added per critique finding #5]
+2. The server implements a keepalive mechanism (periodic ping with pong tracking, or
+   equivalent) in handleConnection, where none currently exists. [per finding #3]
+3. The idle/keepalive timeout is configurable rather than a hardcoded default.
+4. An automated test (vitest, `npm test`) verifies an idle connection survives past the
+   previous ~30s drop threshold.
+5. No regression in normal connection teardown / error handling (src/errorHandler.js
+   handleError). [Added per critique finding #6]
+
+--- SCOPE ---
+In scope: keepalive / idle-timeout handling in src/server.js handleConnection.
+Out of scope: client-side reconnection logic; auth and error-handler behavior (beyond no-regression).
+
+--- AFFECTED COMPONENTS ---
+- src/server.js -> handleConnection(socket) (verified present; no keepalive logic currently).
+
+--- RISK ASSESSMENT ---
+- ~30s close may be app-side OR upstream proxy/LB on staging; investigation must distinguish. [#4]
+- Naive keepalive w/o pong tracking leaves half-open/zombie connections + leaks; track liveness.
+
+--- RELATED ISSUES ---
+- None (dedup returned no matches).
+
+=============================================
+Critique summary: 6 findings applied (0 Critical, 2 High, 2 Medium, 2 Low)
+Review the specification above. Provide any changes, or type "approved" to proceed.
+```
+
+**User:** "approved"  → approved on 1st iteration, 0 feedback rounds.
+
+---
+
+## Step 8 — Create GitHub Issue
+
+Body written to `/tmp/wf1-issue-body.md` (2538 bytes).
+
+Label list:
+```
+$ /tmp/.../bin/gh label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+EXIT=0
+```
+Base label `bug` exists. Created missing scope label `server`:
+```
+$ /tmp/.../bin/gh label create "server" --repo octo-eval/sentinel-app --description "src/server.js (WebSocket/connection layer)" --color "1D76DB"
+Created label 'server'
+EXIT=0
+```
+
+Create issue:
+```
+$ /tmp/.../bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "fix(server): keep idle WebSocket connections alive past 30s" \
+    --body-file /tmp/wf1-issue-body.md \
+    --label "bug" --label "server"
+https://github.com/octo-eval/sentinel-app/issues/101
+EXIT=0
+```
+
+Mock record (`.gh-mock/created-issue.json`):
+```json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "fix(server): keep idle WebSocket connections alive past 30s",
+  "labels": ["bug", "server"],
+  "body_len": 2536,
+  "ts": 1781587713
+}
+```
+
+`.gh-mock/calls.log`:
+```
+gh issue list --repo octo-eval/sentinel-app --search websocket connection drop inactivity timeout keepalive --limit 10
+gh issue list --repo octo-eval/sentinel-app --search websocket --limit 10 --state all
+gh label list --repo octo-eval/sentinel-app
+gh label create server --repo octo-eval/sentinel-app --description src/server.js (WebSocket/connection layer) --color 1D76DB
+gh issue create --repo octo-eval/sentinel-app --title fix(server): keep idle WebSocket connections alive past 30s --body-file /tmp/wf1-issue-body.md --label bug --label server
+```
+
+Temp body cleaned up: `rm -f /tmp/wf1-issue-body.md` (confirmed absent).
+
+---
+
+## Step 9 — Workflow Completion Summary
+
+```
+WF1 COMPLETE
+=============
+GitHub Issue: https://github.com/octo-eval/sentinel-app/issues/101 (Issue #101)
+Type: bug
+Title: fix(server): keep idle WebSocket connections alive past 30s
+Labels: bug, server
+
+Critique Summary:
+- Total findings: 6
+- Applied: 6 (0 Critical, 2 High, 2 Medium, 2 Low)
+- Ambiguity circuit breaker: not triggered
+- Loop-backs: 0
+- Memorized insights: none (correctly skipped)
+
+User Review: approved immediately (1 iteration)
+```
+
+### <completion-gate> — all PASS
+1. Step markers logged for ALL executed steps (1–9) — PASS
+2. Final completion summary presented to user — PASS
+3. Session notes updated with completion summary — PASS
+4. Issue URL documented in session notes (#101) — PASS
+5. Memorize step completed (correctly skipped) — PASS
+6. Issue body matches critique findings (#2 Error Logs, #3 keepalive-missing, #4 risk, #5 idle≥5min, #6 no-regression) — PASS
+
+WF1 complete. No auto-transition to WF2.
+
+---
+
+## FINAL RESULT
+- Issue URL: https://github.com/octo-eval/sentinel-app/issues/101
+- Title: fix(server): keep idle WebSocket connections alive past 30s
+- Labels: bug, server

--- a/skills/create-issue-workspace/iteration-2/bug-report/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-2/bug-report/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 72870,
+  "duration_ms": 329923,
+  "total_duration_seconds": 329.9
+}

--- a/skills/create-issue-workspace/iteration-2/bug-report/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-2/bug-report/without_skill/grading.json
@@ -1,0 +1,50 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "7 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Conventional title fix(scope): ...",
+      "passed": false,
+      "evidence": "title = 'WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)'"
+    },
+    {
+      "text": "Labeled 'bug'",
+      "passed": true,
+      "evidence": "labels = ['bug']"
+    },
+    {
+      "text": "Steps to reproduce present",
+      "passed": true,
+      "evidence": "'reproduc' in body = True"
+    },
+    {
+      "text": "Expected AND actual behavior documented",
+      "passed": true,
+      "evidence": "expected=True actual=True"
+    },
+    {
+      "text": "Environment details present",
+      "passed": true,
+      "evidence": "'environment' in body = True"
+    }
+  ],
+  "summary": {
+    "passed": 6,
+    "failed": 1,
+    "total": 7,
+    "pass_rate": 0.8571
+  },
+  "timing": {
+    "total_tokens": 42607,
+    "duration_ms": 106505,
+    "total_duration_seconds": 106.5
+  }
+}

--- a/skills/create-issue-workspace/iteration-2/bug-report/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-2/bug-report/without_skill/outputs/transcript.md
@@ -1,0 +1,201 @@
+# Transcript — Report WebSocket idle-disconnect bug
+
+User request: Report a bug — the server drops WebSocket connections after about
+30 seconds of inactivity instead of keeping them alive. Reproduces reliably on
+the staging box. Inspect the project (config, issue templates, source) and check
+for a similar existing issue before creating. Use the mock `gh`.
+
+All `gh` calls use the absolute path to the mocked CLI:
+`/tmp/ci-iter2/bug-report/without_skill/fixture/bin/gh`
+
+---
+
+## 1. Set working directory
+
+```
+$ cd /tmp/ci-iter2/bug-report/without_skill/fixture && pwd
+/tmp/ci-iter2/bug-report/without_skill/fixture
+```
+
+## 2. Inspect the project
+
+### Workspace config (`.rawgentic_workspace.json`)
+Active project: `sentinel-app` at `./projects/sentinel-app`, protection level `sandbox`.
+
+### Project config (`projects/sentinel-app/.rawgentic.json`)
+```json
+{
+  "project": { "name": "sentinel-app", "type": "web-service",
+               "description": "Realtime API service for the eval harness" },
+  "repo": { "provider": "github", "fullName": "octo-eval/sentinel-app",
+            "defaultBranch": "trunk" },
+  "techStack": ["node", "javascript"]
+}
+```
+=> Repo for `gh` operations: **octo-eval/sentinel-app**.
+
+### README (`projects/sentinel-app/README.md`)
+```
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+
+### Source files
+`src/server.js`:
+```js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+```
+`src/errorHandler.js`:
+```js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+=> `handleConnection(socket)` is the WebSocket entry point; there is no visible
+keep-alive/heartbeat or idle-timeout handling — consistent with idle sockets
+being dropped at ~30s.
+
+### Issue template (`projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md`)
+```
+---
+name: Bug report
+about: Report broken behavior
+labels: bug
+---
+
+## Description
+
+## Steps to Reproduce
+1.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+
+## Error Logs
+```
+=> The bug template carries the `bug` label and defines the section structure the
+issue body should follow.
+
+## 3. Verify auth and existing labels
+
+```
+$ /tmp/.../bin/gh auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+```
+
+```
+$ /tmp/.../bin/gh label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+```
+=> The `bug` label already exists; no label creation needed.
+
+## 4. Check for a similar existing issue (dedup)
+
+```
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "websocket" --state all --limit 50
+(no output)
+
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "connection drop timeout" --state all --limit 50
+(no output)
+
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "keepalive idle timeout" --state all --limit 50
+(no output)
+
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --state all --limit 100
+(no output)
+```
+=> No existing or duplicate issue covers this WebSocket idle-disconnect bug.
+Safe to create a new one.
+
+## 5. Compose the issue body
+
+Wrote `outputs/issue-body.md` following the project's `bug_report.md` template
+(Description / Steps to Reproduce / Expected / Actual / Environment / Error Logs).
+Body content:
+
+```markdown
+## Description
+
+The server drops WebSocket connections after roughly 30 seconds of inactivity instead of keeping them alive. Idle clients are disconnected even though the connection should persist. This reproduces reliably on the staging box.
+
+The realtime API service (`src/server.js`) accepts WebSocket connections via `handleConnection(socket)`, but there appears to be no keep-alive / heartbeat (ping-pong) mechanism or idle-timeout configuration that holds an idle connection open, so idle sockets are torn down at the ~30s mark.
+
+## Steps to Reproduce
+1. Deploy/run the service on the staging box.
+2. Open a WebSocket connection to the server.
+3. Leave the connection idle (send no frames) for ~30 seconds.
+4. Observe that the server closes the connection.
+
+## Expected Behavior
+
+Idle WebSocket connections stay alive. The server should keep idle connections open (e.g. via a periodic ping/pong heartbeat or an appropriately long / disabled idle timeout) rather than dropping them after ~30 seconds of inactivity.
+
+## Actual Behavior
+
+After about 30 seconds of inactivity the server drops the WebSocket connection. The client is disconnected even though it has done nothing wrong and the connection should still be valid.
+
+## Environment
+
+- Environment: staging box (reproduces reliably)
+- Service: sentinel-app (realtime API service)
+- Stack: Node.js / JavaScript
+- Relevant modules: `src/server.js` (`startServer`, `handleConnection`)
+
+## Error Logs
+
+(Not yet captured. To be added once staging WebSocket close-frame / disconnect logs are collected — capture the close code/reason emitted at the ~30s mark.)
+```
+
+## 6. Create the issue
+
+```
+$ /tmp/.../bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)" \
+    --body-file /tmp/ci-iter2/bug-report/without_skill/fixture/outputs/issue-body.md \
+    --label bug
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+## 7. Verify recorded state
+
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)",
+  "labels": [
+    "bug"
+  ],
+  "body_len": 1616,
+  "ts": 1781586994
+}
+```
+
+```
+$ cat .gh-mock/calls.log
+gh auth status
+gh label list --repo octo-eval/sentinel-app
+gh issue list --repo octo-eval/sentinel-app --search websocket --state all --limit 50
+gh issue list --repo octo-eval/sentinel-app --search connection drop timeout --state all --limit 50
+gh issue list --repo octo-eval/sentinel-app --search keepalive idle timeout --state all --limit 50
+gh issue list --repo octo-eval/sentinel-app --state all --limit 100
+gh issue create --repo octo-eval/sentinel-app --title WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging) --body-file /tmp/ci-iter2/bug-report/without_skill/fixture/outputs/issue-body.md --label bug
+```
+
+---
+
+## Final result
+
+- **Issue URL:** https://github.com/octo-eval/sentinel-app/issues/101
+- **Title:** WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)
+- **Labels:** `bug`
+- **Repo:** octo-eval/sentinel-app
+- **Dedup:** Checked (websocket / connection-drop / keepalive searches + full list) — no existing similar issue.

--- a/skills/create-issue-workspace/iteration-2/bug-report/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-2/bug-report/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 42607,
+  "duration_ms": 106505,
+  "total_duration_seconds": 106.5
+}

--- a/skills/create-issue-workspace/iteration-2/config-decoy/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-2/config-decoy/eval_metadata.json
@@ -1,0 +1,14 @@
+{
+  "eval_id": 3,
+  "eval_name": "config-decoy",
+  "scenario": "config-decoy",
+  "prompt": "Create an issue for improving error handling across the service.",
+  "fixture_with": "/tmp/ci-iter2/config-decoy/with_skill/fixture",
+  "fixture_without": "/tmp/ci-iter2/config-decoy/without_skill/fixture",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Issue was actually created via gh (not simulated)",
+    "Uses config repo, not the CLAUDE.md decoy",
+    "Decoy repo never used in any gh call or issue body"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-2/config-decoy/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-2/config-decoy/with_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "3 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Uses config repo, not the CLAUDE.md decoy",
+      "passed": true,
+      "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"
+    },
+    {
+      "text": "Decoy repo never used in any gh call or issue body",
+      "passed": true,
+      "evidence": "decoy in calls=False, in body=False"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 66217,
+    "duration_ms": 267605,
+    "total_duration_seconds": 267.6
+  }
+}

--- a/skills/create-issue-workspace/iteration-2/config-decoy/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-2/config-decoy/with_skill/outputs/transcript.md
@@ -1,0 +1,220 @@
+# WF1 create-issue — Complete Transcript
+
+User request: **Create an issue for improving error handling across the service.**
+
+All `gh` calls used the mocked CLI at `./bin/gh` (absolute: `/tmp/ci-iter2/config-decoy/with_skill/fixture/bin/gh`). The Step 3 three-judge critique was performed inline (harness constraint: no subagents).
+
+---
+
+## Config Resolution (Step 1 `<config-loading>`)
+
+Active-project fallback chain:
+- **Level 1 (conversation context):** no `/rawgentic:switch` in this session.
+- **Level 2 (session registry):** `claude_docs/session_registry.jsonl` does NOT exist -> no match.
+- **Level 3 (workspace default):** `.rawgentic_workspace.json` has exactly ONE active project -> `sentinel-app` at `./projects/sentinel-app`. Used.
+
+Disabled-skill check: project entry `disabledSkills: []`, no `bmadDetected` -> proceed.
+
+### Capabilities derivation (the source of truth)
+
+Command:
+```
+$ python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+```
+Real output (EXIT 0):
+```json
+{"config":{"version":1,"project":{"name":"sentinel-app","type":"web-service","description":"Realtime API service for the eval harness"},"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},"protectionLevel":"sandbox","techStack":["node","javascript"],"testing":{"frameworks":[{"name":"vitest","type":"unit","command":"npm test","testDir":"test"}]},"ci":{"provider":"github-actions","workflowDir":".github/workflows"},"documentation":{"primaryFiles":["README.md"],"format":"markdown"},"custom":{}},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+```
+
+### Resolved config values used (ESPECIALLY repository — and WHY)
+- **`capabilities.repo` = `octo-eval/sentinel-app`** — taken from `config.repo.fullName` via the capabilities CLI (the skill's single source of truth).
+- **`capabilities.default_branch` = `trunk`** — from `config.repo.defaultBranch`.
+- `project_type=web-service`, `has_tests=true`, `test_commands=[npm test]`, `has_ci=true`, `has_deploy=false`, `has_database=false`, `has_docker=false`.
+
+**DECOY HANDLED:** `CLAUDE.md` in the workspace root claims `Primary repository: octo-eval/sentinel-legacy` and `Default branch: main`. The skill mandates `capabilities.repo` / `capabilities.default_branch` from the config CLI, NOT CLAUDE.md. Therefore the issue targets **`octo-eval/sentinel-app`** (branch `trunk`), and the `sentinel-legacy`/`main` values in CLAUDE.md were correctly IGNORED.
+
+---
+
+## Step 1: Receive User Intent
+
+Classification: **feature** (enhancement of existing behavior; not a report of broken behavior).
+
+Dedup check:
+```
+$ ./bin/gh issue list --repo octo-eval/sentinel-app --search "error handling" --limit 10
+(EXIT 0, no output -> no existing issues)
+```
+
+Presented to user:
+```
+Issue Classification:
+- Type: feature
+- Summary: Improve error handling consistency and robustness across the sentinel-app service.
+- Scope hints: src/errorHandler.js (handleError), src/server.js (startServer, handleConnection)
+- Existing issues found: none
+Proceeding to brainstorm. Confirm or correct this classification.
+```
+User (played): **Confirmed — feature.**
+
+---
+
+## Step 2: Brainstorm (inline; moderate feature)
+
+Read templates, README, source. Verified components exist:
+```
+$ grep -rn "handleError\|startServer\|handleConnection" projects/sentinel-app/src
+projects/sentinel-app/src/errorHandler.js:2:export function handleError(err, req, res) { /* ... */ }
+projects/sentinel-app/src/server.js:2:export function startServer(port) { /* ... */ }
+projects/sentinel-app/src/server.js:3:export function handleConnection(socket) { /* ... */ }
+```
+No MEMORY.md; no `test/` dir yet (config declares vitest `npm test`). All component claims grounded in these real symbols — no hallucinated modules.
+
+Draft title: `feat(error-handling): standardize error handling across server and connection paths`. 5 ACs, scope/out-of-scope, affected components, risk, complexity = M.
+
+---
+
+## Step 3: Critique (inline 3-judge — reflexion default; no `critiqueMethod` set)
+
+- **Judge 1 (Requirements Validator):** #1 High (correlation-id origin undefined), #2 Medium (mark Related=None), #3 Low (dedup ok). Components verified present — no hallucinations.
+- **Judge 2 (Solution Architect):** #4 High (process-level handler must not swallow fatal errors), #5 Medium (keep DB/Docker/deploy out-of-scope — none in config), #6 Low (complexity M reasonable).
+- **Judge 3 (Code Quality Reviewer):** #7 Medium (enumerate error envelope fields for testability), #8 Low (title token fine), #9 High (client errors must omit stack traces — no `security` block in config).
+
+Synthesis: no disagreements, no conflicts. Counts: **0 Critical, 3 High, 3 Medium, 3 Low.**
+Volume thresholds (per-tier): 0<=5, 3<=5, 3<=10, 3<=10 -> **no loop-back** (loop_iteration=0).
+
+---
+
+## Step 4: Apply Findings (Ambiguity Circuit Breaker)
+
+Sub-step 0 (adversarial review, default-off, opt-in):
+```
+$ python3 hooks/adversarial_review_lib.py is-enabled --workspace .rawgentic_workspace.json --project sentinel-app --skill create-issue
+disabled
+(EXIT 1)
+```
+-> **skipped silently** (no temp file, no subprocess). Behavior byte-for-byte unchanged.
+
+Circuit-breaker scan: `ambiguous_findings=[]`, `conflicting_findings=[]`, `judgment_findings=[]` (all findings clear and resolvable from description + verified codebase).
+-> **CLEAR PATH.** workflow_state = clear.
+User notification: "Critique complete. 9 findings applied (0 Critical, 3 High, 3 Medium, 3 Low). All clear — no ambiguity detected."
+
+---
+
+## Step 5: Incorporate Amendments
+
+Applied: #7 enumerate `{code,message,requestId}` (AC1); #1 correlation-id generated at entry (AC4); #4 process-level handler logs + exits non-zero, never swallows (AC3); #9 no stack-trace leak (AC5); #5 DB/Docker/deploy explicitly out-of-scope; #2 Related = None. #3/#6/#8 were validations (no change). No internal contradictions; template-conformant; under 2000 words.
+
+## Step 6: Memorization (parallel)
+SKIPPED — insights are generic best-practice, not novel/cross-project; no MEMORY.md to update. No output.
+
+---
+
+## Step 7: User Review — DRAFT ISSUE SPECIFICATION
+
+```
+Title: feat(error-handling): standardize error handling across server and connection paths
+Type: feature
+Labels: enhancement
+Complexity: M
+
+--- DESCRIPTION ---
+The service centralizes error handling in src/errorHandler.js via handleError(err, req, res),
+but the request/connection lifecycle in src/server.js (startServer, handleConnection) does not
+consistently route failures through it. This feature standardizes error handling so every error
+path produces a consistent, structured, client-safe response and is observable via logs with a
+correlation id. Goal: predictable error envelopes, no silent failures, no leaked internals.
+
+--- ACCEPTANCE CRITERIA ---
+1. handleError(err, req, res) returns a structured error envelope with a stable shape
+   { code, message, requestId } for all handled errors.
+2. handleConnection(socket) wraps socket processing so thrown/rejected errors are routed through
+   handleError rather than crashing the connection.
+3. startServer(port) registers process-level handlers for unhandledRejection / uncaughtException
+   that delegate to the centralized handler, log the error, and exit non-zero on fatal errors
+   (errors are never silently swallowed).
+4. A correlation id (requestId) is generated at request/connection entry and included in both the
+   error envelope and the log line; 4xx vs 5xx classification is consistent.
+5. Client-facing error responses omit stack traces and internal implementation details.
+6. Unit tests (vitest, `npm test`) cover handleError and the handleConnection error path.
+
+--- SCOPE ---
+In scope:  src/errorHandler.js (handleError); src/server.js (startServer, handleConnection); new tests under test/
+Out of scope: changing public response schema beyond the error envelope; auth/rate-limiting/new transports;
+              database, Docker, or deployment changes (none exist in config)
+
+--- AFFECTED COMPONENTS ---
+- src/errorHandler.js::handleError (verified present)
+- src/server.js::startServer (verified present)
+- src/server.js::handleConnection (verified present)
+
+--- RISK ASSESSMENT ---
+- Low–Medium; stable error envelope may affect clients (mitigated by stable shape).
+- Process-level handlers must not swallow fatal errors (AC3). No DB/Docker/deploy -> no infra risk.
+- CI: github-actions; new tests must pass `npm test`.
+
+--- RELATED ISSUES ---
+- None (dedup search returned no matches).
+
+Critique summary: 9 findings applied (0 Critical, 3 High, 3 Medium, 3 Low)
+```
+User (played): **approved** (1 presentation, 0 feedback iterations).
+
+---
+
+## Step 8: Create GitHub Issue
+
+Body written to `/tmp/wf1-issue-body.md` (2324 bytes).
+
+Existing labels:
+```
+$ ./bin/gh label list --repo octo-eval/sentinel-app
+bug          Something isn't working    d73a4a
+enhancement  New feature or request     a2eeef
+(EXIT 0)
+```
+Used `enhancement` (base label for a feature). Did NOT invent/create an `error-handling` scope label (not present in repo).
+
+Create:
+```
+$ ./bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "feat(error-handling): standardize error handling across server and connection paths" \
+    --body-file /tmp/wf1-issue-body.md \
+    --label "enhancement"
+https://github.com/octo-eval/sentinel-app/issues/101
+(EXIT 0)
+```
+Temp file removed (`rm -f /tmp/wf1-issue-body.md`).
+
+---
+
+## Step 9: Completion Summary
+
+```
+WF1 COMPLETE
+=============
+GitHub Issue: https://github.com/octo-eval/sentinel-app/issues/101 (Issue #101)
+Repo targeted: octo-eval/sentinel-app  (from config CLI; CLAUDE.md `sentinel-legacy` decoy ignored)
+Type: feature
+Title: feat(error-handling): standardize error handling across server and connection paths
+
+Critique Summary:
+- Total findings: 9
+- Applied: 9 (0 Critical, 3 High, 3 Medium, 3 Low)
+- Ambiguity circuit breaker: not triggered
+- Loop-backs: 0
+- Memorized insights: none (correctly skipped)
+
+User Review: approved immediately (0 iterations)
+```
+
+## Completion Gate (all PASS)
+1. [PASS] Step markers logged for ALL executed steps (1-9 + Step 4 adversarial skip)
+2. [PASS] Completion summary presented to user
+3. [PASS] Session notes updated with completion summary
+4. [PASS] Issue URL documented in session notes
+5. [PASS] Memorize step completed (correctly skipped)
+6. [PASS] Issue body matches critique findings
+
+**FINAL RESULT:** Issue https://github.com/octo-eval/sentinel-app/issues/101 created in repo **octo-eval/sentinel-app**.
+WF1 terminates here. No auto-transition to WF2.

--- a/skills/create-issue-workspace/iteration-2/config-decoy/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-2/config-decoy/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 66217,
+  "duration_ms": 267605,
+  "total_duration_seconds": 267.6
+}

--- a/skills/create-issue-workspace/iteration-2/config-decoy/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-2/config-decoy/without_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Uses config repo, not the CLAUDE.md decoy",
+      "passed": true,
+      "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"
+    },
+    {
+      "text": "Decoy repo never used in any gh call or issue body",
+      "passed": true,
+      "evidence": "decoy in calls=False, in body=False"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 44246,
+    "duration_ms": 124396,
+    "total_duration_seconds": 124.4
+  }
+}

--- a/skills/create-issue-workspace/iteration-2/config-decoy/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-2/config-decoy/without_skill/outputs/transcript.md
@@ -1,0 +1,269 @@
+# Transcript: Create issue for improving error handling across the service
+
+## Task
+Create a GitHub issue for improving error handling across the sentinel-app service.
+Determine the correct repository from project configuration, inspect issue templates
+and source files, check for a similar existing issue first, then create the issue
+using the mocked `gh` CLI (invoked by absolute path
+`/tmp/ci-iter2/config-decoy/without_skill/fixture/bin/gh`).
+
+---
+
+## 1. Establish working directory
+
+```
+$ cd /tmp/ci-iter2/config-decoy/without_skill/fixture && pwd
+/tmp/ci-iter2/config-decoy/without_skill/fixture
+```
+
+## 2. Explore workspace structure and config
+
+```
+$ ls -la
+total 40
+drwxrwxr-x 8 ... .gh-mock
+-rw-rw-r-- 1 ... .rawgentic_workspace.json
+-rw-rw-r-- 1 ... CLAUDE.md
+drwxrwxr-x 2 ... bin
+drwxrwxr-x 2 ... claude_docs
+drwxrwxr-x 2 ... hooks
+drwxrwxr-x 2 ... outputs
+drwxrwxr-x 3 ... projects
+
+$ cat .rawgentic_workspace.json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+
+$ ls -la projects/
+drwxrwxr-x ... sentinel-app
+```
+
+The active project is `sentinel-app` at `./projects/sentinel-app`.
+
+## 3. Read root CLAUDE.md and list project files
+
+```
+$ cat CLAUDE.md
+# sentinel-app workspace
+
+Primary repository: octo-eval/sentinel-legacy
+Default branch: main
+
+Contributions go through the standard PR flow.
+
+$ find projects/sentinel-app -type f -not -path '*/.git/*' | sort
+projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md
+projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md
+projects/sentinel-app/.rawgentic.json
+projects/sentinel-app/README.md
+projects/sentinel-app/src/errorHandler.js
+projects/sentinel-app/src/server.js
+```
+
+**DISCREPANCY NOTED:** The root `CLAUDE.md` says "Primary repository: octo-eval/sentinel-legacy"
+with default branch `main`. This is a decoy/stale value. The authoritative,
+structured per-project config (`projects/sentinel-app/.rawgentic.json`) is the
+source of truth for the repo and must be checked (see next step).
+
+## 4. Read project config and README
+
+```
+$ cat projects/sentinel-app/.rawgentic.json
+{
+  "version": 1,
+  "project": {
+    "name": "sentinel-app",
+    "type": "web-service",
+    "description": "Realtime API service for the eval harness"
+  },
+  "repo": {
+    "provider": "github",
+    "fullName": "octo-eval/sentinel-app",
+    "defaultBranch": "trunk"
+  },
+  "protectionLevel": "sandbox",
+  "techStack": ["node", "javascript"],
+  "testing": {
+    "frameworks": [
+      { "name": "vitest", "type": "unit", "command": "npm test", "testDir": "test" }
+    ]
+  },
+  "ci": { "provider": "github-actions", "workflowDir": ".github/workflows" },
+  "documentation": { "primaryFiles": ["README.md"], "format": "markdown" },
+  "custom": {}
+}
+
+$ cat projects/sentinel-app/README.md
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+
+**REPO DECISION:** Target repo is **`octo-eval/sentinel-app`**, taken from
+`projects/sentinel-app/.rawgentic.json` -> `repo.fullName`. This is the active
+project's own structured configuration and is the authoritative source for where
+issues are filed. The root `CLAUDE.md` value (`octo-eval/sentinel-legacy`) is a
+mismatched decoy — "legacy" naming, a conflicting default branch (`main` vs the
+project config's `trunk`), and no corroboration anywhere else (no git remote, README
+names only `sentinel-app`). The per-project config wins.
+
+## 5. Check git remote (none) and read issue templates
+
+```
+$ (cd projects/sentinel-app && git remote -v; git config --get remote.origin.url; echo "rc: $?")
+git status rc: 1        # not a git repo / no remote — no remote signal to corroborate
+
+$ cat projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md
+---
+name: Bug report
+about: Report broken behavior
+labels: bug
+---
+## Description
+## Steps to Reproduce
+1.
+## Expected Behavior
+## Actual Behavior
+## Environment
+## Error Logs
+
+$ cat projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md
+---
+name: Feature request
+about: Propose new functionality
+labels: enhancement
+---
+## Description
+## Acceptance Criteria
+1.
+## Scope
+In scope:
+-
+Out of scope:
+-
+## Affected Components
+## Risk Assessment
+## Complexity
+<!-- S / M / L / XL -->
+## Related Issues
+```
+
+**TEMPLATE DECISION:** "Improving error handling across the service" is an
+enhancement / new-functionality effort, not a report of broken behavior, so the
+**feature_request.md** template applies (label: `enhancement`).
+
+## 6. Read source files (to write a substantive, accurate issue)
+
+```
+$ cat projects/sentinel-app/src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat projects/sentinel-app/src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+
+Modules referenced in the issue: `src/errorHandler.js` (`handleError`) and
+`src/server.js` (`startServer`, `handleConnection`).
+
+## 7. Inspect the mock gh interface
+
+Read `bin/gh`. Supported subcommands: `auth status`, `issue list`, `issue view`,
+`label list`, `label create`, `issue create`. `issue create` accepts `--repo`,
+`--title`, `--body-file`/`--body`, repeated `--label`. Seed data lives in
+`.gh-mock/` (`seed_issues.tsv` was 0 bytes -> clean repo, no seeded duplicates).
+
+## 8. Verify auth and check for a similar/duplicate issue BEFORE creating
+
+```
+$ GH=/tmp/ci-iter2/config-decoy/without_skill/fixture/bin/gh
+
+$ "$GH" auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+
+$ "$GH" issue list --repo octo-eval/sentinel-app --search "error handling" --state all --limit 30
+            # (no output) -> exit 0, no matching issues
+
+$ "$GH" issue list --repo octo-eval/sentinel-app --search "error handler" --state all --limit 30
+            # (no output) -> exit 0, no matching issues
+
+$ "$GH" label list --repo octo-eval/sentinel-app
+bug         Something isn't working   d73a4a
+enhancement New feature or request    a2eeef
+```
+
+**DEDUP RESULT:** Two searches (all states) returned nothing — no existing or
+duplicate issue. Safe to create. The `enhancement` label already exists (matches
+the feature_request template), so no label creation needed.
+
+## 9. Create the issue
+
+Body written to `.gh-mock/new-issue-body.md` following the feature_request template
+(Description, Acceptance Criteria, Scope, Affected Components, Risk Assessment,
+Complexity, Related Issues), grounded in the actual source modules.
+
+```
+$ "$GH" issue create \
+    --repo octo-eval/sentinel-app \
+    --title "Improve error handling across the service" \
+    --body-file /tmp/ci-iter2/config-decoy/without_skill/fixture/.gh-mock/new-issue-body.md \
+    --label enhancement
+https://github.com/octo-eval/sentinel-app/issues/101
+[exit 0]
+```
+
+## 10. Verify the mock recorded the creation
+
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "Improve error handling across the service",
+  "labels": [
+    "enhancement"
+  ],
+  "body_len": 2415,
+  "ts": 1781586991
+}
+
+$ cat .gh-mock/calls.log
+gh auth status
+gh issue list --repo octo-eval/sentinel-app --search error handling --state all --limit 30
+gh issue list --repo octo-eval/sentinel-app --search error handler --state all --limit 30
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title Improve error handling across the service --body-file /tmp/ci-iter2/config-decoy/without_skill/fixture/.gh-mock/new-issue-body.md --label enhancement
+```
+
+---
+
+## Final result
+
+- **Repository targeted:** `octo-eval/sentinel-app`
+  - **Why:** Source of truth is the active project's own structured config,
+    `projects/sentinel-app/.rawgentic.json` (`repo.fullName = octo-eval/sentinel-app`).
+    The root `CLAUDE.md` "octo-eval/sentinel-legacy" is a stale/decoy value
+    (conflicting default branch, "legacy" naming, uncorroborated by README or any
+    git remote) and was correctly overridden by the per-project config.
+- **Template used:** `feature_request.md` (enhancement), since improving error
+  handling is new/enhanced functionality, not a bug report.
+- **Dedup check:** Performed two `issue list` searches (`error handling`,
+  `error handler`, `--state all`) before creating; no similar issue existed.
+- **Issue title:** "Improve error handling across the service"
+- **Label:** `enhancement` (pre-existing)
+- **Issue URL:** https://github.com/octo-eval/sentinel-app/issues/101

--- a/skills/create-issue-workspace/iteration-2/config-decoy/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-2/config-decoy/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 44246,
+  "duration_ms": 124396,
+  "total_duration_seconds": 124.4
+}

--- a/skills/create-issue-workspace/iteration-2/dedup-hit/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-2/dedup-hit/eval_metadata.json
@@ -1,0 +1,14 @@
+{
+  "eval_id": 2,
+  "eval_name": "dedup-hit",
+  "scenario": "dedup-hit",
+  "prompt": "I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it.",
+  "fixture_with": "/tmp/ci-iter2/dedup-hit/with_skill/fixture",
+  "fixture_without": "/tmp/ci-iter2/dedup-hit/without_skill/fixture",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Deduplication search ran",
+    "Existing matching issue (#42) surfaced to the user",
+    "Did not blindly create a duplicate"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-2/dedup-hit/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-2/dedup-hit/with_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Deduplication search ran",
+      "passed": true,
+      "evidence": "issue-list-with-search logged = True"
+    },
+    {
+      "text": "Existing matching issue (#42) surfaced to the user",
+      "passed": true,
+      "evidence": "'#42'/'42' in transcript = True"
+    },
+    {
+      "text": "Did not blindly create a duplicate",
+      "passed": true,
+      "evidence": "no new issue created (acknowledged existing) -- acceptable"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 56778,
+    "duration_ms": 129991,
+    "total_duration_seconds": 130.0
+  }
+}

--- a/skills/create-issue-workspace/iteration-2/dedup-hit/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-2/dedup-hit/with_skill/outputs/transcript.md
@@ -1,0 +1,150 @@
+# WF1 Issue-Creation Transcript
+
+**User request:** "I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it."
+
+**Skill under test:** `rawgentic:create-issue` (WF1, 9-step issue-creation workflow).
+
+---
+
+## Step 0 — Working directory
+
+```
+$ cd /tmp/ci-iter2/dedup-hit/with_skill/fixture && pwd
+/tmp/ci-iter2/dedup-hit/with_skill/fixture
+```
+
+Confirmed: a self-contained rawgentic workspace with one active project (`sentinel-app`).
+
+---
+
+## Config-loading (runs before any workflow step)
+
+### Active-project fallback chain
+- **Level 1 (conversation context):** No `/rawgentic:switch` ran in this session → not bound here.
+- **Level 2 (session registry):** `claude_docs/session_registry.jsonl` does not exist → no binding.
+
+```
+$ cat claude_docs/session_registry.jsonl
+(no session_registry.jsonl)
+```
+
+- **Level 3 (workspace default):** Read `.rawgentic_workspace.json` from the workspace root.
+
+```
+$ cat .rawgentic_workspace.json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+```
+
+Exactly one project has `active == true` → **bind to `sentinel-app`** (path `./projects/sentinel-app`, resolved against the workspace root).
+
+### Step 1b — disabled-skill check
+- Project entry has `disabledSkills: []` (field present, empty). `create-issue` is **not** in it.
+- Workspace has **no** `bmadDetected` field (so the "BMAD detected but no skill prefs" STOP does not apply).
+- → Proceed.
+
+### Capabilities derivation (single source of truth)
+
+```
+$ python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+{"config":{"version":1,"project":{"name":"sentinel-app","type":"web-service","description":"Realtime API service for the eval harness"},"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},"protectionLevel":"sandbox","techStack":["node","javascript"],"testing":{"frameworks":[{"name":"vitest","type":"unit","command":"npm test","testDir":"test"}]},"ci":{"provider":"github-actions","workflowDir":".github/workflows"},"documentation":{"primaryFiles":["README.md"],"format":"markdown"},"custom":{}},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+EXIT=0
+```
+
+**Exit 0 — config valid.** Resolved values carried as literals:
+
+| field | value |
+|---|---|
+| repo | `octo-eval/sentinel-app` |
+| default_branch | `trunk` |
+| project_type | `web-service` |
+| has_tests | `true` (`npm test`) |
+| has_ci | `true` (github-actions) |
+| has_deploy | `false` |
+| has_database | `false` |
+| has_docker | `false` |
+
+---
+
+## Step 1 — Receive User Intent
+
+**Acknowledge:** Request received — add WebSocket support to the API for realtime client updates.
+
+**Classification:** **FEATURE** — new functionality (a WebSocket transport that pushes realtime updates to clients). Unambiguously a feature request, not a bug; no classification clarifying question needed.
+
+**Scope hints:** server/API layer (`projects/sentinel-app/src/server.js`), realtime transport, client push updates.
+
+**Information sufficiency:** Enough to draft acceptance criteria; but before any drafting, the dedup gate runs (Step 1.6).
+
+### Deduplication check (mocked `gh`, invoked via absolute path)
+
+```
+$ /tmp/ci-iter2/dedup-hit/with_skill/fixture/bin/gh issue list --repo octo-eval/sentinel-app --search "websocket realtime" --limit 10
+42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z
+EXIT=0
+```
+
+Confirming with additional keyword variations:
+
+```
+$ .../bin/gh issue list --repo octo-eval/sentinel-app --search "websocket" --limit 10
+42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z
+
+$ .../bin/gh issue list --repo octo-eval/sentinel-app --search "WebSocket API realtime updates clients" --limit 10
+42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z
+
+$ .../bin/gh issue view 42 --repo octo-eval/sentinel-app
+title:	stub
+state:	OPEN
+```
+
+### Dedup search results
+- **Issue #42 — `feat(server): add WebSocket support for realtime updates`** — label `enhancement`, created 2026-05-01, **state OPEN**.
+- Every keyword variation returns this same single issue.
+
+### Duplicate decision (answering honestly as the user)
+Per Step 1.7, presenting #42 and asking "Does this cover your request?":
+
+> My request is "add WebSocket support to the API so clients get realtime updates." Issue **#42** is titled "add WebSocket support for realtime updates" and is **OPEN**. That is the same feature, near-verbatim. **Yes — #42 fully covers my request.**
+
+This is a **genuine duplicate**, so per the test's honesty instruction and the skill's Step 1 failure-mode ("Dedup check finds a matching issue → present to user and ask if it covers their request before proceeding"), the workflow must **not** create a duplicate.
+
+**Decision: Do NOT create a new issue.** WF1 stops at the dedup gate and points the user at the existing open issue #42. Steps 2–9 (brainstorm, critique, circuit breaker, review, create) are intentionally not run, because creating an issue would duplicate #42.
+
+---
+
+## Issue Classification (Step 1 output)
+
+```
+Issue Classification:
+- Type: feature
+- Summary: Add WebSocket support to the API so clients receive realtime updates.
+- Scope hints: server/API (src/server.js), realtime transport, client push
+- Existing issues found: #42 "feat(server): add WebSocket support for realtime updates" (enhancement, OPEN, 2026-05-01)
+
+Dedup result: #42 is an OPEN, near-verbatim duplicate of this request. No new issue created.
+```
+
+---
+
+## Step 6 — Conditional memorization
+No novel cross-cutting insight was produced (no brainstorm/critique ran), so the memorize step is correctly **skipped** — no output.
+
+---
+
+## Final outcome
+
+**WF1 terminated at the dedup gate — no new GitHub issue created.** The request is already tracked by existing **OPEN issue #42 ("feat(server): add WebSocket support for realtime updates")**. The user was shown the duplicate and confirmed it covers the request, so the workflow correctly avoided creating a duplicate and directed the user to follow #42.

--- a/skills/create-issue-workspace/iteration-2/dedup-hit/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-2/dedup-hit/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 56778,
+  "duration_ms": 129991,
+  "total_duration_seconds": 130.0
+}

--- a/skills/create-issue-workspace/iteration-2/dedup-hit/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-2/dedup-hit/without_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "4 gh call(s) logged"
+    },
+    {
+      "text": "Deduplication search ran",
+      "passed": true,
+      "evidence": "issue-list-with-search logged = True"
+    },
+    {
+      "text": "Existing matching issue (#42) surfaced to the user",
+      "passed": true,
+      "evidence": "'#42'/'42' in transcript = True"
+    },
+    {
+      "text": "Did not blindly create a duplicate",
+      "passed": true,
+      "evidence": "no new issue created (acknowledged existing) -- acceptable"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 40980,
+    "duration_ms": 99110,
+    "total_duration_seconds": 99.1
+  }
+}

--- a/skills/create-issue-workspace/iteration-2/dedup-hit/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-2/dedup-hit/without_skill/outputs/transcript.md
@@ -1,0 +1,171 @@
+# Transcript — Add WebSocket support issue request
+
+## User request
+> I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it.
+
+Instruction: inspect the project, check whether a similar issue already exists, and handle it sensibly before creating anything. Use the mock `gh` (absolute path).
+
+---
+
+## 1. Explore the project
+
+### `cat .rawgentic_workspace.json`
+```json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+```
+
+### `find projects/sentinel-app -type f`
+```
+projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md
+projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md
+projects/sentinel-app/.rawgentic.json
+projects/sentinel-app/README.md
+projects/sentinel-app/src/errorHandler.js
+projects/sentinel-app/src/server.js
+```
+
+### `cat projects/sentinel-app/.rawgentic.json` (key fields)
+```json
+{
+  "project": { "name": "sentinel-app", "type": "web-service", "description": "Realtime API service for the eval harness" },
+  "repo": { "provider": "github", "fullName": "octo-eval/sentinel-app", "defaultBranch": "trunk" },
+  "techStack": ["node", "javascript"]
+}
+```
+- Repo for `gh`: **octo-eval/sentinel-app**
+
+### `cat projects/sentinel-app/README.md`
+```
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+
+### Source
+`src/server.js`
+```js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+```
+`src/errorHandler.js`
+```js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+
+### Issue template that would apply (`feature_request.md`)
+```
+---
+name: Feature request
+about: Propose new functionality
+labels: enhancement
+---
+
+## Description
+## Acceptance Criteria
+1.
+## Scope
+In scope:
+-
+Out of scope:
+-
+## Affected Components
+## Risk Assessment
+## Complexity
+<!-- S / M / L / XL -->
+## Related Issues
+```
+(`bug_report.md` also present but not relevant — this is a feature.)
+
+---
+
+## 2. Verify auth (mock gh)
+
+Command:
+```
+/tmp/ci-iter2/dedup-hit/without_skill/fixture/bin/gh auth status
+```
+Output (stderr):
+```
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+```
+
+---
+
+## 3. Duplicate check (BEFORE creating anything)
+
+### Search 1 — "websocket"
+Command:
+```
+/tmp/ci-iter2/dedup-hit/without_skill/fixture/bin/gh issue list --repo octo-eval/sentinel-app --search "websocket" --state all --limit 20
+```
+Output:
+```
+42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z
+```
+
+### Search 2 — "realtime updates"
+Command:
+```
+/tmp/ci-iter2/dedup-hit/without_skill/fixture/bin/gh issue list --repo octo-eval/sentinel-app --search "realtime updates" --state all --limit 20
+```
+Output:
+```
+42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z
+```
+
+### Inspect the match
+Command:
+```
+/tmp/ci-iter2/dedup-hit/without_skill/fixture/bin/gh issue view 42 --repo octo-eval/sentinel-app
+```
+Output:
+```
+title:	stub
+state:	OPEN
+```
+
+### Dedup result
+**A near-identical issue already exists and is OPEN.**
+
+| # | Title | Labels | State | Updated |
+|---|-------|--------|-------|---------|
+| 42 | feat(server): add WebSocket support for realtime updates | enhancement | OPEN | 2026-05-01 |
+
+The user's request ("add WebSocket support to the API so clients get realtime updates") maps directly onto issue #42, both in subject (WebSocket support) and in motivation (realtime updates to clients). It is the same feature.
+
+---
+
+## 4. Decision — handle sensibly
+
+Creating a second issue would be a duplicate. The sensible action is **NOT to create a new issue**. Instead, point the user at the existing open issue #42 so the discussion/work stays consolidated there.
+
+- No `gh issue create` was run.
+- No `gh label create` was run (the existing `enhancement` label already covers it, and no new issue is being filed).
+
+---
+
+## 5. Final outcome
+
+No new issue created. An existing open issue already tracks this exact request:
+
+- **#42 — feat(server): add WebSocket support for realtime updates** (label: `enhancement`, state: OPEN)
+- URL: https://github.com/octo-eval/sentinel-app/issues/42
+
+Recommendation to the user: add any additional detail (acceptance criteria, affected components — `src/server.js#handleConnection`, `src/server.js#startServer`) as a comment on #42 rather than opening a duplicate. If #42 turns out to be stale or scoped differently than intended, reopen the conversation there or explicitly request a fresh issue.

--- a/skills/create-issue-workspace/iteration-2/dedup-hit/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-2/dedup-hit/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 40980,
+  "duration_ms": 99110,
+  "total_duration_seconds": 99.1
+}

--- a/skills/create-issue-workspace/iteration-2/feature-quality/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-2/feature-quality/eval_metadata.json
@@ -1,0 +1,18 @@
+{
+  "eval_id": 1,
+  "eval_name": "feature-quality",
+  "scenario": "feature-quality",
+  "prompt": "Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.",
+  "fixture_with": "/tmp/ci-iter2/feature-quality/with_skill/fixture",
+  "fixture_without": "/tmp/ci-iter2/feature-quality/without_skill/fixture",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Issue was actually created via gh (not simulated)",
+    "Targets the config repo octo-eval/sentinel-app",
+    "Conventional title feat(scope): ...",
+    "At least 3 numbered acceptance criteria",
+    "Explicit in-scope AND out-of-scope sections",
+    "Risk assessment present",
+    "Deduplication search ran before creation"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-2/feature-quality/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-2/feature-quality/with_skill/grading.json
@@ -1,0 +1,55 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Targets the config repo octo-eval/sentinel-app",
+      "passed": true,
+      "evidence": "created repo = 'octo-eval/sentinel-app'"
+    },
+    {
+      "text": "Conventional title feat(scope): ...",
+      "passed": true,
+      "evidence": "title = 'feat(server): add WebSocket support for realtime updates'"
+    },
+    {
+      "text": "At least 3 numbered acceptance criteria",
+      "passed": true,
+      "evidence": "6 numbered items in body"
+    },
+    {
+      "text": "Explicit in-scope AND out-of-scope sections",
+      "passed": true,
+      "evidence": "in-scope=True out-of-scope=True"
+    },
+    {
+      "text": "Risk assessment present",
+      "passed": true,
+      "evidence": "'risk' in body = True"
+    },
+    {
+      "text": "Deduplication search ran before creation",
+      "passed": true,
+      "evidence": "issue-list-with-search logged = True"
+    }
+  ],
+  "summary": {
+    "passed": 8,
+    "failed": 0,
+    "total": 8,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 67239,
+    "duration_ms": 253092,
+    "total_duration_seconds": 253.1
+  }
+}

--- a/skills/create-issue-workspace/iteration-2/feature-quality/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-2/feature-quality/with_skill/outputs/transcript.md
@@ -1,0 +1,278 @@
+# WF1 create-issue — Full Transcript
+
+User request: *Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.*
+
+All `gh` calls use the mocked CLI at `/tmp/ci-iter2/feature-quality/with_skill/fixture/bin/gh` (invoked here as `./bin/gh` from the fixture root). Step 3's three parallel judge subagents were performed INLINE per the harness constraint (no subagents spawned).
+
+---
+
+## Config Loading
+
+**Active-project fallback chain:**
+- Level 1 (conversation context): no prior `/rawgentic:switch` in session → no match.
+- Level 2 (session registry): `claude_docs/session_registry.jsonl` does not exist → no match.
+- Level 3 (workspace default): `.rawgentic_workspace.json` has exactly one project with `active == true` → **`sentinel-app`** (path `./projects/sentinel-app`).
+
+**Disabled-skill check:** project entry `disabledSkills: []` (create-issue not present). Workspace has no `bmadDetected` field. → proceed.
+
+**Command (run from workspace root):**
+```bash
+python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+```
+**Exit:** 0
+
+**Resolved config + capabilities (literal values carried into later steps):**
+```json
+{"config":{"version":1,"project":{"name":"sentinel-app","type":"web-service","description":"Realtime API service for the eval harness"},"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},"protectionLevel":"sandbox","techStack":["node","javascript"],"testing":{"frameworks":[{"name":"vitest","type":"unit","command":"npm test","testDir":"test"}]},"ci":{"provider":"github-actions","workflowDir":".github/workflows"},"documentation":{"primaryFiles":["README.md"],"format":"markdown"},"custom":{}},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+```
+
+| Capability | Value |
+|---|---|
+| repo | `octo-eval/sentinel-app` |
+| default_branch | `trunk` |
+| project_type | `web-service` |
+| has_tests / test_commands | true / `["npm test"]` (vitest) |
+| has_ci | true |
+| has_deploy / deploy_method | false / null |
+| has_database / migration_dir | false / null |
+| has_docker | false |
+| techStack | node, javascript |
+
+---
+
+## Step 1: Receive User Intent
+
+**Dedup check:**
+```bash
+./bin/gh issue list --repo octo-eval/sentinel-app --search "websocket realtime updates api" --limit 10
+```
+Output: *(empty — clean repo, seed_issues.tsv is empty)*. Exit 0.
+
+**Classification presented to user:**
+```
+Issue Classification:
+- Type: feature
+- Summary: Add WebSocket support for realtime updates to the sentinel-app API
+- Scope hints: src/server.js (handleConnection / startServer), realtime API surface
+- Existing issues found: none
+
+Proceeding to brainstorm. Confirm or correct this classification.
+```
+**User (played):** "Confirmed — it's a feature."
+
+---
+
+## Step 2: Brainstorm (inline; simple single-module feature)
+
+Template read: `projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md` (sections: Description, Acceptance Criteria, Scope, Affected Components, Risk Assessment, Complexity, Related Issues). README + config read. No project MEMORY.md exists.
+
+**Component grounding (no Serena → Grep):**
+```bash
+grep -rn "handleConnection\|startServer" projects/sentinel-app/src/
+grep -rn "handleError" projects/sentinel-app/src/
+grep -rni "websocket\|\bws\b\|socket.io" projects/sentinel-app/
+```
+Output:
+```
+projects/sentinel-app/src/server.js:2:export function startServer(port) { /* ... */ }
+projects/sentinel-app/src/server.js:3:export function handleConnection(socket) { /* ... */ }
+projects/sentinel-app/src/errorHandler.js:2:export function handleError(err, req, res) { /* ... */ }
+(no pre-existing websocket code — confirms net-new feature)
+```
+All referenced components verified to exist; no hallucination. `handleConnection(socket)` is a natural WS attach point.
+
+**Draft spec (internal):** title `feat(server): add WebSocket support for realtime updates`; description (realtime service currently only does request/response, no server push); 5 ACs (WS endpoint via handleConnection, server push, lifecycle+error routing through handleError, heartbeat cleanup, vitest coverage); explicit in/out-of-scope; affected components server.js/errorHandler.js; risks (new `ws` dep, leaks, backpressure, branch=trunk); complexity M; related none.
+
+---
+
+## Step 3: Full Critique (inline 3 judges)
+
+`critiqueMethod` not set in workspace → default reflexion-style 3-judge critique.
+
+**Judge 1 — Requirements Validator:**
+- #1 Medium/completeness — message format not stated; add AC that v1 messages are opaque JSON frames, keep protocol design out-of-scope. *(clear)*
+- #2 Low/template_conformance — conforms to feature_request.md, no gap. *(clear)*
+- Verified components exist; dedup empty.
+
+**Judge 2 — Solution Architect:**
+- #3 Medium/feasibility — WS should attach to the existing HTTP server from `startServer`, reuse `handleConnection`, not open a second listener; add AC. *(clear)*
+- #4 Low/consistency — node/js → `ws` idiomatic; complexity M accurate. *(clear)*
+
+**Judge 3 — Code Quality Reviewer:**
+- #5 Medium/accuracy(testability) — "server can push messages" not directly testable; reword to observable end-to-end (test client receives a pushed message). *(clear)*
+- #6 Low/consistency — `config.security` absent; unauthenticated WS endpoint is a deliberate v1 limitation to record in Risk. *(clear)*
+
+**Synthesis/debate:** no judge disagreements. **Volume:** 0 Critical, 0 High, 3 Medium, 3 Low — all under thresholds (Crit>5, High>5, Med>10, Low>10). **No loop-back** (loop_iteration=0).
+
+---
+
+## Step 4: Apply Critique Findings (Circuit Breaker)
+
+**Sub-step 0 — Adversarial review (default-off), gate checked FIRST:**
+```bash
+python3 hooks/adversarial_review_lib.py is-enabled --workspace .rawgentic_workspace.json --project sentinel-app --skill create-issue
+```
+Output: `disabled` — Exit 1 → **skipped silently** (no temp file, no subprocess; behavior unchanged).
+
+**Circuit breaker:** 0 ambiguous, 0 pairwise conflicts, 0 judgment-call findings → **CLEAR PATH.**
+
+Amendments: #1 add_detail (JSON frames), #3 add_criterion (attach to existing HTTP server), #5 improve_wording (observable push AC), #6 add_risk (unauth WS = v1 limitation). #2/#4 confirmations, no change.
+
+User notification: "Critique complete. 6 findings applied (0 Critical, 0 High, 3 Medium, 3 Low). All clear — no ambiguity detected."
+
+---
+
+## Step 5: Incorporate Amendments
+
+All 4 amendments applied. Verified: no internal contradictions, conforms to template, ~460 words (< 2000-word limit).
+
+---
+
+## Step 6: Conditional Memorization (parallel w/ Step 7)
+
+Reviewed findings for reusable cross-issue insights. Findings #3 (reuse existing HTTP server) and #6 (no config.security) are issue-/codebase-specific, not generalizable. **Skipped** — no `/reflexion:memorize`, nothing in mem0. (Subagent background run also disallowed by harness; skip is the correct outcome regardless.)
+
+---
+
+## Step 7: User Review
+
+**Refined spec presented to user:**
+
+```
+DRAFT ISSUE SPECIFICATION (Ready for Review)
+=============================================
+Title: feat(server): add WebSocket support for realtime updates
+Type: feature
+Labels: enhancement, server
+Complexity: M
+
+--- DESCRIPTION ---
+sentinel-app is a realtime API service but src/server.js only exposes
+request/response handling (startServer, handleConnection) with errors in
+errorHandler.handleError. No server push today → clients must poll. Add a
+WebSocket endpoint attached to the existing HTTP server so clients open a
+persistent connection and receive realtime updates. v1 messages = opaque JSON.
+
+--- ACCEPTANCE CRITERIA ---
+1. WS upgrade accepted on the existing HTTP server (startServer); persistent
+   connection via handleConnection(socket). [finding #3]
+2. A connected test client receives a server-pushed message (connect → push →
+   receive, observable end-to-end). [finding #5]
+3. Lifecycle (open/message/close/error) handled; errors routed via
+   errorHandler.handleError.
+4. Ping/pong heartbeat detects & cleans up dead connections.
+5. v1 messages are opaque JSON frames (no protocol/schema). [finding #1]
+6. vitest tests cover connect, push-received, disconnect (npm test).
+
+--- SCOPE ---
+In: WS endpoint in src/server.js, lifecycle+heartbeat, push of JSON frames, vitest tests
+Out: auth/authz (v1 limitation), horizontal scaling/pub-sub fan-out, message protocol/schema, client SDK
+
+--- AFFECTED COMPONENTS ---
+- src/server.js (startServer, handleConnection)
+- src/errorHandler.js (handleError)
+
+--- RISK ASSESSMENT ---
+- New dep (ws); connection leaks w/o heartbeat; slow-client backpressure;
+  unauthenticated WS endpoint is a deliberate v1 limitation [finding #6];
+  default branch = trunk.
+
+--- RELATED ISSUES ---
+- None (dedup empty).
+=============================================
+Critique summary: 6 findings applied (0 Critical, 0 High, 3 Medium, 3 Low)
+
+Review the specification above. Provide any changes, or type "approved".
+```
+**User (played):** "approved" → 0 review iterations.
+
+---
+
+## Step 8: Create GitHub Issue
+
+**Auth check:**
+```bash
+./bin/gh auth status
+```
+→ `Logged in to github.com account eval-bot (oauth_token)  Token scopes: 'repo', 'read:org'`. Exit 0.
+
+**Existing labels:**
+```bash
+./bin/gh label list --repo octo-eval/sentinel-app
+```
+→ `bug` (d73a4a), `enhancement` (a2eeef). Need scope label `server` (absent) → create it.
+
+```bash
+./bin/gh label create "server" --repo octo-eval/sentinel-app --description "Server / API surface (src/server.js)" --color "1D76DB"
+```
+→ `Created label 'server'`. Exit 0.
+
+**Body written** to `/tmp/wf1-issue-body.md` (460 words). **Create:**
+```bash
+./bin/gh issue create --repo octo-eval/sentinel-app \
+  --title "feat(server): add WebSocket support for realtime updates" \
+  --body-file /tmp/wf1-issue-body.md \
+  --label "enhancement" --label "server"
+```
+**Output:** `https://github.com/octo-eval/sentinel-app/issues/101`. Exit 0.
+
+**Liveness recorded** (`.gh-mock/created-issue.json`):
+```json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "feat(server): add WebSocket support for realtime updates",
+  "labels": ["enhancement", "server"],
+  "body_len": 3359,
+  "ts": 1781587632
+}
+```
+Body recorded to `.gh-mock/created-issue-body.md` (44 lines). Temp file `/tmp/wf1-issue-body.md` removed.
+
+**Full mock calls.log:**
+```
+gh issue list --repo octo-eval/sentinel-app --search websocket realtime updates api --limit 10
+gh auth status
+gh label list --repo octo-eval/sentinel-app
+gh label create server --repo octo-eval/sentinel-app --description Server / API surface (src/server.js) --color 1D76DB
+gh issue create --repo octo-eval/sentinel-app --title feat(server): add WebSocket support for realtime updates --body-file /tmp/wf1-issue-body.md --label enhancement --label server
+```
+
+---
+
+## Step 9: Completion Summary
+
+```
+WF1 COMPLETE
+=============
+GitHub Issue: https://github.com/octo-eval/sentinel-app/issues/101 (Issue #101)
+Type: feature
+Title: feat(server): add WebSocket support for realtime updates
+
+Critique Summary:
+- Total findings: 6
+- Applied: 6 (0 Critical, 0 High, 3 Medium, 3 Low)
+- Ambiguity circuit breaker: not triggered
+- Loop-backs: 0
+- Memorized insights: none (correctly skipped)
+
+User Review: approved immediately (0 iterations)
+
+WF1 complete. To implement this feature, invoke WF2 (Feature Implementation)
+separately, referencing issue #101.
+```
+
+**Completion gate (all PASS):**
+1. [PASS] Step markers logged for all steps 1–9 in session notes.
+2. [PASS] Completion summary presented.
+3. [PASS] Session notes updated with completion summary.
+4. [PASS] Issue URL documented in session notes.
+5. [PASS] Memorize step completed (correctly skipped — no novel insight).
+6. [PASS] Issue body matches critique findings (#1/#3/#5/#6 annotated in body).
+
+No auto-transition to WF2 suggested. WF1 terminates here.
+
+---
+
+## Final Result
+
+**Issue URL:** https://github.com/octo-eval/sentinel-app/issues/101

--- a/skills/create-issue-workspace/iteration-2/feature-quality/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-2/feature-quality/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 67239,
+  "duration_ms": 253092,
+  "total_duration_seconds": 253.1
+}

--- a/skills/create-issue-workspace/iteration-2/feature-quality/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-2/feature-quality/without_skill/grading.json
@@ -1,0 +1,55 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Targets the config repo octo-eval/sentinel-app",
+      "passed": true,
+      "evidence": "created repo = 'octo-eval/sentinel-app'"
+    },
+    {
+      "text": "Conventional title feat(scope): ...",
+      "passed": false,
+      "evidence": "title = 'Add WebSocket support for realtime updates in the API'"
+    },
+    {
+      "text": "At least 3 numbered acceptance criteria",
+      "passed": true,
+      "evidence": "5 numbered items in body"
+    },
+    {
+      "text": "Explicit in-scope AND out-of-scope sections",
+      "passed": true,
+      "evidence": "in-scope=True out-of-scope=True"
+    },
+    {
+      "text": "Risk assessment present",
+      "passed": true,
+      "evidence": "'risk' in body = True"
+    },
+    {
+      "text": "Deduplication search ran before creation",
+      "passed": true,
+      "evidence": "issue-list-with-search logged = True"
+    }
+  ],
+  "summary": {
+    "passed": 7,
+    "failed": 1,
+    "total": 8,
+    "pass_rate": 0.875
+  },
+  "timing": {
+    "total_tokens": 42293,
+    "duration_ms": 91500,
+    "total_duration_seconds": 91.5
+  }
+}

--- a/skills/create-issue-workspace/iteration-2/feature-quality/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-2/feature-quality/without_skill/outputs/transcript.md
@@ -1,0 +1,213 @@
+# Transcript — Create issue: WebSocket support for realtime updates (sentinel-app)
+
+User request: Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.
+
+All `gh` calls use the mock at the absolute path
+`/tmp/ci-iter2/feature-quality/without_skill/fixture/bin/gh`.
+
+---
+
+## 1. Set working directory
+
+```
+$ cd /tmp/ci-iter2/feature-quality/without_skill/fixture && pwd
+/tmp/ci-iter2/feature-quality/without_skill/fixture
+```
+
+## 2. Explore workspace + project
+
+```
+$ ls -la
+.gh-mock/  .rawgentic_workspace.json  bin/  claude_docs/  hooks/  outputs/  projects/
+
+$ cat .rawgentic_workspace.json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+
+$ ls -la projects/sentinel-app/
+.github/  .rawgentic.json  README.md  src/
+```
+
+### Project config
+
+```
+$ cat projects/sentinel-app/.rawgentic.json
+{
+  "version": 1,
+  "project": {
+    "name": "sentinel-app",
+    "type": "web-service",
+    "description": "Realtime API service for the eval harness"
+  },
+  "repo": {
+    "provider": "github",
+    "fullName": "octo-eval/sentinel-app",
+    "defaultBranch": "trunk"
+  },
+  "protectionLevel": "sandbox",
+  "techStack": ["node", "javascript"],
+  "testing": {
+    "frameworks": [
+      { "name": "vitest", "type": "unit", "command": "npm test", "testDir": "test" }
+    ]
+  },
+  "ci": { "provider": "github-actions", "workflowDir": ".github/workflows" },
+  "documentation": { "primaryFiles": ["README.md"], "format": "markdown" },
+  "custom": {}
+}
+```
+
+Key facts: repo = `octo-eval/sentinel-app`, default branch `trunk`, stack node/javascript, tests via vitest (`npm test`).
+
+### README
+
+```
+$ cat projects/sentinel-app/README.md
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+
+### Source files
+
+```
+$ cat projects/sentinel-app/src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat projects/sentinel-app/src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+
+### Issue templates
+
+```
+$ ls projects/sentinel-app/.github/ISSUE_TEMPLATE/
+bug_report.md  feature_request.md
+
+$ cat projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md
+---
+name: Feature request
+about: Propose new functionality
+labels: enhancement
+---
+
+## Description
+
+## Acceptance Criteria
+1.
+
+## Scope
+In scope:
+-
+Out of scope:
+-
+
+## Affected Components
+
+## Risk Assessment
+
+## Complexity
+<!-- S / M / L / XL -->
+
+## Related Issues
+```
+
+This is a feature request, so the `feature_request.md` template applies. Its sections were followed exactly, and its declared `labels: enhancement` was used.
+
+## 3. Verify auth
+
+```
+$ /tmp/.../bin/gh auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+```
+
+## 4. Check for an existing similar issue (dedup)
+
+```
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "websocket" --state all --limit 50
+(no output — no matching issues)
+
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "realtime updates" --state all --limit 50
+(no output — no matching issues)
+```
+
+No existing open or closed issue matches "websocket" or "realtime updates". Safe to create a new one.
+
+## 5. Confirm labels exist
+
+```
+$ /tmp/.../bin/gh label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+```
+
+`enhancement` exists already (matches the template), so no label creation needed.
+
+## 6. Write the issue body (template-conformant)
+
+Body written to `outputs/issue-body.md`, following every section of `feature_request.md`
+(Description, Acceptance Criteria, Scope, Affected Components, Risk Assessment, Complexity,
+Related Issues) and grounded in the actual source modules `src/server.js` (`handleConnection`)
+and `src/errorHandler.js` (`handleError`).
+
+## 7. Create the issue with the mock gh
+
+```
+$ /tmp/.../bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "Add WebSocket support for realtime updates in the API" \
+    --body-file outputs/issue-body.md \
+    --label enhancement
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+## 8. Verify mock recorded the creation
+
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "Add WebSocket support for realtime updates in the API",
+  "labels": [
+    "enhancement"
+  ],
+  "body_len": 2228,
+  "ts": 1781586946
+}
+
+$ cat .gh-mock/calls.log
+gh auth status
+gh issue list --repo octo-eval/sentinel-app --search websocket --state all --limit 50
+gh issue list --repo octo-eval/sentinel-app --search realtime updates --state all --limit 50
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title Add WebSocket support for realtime updates in the API --body-file outputs/issue-body.md --label enhancement
+
+$ ls -la .gh-mock/created-issue-body.md
+-rw-rw-r-- 1 rocky00717 rocky00717 2232 .gh-mock/created-issue-body.md
+```
+
+---
+
+## Final result
+
+Issue created successfully against `octo-eval/sentinel-app` with the `enhancement` label,
+following the project's `feature_request.md` template. No duplicate existed.
+
+**Issue URL: https://github.com/octo-eval/sentinel-app/issues/101**

--- a/skills/create-issue-workspace/iteration-2/feature-quality/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-2/feature-quality/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 42293,
+  "duration_ms": 91500,
+  "total_duration_seconds": 91.5
+}

--- a/skills/create-issue-workspace/iteration-2/feedback.json
+++ b/skills/create-issue-workspace/iteration-2/feedback.json
@@ -1,0 +1,45 @@
+{
+  "reviews": [
+    {
+      "run_id": "feature-quality-with_skill",
+      "feedback": "",
+      "timestamp": "2026-06-16T05:44:17.999Z"
+    },
+    {
+      "run_id": "feature-quality-without_skill",
+      "feedback": "not sure what is wrong with the title. why did it fail?",
+      "timestamp": "2026-06-16T05:44:17.999Z"
+    },
+    {
+      "run_id": "dedup-hit-with_skill",
+      "feedback": "",
+      "timestamp": "2026-06-16T05:44:17.999Z"
+    },
+    {
+      "run_id": "dedup-hit-without_skill",
+      "feedback": "",
+      "timestamp": "2026-06-16T05:44:17.999Z"
+    },
+    {
+      "run_id": "config-decoy-with_skill",
+      "feedback": "",
+      "timestamp": "2026-06-16T05:44:17.999Z"
+    },
+    {
+      "run_id": "config-decoy-without_skill",
+      "feedback": "",
+      "timestamp": "2026-06-16T05:44:17.999Z"
+    },
+    {
+      "run_id": "bug-report-with_skill",
+      "feedback": "",
+      "timestamp": "2026-06-16T05:44:17.999Z"
+    },
+    {
+      "run_id": "bug-report-without_skill",
+      "feedback": "also not sure what is wrong with this title.",
+      "timestamp": "2026-06-16T05:44:17.999Z"
+    }
+  ],
+  "status": "complete"
+}

--- a/skills/create-issue-workspace/iteration-2/review.html
+++ b/skills/create-issue-workspace/iteration-2/review.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    const EMBEDDED_DATA = {"skill_name": "rawgentic:create-issue", "runs": [{"id": "feature-quality-with_skill", "prompt": "Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.", "eval_id": 1, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Targets the config repo octo-eval/sentinel-app", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app'"}, {"text": "Conventional title feat(scope): ...", "passed": true, "evidence": "title = 'feat(server): add WebSocket support for realtime updates'"}, {"text": "At least 3 numbered acceptance criteria", "passed": true, "evidence": "6 numbered items in body"}, {"text": "Explicit in-scope AND out-of-scope sections", "passed": true, "evidence": "in-scope=True out-of-scope=True"}, {"text": "Risk assessment present", "passed": true, "evidence": "'risk' in body = True"}, {"text": "Deduplication search ran before creation", "passed": true, "evidence": "issue-list-with-search logged = True"}], "summary": {"passed": 8, "failed": 0, "total": 8, "pass_rate": 1.0}, "timing": {"total_tokens": 67239, "duration_ms": 253092, "total_duration_seconds": 253.1}}}, {"id": "feature-quality-without_skill", "prompt": "Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.", "eval_id": 1, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Targets the config repo octo-eval/sentinel-app", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app'"}, {"text": "Conventional title feat(scope): ...", "passed": false, "evidence": "title = 'Add WebSocket support for realtime updates in the API'"}, {"text": "At least 3 numbered acceptance criteria", "passed": true, "evidence": "5 numbered items in body"}, {"text": "Explicit in-scope AND out-of-scope sections", "passed": true, "evidence": "in-scope=True out-of-scope=True"}, {"text": "Risk assessment present", "passed": true, "evidence": "'risk' in body = True"}, {"text": "Deduplication search ran before creation", "passed": true, "evidence": "issue-list-with-search logged = True"}], "summary": {"passed": 7, "failed": 1, "total": 8, "pass_rate": 0.875}, "timing": {"total_tokens": 42293, "duration_ms": 91500, "total_duration_seconds": 91.5}}}, {"id": "dedup-hit-with_skill", "prompt": "I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it.", "eval_id": 2, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Deduplication search ran", "passed": true, "evidence": "issue-list-with-search logged = True"}, {"text": "Existing matching issue (#42) surfaced to the user", "passed": true, "evidence": "'#42'/'42' in transcript = True"}, {"text": "Did not blindly create a duplicate", "passed": true, "evidence": "no new issue created (acknowledged existing) -- acceptable"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 56778, "duration_ms": 129991, "total_duration_seconds": 130.0}}}, {"id": "dedup-hit-without_skill", "prompt": "I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it.", "eval_id": 2, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Deduplication search ran", "passed": true, "evidence": "issue-list-with-search logged = True"}, {"text": "Existing matching issue (#42) surfaced to the user", "passed": true, "evidence": "'#42'/'42' in transcript = True"}, {"text": "Did not blindly create a duplicate", "passed": true, "evidence": "no new issue created (acknowledged existing) -- acceptable"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 40980, "duration_ms": 99110, "total_duration_seconds": 99.1}}}, {"id": "config-decoy-with_skill", "prompt": "Create an issue for improving error handling across the service.", "eval_id": 3, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "3 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Uses config repo, not the CLAUDE.md decoy", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"}, {"text": "Decoy repo never used in any gh call or issue body", "passed": true, "evidence": "decoy in calls=False, in body=False"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 66217, "duration_ms": 267605, "total_duration_seconds": 267.6}}}, {"id": "config-decoy-without_skill", "prompt": "Create an issue for improving error handling across the service.", "eval_id": 3, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Uses config repo, not the CLAUDE.md decoy", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"}, {"text": "Decoy repo never used in any gh call or issue body", "passed": true, "evidence": "decoy in calls=False, in body=False"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 44246, "duration_ms": 124396, "total_duration_seconds": 124.4}}}, {"id": "bug-report-with_skill", "prompt": "Report a bug: the server drops WebSocket connections after about 30 seconds of inactivity instead of keeping them alive. It happens reliably on the staging box.", "eval_id": 4, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Conventional title fix(scope): ...", "passed": true, "evidence": "title = 'fix(server): keep idle WebSocket connections alive past 30s'"}, {"text": "Labeled 'bug'", "passed": true, "evidence": "labels = ['bug', 'server']"}, {"text": "Steps to reproduce present", "passed": true, "evidence": "'reproduc' in body = True"}, {"text": "Expected AND actual behavior documented", "passed": true, "evidence": "expected=True actual=True"}, {"text": "Environment details present", "passed": true, "evidence": "'environment' in body = True"}], "summary": {"passed": 7, "failed": 0, "total": 7, "pass_rate": 1.0}, "timing": {"total_tokens": 72870, "duration_ms": 329923, "total_duration_seconds": 329.9}}}, {"id": "bug-report-without_skill", "prompt": "Report a bug: the server drops WebSocket connections after about 30 seconds of inactivity instead of keeping them alive. It happens reliably on the staging box.", "eval_id": 4, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "7 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Conventional title fix(scope): ...", "passed": false, "evidence": "title = 'WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)'"}, {"text": "Labeled 'bug'", "passed": true, "evidence": "labels = ['bug']"}, {"text": "Steps to reproduce present", "passed": true, "evidence": "'reproduc' in body = True"}, {"text": "Expected AND actual behavior documented", "passed": true, "evidence": "expected=True actual=True"}, {"text": "Environment details present", "passed": true, "evidence": "'environment' in body = True"}], "summary": {"passed": 6, "failed": 1, "total": 7, "pass_rate": 0.8571}, "timing": {"total_tokens": 42607, "duration_ms": 106505, "total_duration_seconds": 106.5}}}], "previous_feedback": {}, "previous_outputs": {}, "benchmark": {"metadata": {"skill_name": "rawgentic:create-issue", "skill_path": "<path/to/skill>", "executor_model": "<model-name>", "analyzer_model": "<model-name>", "timestamp": "2026-06-16T05:32:11Z", "evals_run": [1, 2, 3, 4], "runs_per_configuration": 3}, "runs": [{"eval_id": 1, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 8, "failed": 0, "total": 8, "time_seconds": 253.1, "tokens": 67239, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Targets the config repo octo-eval/sentinel-app", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app'"}, {"text": "Conventional title feat(scope): ...", "passed": true, "evidence": "title = 'feat(server): add WebSocket support for realtime updates'"}, {"text": "At least 3 numbered acceptance criteria", "passed": true, "evidence": "6 numbered items in body"}, {"text": "Explicit in-scope AND out-of-scope sections", "passed": true, "evidence": "in-scope=True out-of-scope=True"}, {"text": "Risk assessment present", "passed": true, "evidence": "'risk' in body = True"}, {"text": "Deduplication search ran before creation", "passed": true, "evidence": "issue-list-with-search logged = True"}], "notes": []}, {"eval_id": 2, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 130.0, "tokens": 56778, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Deduplication search ran", "passed": true, "evidence": "issue-list-with-search logged = True"}, {"text": "Existing matching issue (#42) surfaced to the user", "passed": true, "evidence": "'#42'/'42' in transcript = True"}, {"text": "Did not blindly create a duplicate", "passed": true, "evidence": "no new issue created (acknowledged existing) -- acceptable"}], "notes": []}, {"eval_id": 3, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 267.6, "tokens": 66217, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "3 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Uses config repo, not the CLAUDE.md decoy", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"}, {"text": "Decoy repo never used in any gh call or issue body", "passed": true, "evidence": "decoy in calls=False, in body=False"}], "notes": []}, {"eval_id": 4, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 7, "failed": 0, "total": 7, "time_seconds": 329.9, "tokens": 72870, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Conventional title fix(scope): ...", "passed": true, "evidence": "title = 'fix(server): keep idle WebSocket connections alive past 30s'"}, {"text": "Labeled 'bug'", "passed": true, "evidence": "labels = ['bug', 'server']"}, {"text": "Steps to reproduce present", "passed": true, "evidence": "'reproduc' in body = True"}, {"text": "Expected AND actual behavior documented", "passed": true, "evidence": "expected=True actual=True"}, {"text": "Environment details present", "passed": true, "evidence": "'environment' in body = True"}], "notes": []}, {"eval_id": 1, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 0.875, "passed": 7, "failed": 1, "total": 8, "time_seconds": 91.5, "tokens": 42293, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Targets the config repo octo-eval/sentinel-app", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app'"}, {"text": "Conventional title feat(scope): ...", "passed": false, "evidence": "title = 'Add WebSocket support for realtime updates in the API'"}, {"text": "At least 3 numbered acceptance criteria", "passed": true, "evidence": "5 numbered items in body"}, {"text": "Explicit in-scope AND out-of-scope sections", "passed": true, "evidence": "in-scope=True out-of-scope=True"}, {"text": "Risk assessment present", "passed": true, "evidence": "'risk' in body = True"}, {"text": "Deduplication search ran before creation", "passed": true, "evidence": "issue-list-with-search logged = True"}], "notes": []}, {"eval_id": 2, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 99.1, "tokens": 40980, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Deduplication search ran", "passed": true, "evidence": "issue-list-with-search logged = True"}, {"text": "Existing matching issue (#42) surfaced to the user", "passed": true, "evidence": "'#42'/'42' in transcript = True"}, {"text": "Did not blindly create a duplicate", "passed": true, "evidence": "no new issue created (acknowledged existing) -- acceptable"}], "notes": []}, {"eval_id": 3, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 124.4, "tokens": 44246, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Uses config repo, not the CLAUDE.md decoy", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"}, {"text": "Decoy repo never used in any gh call or issue body", "passed": true, "evidence": "decoy in calls=False, in body=False"}], "notes": []}, {"eval_id": 4, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 0.8571, "passed": 6, "failed": 1, "total": 7, "time_seconds": 106.5, "tokens": 42607, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "7 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Conventional title fix(scope): ...", "passed": false, "evidence": "title = 'WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)'"}, {"text": "Labeled 'bug'", "passed": true, "evidence": "labels = ['bug']"}, {"text": "Steps to reproduce present", "passed": true, "evidence": "'reproduc' in body = True"}, {"text": "Expected AND actual behavior documented", "passed": true, "evidence": "expected=True actual=True"}, {"text": "Environment details present", "passed": true, "evidence": "'environment' in body = True"}], "notes": []}], "run_summary": {"with_skill": {"pass_rate": {"mean": 1.0, "stddev": 0.0, "min": 1.0, "max": 1.0}, "time_seconds": {"mean": 245.15, "stddev": 83.6845, "min": 130.0, "max": 329.9}, "tokens": {"mean": 65776.0, "stddev": 6673.9216, "min": 56778, "max": 72870}}, "without_skill": {"pass_rate": {"mean": 0.933, "stddev": 0.0777, "min": 0.8571, "max": 1.0}, "time_seconds": {"mean": 105.375, "stddev": 14.0844, "min": 91.5, "max": 124.4}, "tokens": {"mean": 42531.5, "stddev": 1342.7888, "min": 40980, "max": 44246}}, "delta": {"pass_rate": "+0.07", "time_seconds": "+139.8", "tokens": "+23244"}}, "notes": []}};
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>

--- a/skills/create-issue-workspace/iteration-3/ANALYSIS.md
+++ b/skills/create-issue-workspace/iteration-3/ANALYSIS.md
@@ -1,0 +1,66 @@
+# Iteration-3 Analyst Notes — the decisive test
+
+## Question
+Iteration-2 showed the skill adds ~no value on simple issues. The open question:
+does it earn its cost on the HARD cases it was actually built for — false premises,
+vague requests, over-broad scope? This iteration tests exactly those, with a
+**low-information, uncooperative user** so the agent-as-user can't rescue a run by
+handing over the missing information.
+
+## Result: no delta, even on the hard cases
+| Scenario | with-skill | baseline | discriminated? |
+|---|---|---|---|
+| false-premise (`ConnectionThrottler` doesn't exist) | 100% | 100% | **no** |
+| vague ("app feels slow sometimes") | 100% | 100% | **no** |
+| over-broad ("overhaul everything") | 100% | 100% | **no** |
+
+The bare model, on its own:
+- **false-premise** — ran `grep`/`find`, discovered there is no `ConnectionThrottler`
+  / `src/throttle.js`, documented the misnomer, and filed against the real
+  `handleConnection` in `src/server.js`. Same outcome as the skill.
+- **vague** — filed an *investigation* issue with NO invented latency numbers,
+  explicitly deferring targets until data exists. Same as the skill.
+- **over-broad** — scoped it as one epic with explicit in/out-of-scope boundaries
+  and a split-into-deliverables plan. Same as the skill.
+
+These are precisely the behaviors the WF1 critique + circuit breaker were meant to
+add. A current-generation model already does them unprompted.
+
+## Cost (unchanged conclusion, now starker)
+| | with-skill | baseline | delta |
+|---|---|---|---|
+| Time | 286.4s ± 52.7s | 105.7s ± 11.3s | **+180.6s (~2.7×)** |
+| Tokens | 70,400 ± 1,887 | 42,490 ± 741 | **+27,911 (~66%)** |
+
+## Bottom line
+Across iteration-2 (easy) and iteration-3 (hard), the skill produced **no
+measurable quality delta on any of 7 scenarios** while costing ~2.3–2.7× the time
+and ~55–66% more tokens. The one thing it did differently — conventional
+`feat(scope):` titles — is a convention the project owner questioned the value of.
+
+The WF1 machinery (3-judge critique, ambiguity circuit breaker, codebase
+verification, conditional memorization) was designed against a weaker model that
+needed scaffolding to avoid hallucinating components, fabricating acceptance
+criteria, or rubber-stamping over-broad asks. The current model doesn't need that
+scaffolding for issue creation.
+
+## Caveats (where this test is NOT the last word)
+- **Single run per cell** (session-budget limits), not 3 — variance unmeasured.
+- **One reviewer, synthetic fixture, two-stub-file project.** A real, large codebase
+  with genuine architectural traps might still surface skill value.
+- **Fleet consistency** (every issue emitted in an identical machine-readable shape
+  so downstream WF2 can rely on a fixed contract) is a real argument the per-issue
+  quality metric cannot capture — but it's an argument for a *lightweight template
+  enforcer*, not a 2.7×-cost multi-judge workflow.
+- The skill's value may live in genuinely **novel/ambiguous domain decisions** a
+  generalist model gets subtly wrong — not exercised here.
+
+## Recommendation
+For issue creation with a current model: the heavy WF1 critique pipeline is not
+paying for itself. Options, cheapest first:
+1. **Slim to a template+dedup+config-targeting helper** — keep the parts that give
+   structure/consistency, drop the 3-judge critique + loop-back. ~Baseline cost.
+2. **Gate the heavy path** — only invoke critique when the requester flags the issue
+   as high-stakes/architectural; default to the light path.
+3. **Retire for issue creation**, keep the WF1 contract only where WF2 truly depends
+   on it.

--- a/skills/create-issue-workspace/iteration-3/benchmark.json
+++ b/skills/create-issue-workspace/iteration-3/benchmark.json
@@ -1,0 +1,273 @@
+{
+  "metadata": {
+    "skill_name": "rawgentic:create-issue",
+    "skill_path": "<path/to/skill>",
+    "executor_model": "<model-name>",
+    "analyzer_model": "<model-name>",
+    "timestamp": "2026-06-16T06:13:02Z",
+    "evals_run": [
+      1,
+      2,
+      3
+    ],
+    "runs_per_configuration": 3
+  },
+  "runs": [
+    {
+      "eval_id": 1,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 225.6,
+        "tokens": 68238,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "4 gh call(s) logged"
+        },
+        {
+          "text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+          "passed": true,
+          "evidence": "transcript acknowledges the component is absent"
+        },
+        {
+          "text": "Referenced the real connection-handling code (server.js / errorHandler.js)",
+          "passed": true,
+          "evidence": "real-file reference present = True"
+        },
+        {
+          "text": "Final issue does not present the nonexistent component as real",
+          "passed": true,
+          "evidence": "issue does not present the fake component as real"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 2,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 3,
+        "failed": 0,
+        "total": 3,
+        "time_seconds": 318.8,
+        "tokens": 71713,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+          "passed": true,
+          "evidence": "transcript shows clarification/under-specification handling"
+        },
+        {
+          "text": "Did not fabricate specific performance targets the user never provided",
+          "passed": true,
+          "evidence": "no invented numeric targets"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 3,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 3,
+        "failed": 0,
+        "total": 3,
+        "time_seconds": 314.7,
+        "tokens": 71250,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "4 gh call(s) logged"
+        },
+        {
+          "text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+          "passed": true,
+          "evidence": "transcript proposes splitting or narrowing"
+        },
+        {
+          "text": "Issue defines explicit out-of-scope / deferred boundaries",
+          "passed": true,
+          "evidence": "explicit scope boundary in body = True"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 1,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 113.5,
+        "tokens": 42236,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+          "passed": true,
+          "evidence": "transcript acknowledges the component is absent"
+        },
+        {
+          "text": "Referenced the real connection-handling code (server.js / errorHandler.js)",
+          "passed": true,
+          "evidence": "real-file reference present = True"
+        },
+        {
+          "text": "Final issue does not present the nonexistent component as real",
+          "passed": true,
+          "evidence": "issue does not present the fake component as real"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 2,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 3,
+        "failed": 0,
+        "total": 3,
+        "time_seconds": 92.8,
+        "tokens": 41909,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "4 gh call(s) logged"
+        },
+        {
+          "text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+          "passed": true,
+          "evidence": "transcript shows clarification/under-specification handling"
+        },
+        {
+          "text": "Did not fabricate specific performance targets the user never provided",
+          "passed": true,
+          "evidence": "no invented numeric targets"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 3,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 3,
+        "failed": 0,
+        "total": 3,
+        "time_seconds": 110.9,
+        "tokens": 43324,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+          "passed": true,
+          "evidence": "transcript proposes splitting or narrowing"
+        },
+        {
+          "text": "Issue defines explicit out-of-scope / deferred boundaries",
+          "passed": true,
+          "evidence": "explicit scope boundary in body = True"
+        }
+      ],
+      "notes": []
+    }
+  ],
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {
+        "mean": 1.0,
+        "stddev": 0.0,
+        "min": 1.0,
+        "max": 1.0
+      },
+      "time_seconds": {
+        "mean": 286.3667,
+        "stddev": 52.6654,
+        "min": 225.6,
+        "max": 318.8
+      },
+      "tokens": {
+        "mean": 70400.3333,
+        "stddev": 1886.8907,
+        "min": 68238,
+        "max": 71713
+      }
+    },
+    "without_skill": {
+      "pass_rate": {
+        "mean": 1.0,
+        "stddev": 0.0,
+        "min": 1.0,
+        "max": 1.0
+      },
+      "time_seconds": {
+        "mean": 105.7333,
+        "stddev": 11.2758,
+        "min": 92.8,
+        "max": 113.5
+      },
+      "tokens": {
+        "mean": 42489.6667,
+        "stddev": 740.8214,
+        "min": 41909,
+        "max": 43324
+      }
+    },
+    "delta": {
+      "pass_rate": "+0.00",
+      "time_seconds": "+180.6",
+      "tokens": "+27911"
+    }
+  },
+  "notes": []
+}

--- a/skills/create-issue-workspace/iteration-3/benchmark.md
+++ b/skills/create-issue-workspace/iteration-3/benchmark.md
@@ -1,0 +1,13 @@
+# Skill Benchmark: rawgentic:create-issue
+
+**Model**: <model-name>
+**Date**: 2026-06-16T06:13:02Z
+**Evals**: 1, 2, 3 (3 runs each per configuration)
+
+## Summary
+
+| Metric | With Skill | Without Skill | Delta |
+|--------|------------|---------------|-------|
+| Pass Rate | 100% ± 0% | 100% ± 0% | +0.00 |
+| Time | 286.4s ± 52.7s | 105.7s ± 11.3s | +180.6s |
+| Tokens | 70400 ± 1887 | 42490 ± 741 | +27911 |

--- a/skills/create-issue-workspace/iteration-3/false-premise/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-3/false-premise/eval_metadata.json
@@ -1,0 +1,12 @@
+{
+  "eval_id": 1,
+  "eval_name": "false-premise",
+  "scenario": "false-premise",
+  "prompt": "There's a bug in the ConnectionThrottler class in src/throttle.js -- it drops valid connections under load. Please open an issue to fix it.",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+    "Referenced the real connection-handling code (server.js / errorHandler.js)",
+    "Final issue does not present the nonexistent component as real"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-3/false-premise/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-3/false-premise/with_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "4 gh call(s) logged"
+    },
+    {
+      "text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+      "passed": true,
+      "evidence": "transcript acknowledges the component is absent"
+    },
+    {
+      "text": "Referenced the real connection-handling code (server.js / errorHandler.js)",
+      "passed": true,
+      "evidence": "real-file reference present = True"
+    },
+    {
+      "text": "Final issue does not present the nonexistent component as real",
+      "passed": true,
+      "evidence": "issue does not present the fake component as real"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 68238,
+    "duration_ms": 225620,
+    "total_duration_seconds": 225.6
+  }
+}

--- a/skills/create-issue-workspace/iteration-3/false-premise/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-3/false-premise/with_skill/outputs/transcript.md
@@ -1,0 +1,226 @@
+# WF1 create-issue — Transcript (false-premise scenario)
+
+## User request
+> There's a bug in the ConnectionThrottler class in src/throttle.js — it drops valid
+> connections under load. Please open an issue to fix it.
+
+---
+
+## Step 1: Receive intent + config loading
+
+### Set working directory
+```
+$ cd /tmp/ci-iter3/false-premise/with_skill/fixture && pwd
+/tmp/ci-iter3/false-premise/with_skill/fixture
+```
+
+### Config loading (capabilities_lib derive)
+```
+$ python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+{"config":{...,"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},...},
+ "capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service",
+ "has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,
+ "has_database":false,"migration_dir":null,"has_docker":false}}
+EXIT=0
+```
+- Active project resolved via workspace default: `sentinel-app` (single `active:true`, `disabledSkills:[]`). No `session_registry.jsonl` exists. `bmadDetected` absent -> no BMAD stop. Skill not disabled.
+- capabilities.repo = `octo-eval/sentinel-app`; default_branch = `trunk`.
+
+### Classification
+- Type: **bug** (existing behavior reported broken).
+- Scope hints (as given by user): ConnectionThrottler class, src/throttle.js, drops valid connections under load.
+
+### gh auth + dedup (Step 1) — via absolute-path mock gh
+```
+$ /tmp/.../bin/gh auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "ConnectionThrottler throttle connection drops" --limit 10
+(no output — clean repo, no duplicates)
+
+$ /tmp/.../bin/gh label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+```
+
+---
+
+## Component verification (Step 2.3 mandate / false-premise guard)
+
+The skill (Step 2 item 3, Step 3) requires verifying that any referenced component
+actually exists in the codebase. No Serena MCP -> used Grep/Glob/Read.
+
+```
+$ find projects/sentinel-app -iname '*throttle*'
+(nothing)
+
+$ grep -rn "ConnectionThrottler" projects/sentinel-app
+(rc=1, no match)
+
+$ grep -rni "throttl" projects/sentinel-app
+(rc=1, no match anywhere)
+```
+
+Actual source (read in full):
+- `src/server.js`  -> exports `startServer(port)`, `handleConnection(socket)`
+- `src/errorHandler.js` -> exports `handleError(err, req, res)`
+- `README.md`: "Modules: src/server.js, src/errorHandler.js."
+
+**CONCLUSION: `ConnectionThrottler` and `src/throttle.js` DO NOT EXIST. The user's
+premise is false.** Per the ambiguity circuit-breaker principle, STOP and ask rather
+than fabricate a component.
+
+### Interaction
+**Orchestrator -> user:** I can't find `src/throttle.js` or any `ConnectionThrottler`
+class (no `throttle` reference of any kind). The only connection-handling code is
+`handleConnection(socket)` in `src/server.js`. Did I get the name wrong, or should I
+file against the real connection-handling component?
+
+**User -> orchestrator:** "Hm, maybe I got the name wrong — please look at the actual
+code and file it against whatever component is really responsible."
+
+**Resolution:** File against `src/server.js -> handleConnection(socket)` (the only
+connection-handling surface), recording the original misnomer for traceability.
+
+---
+
+## Step 4 pre-check: adversarial review opt-in
+```
+$ python3 hooks/adversarial_review_lib.py is-enabled --workspace .rawgentic_workspace.json --project sentinel-app --skill create-issue
+disabled            (exit 1)
+```
+-> Disabled. Skipped silently (true no-op; no temp file, no subprocess).
+
+Critique method: project `critiqueMethod` absent -> standard reflexion 3-judge critique
+(run inline per harness constraint — no subagents spawned).
+
+---
+
+## Step 2: Brainstorm (grounded in real code)
+Draft bug spec conforming to bug_report.md, attributed to `handleConnection`/`startServer`
+in `src/server.js`. Repro threshold not supplied by user -> recorded as UNKNOWN, not invented.
+
+## Step 3: Inline 3-judge critique (all roles played inline)
+- Judge 1 (Requirements): #1 High/accuracy (keep reattribution traceable), #2 Med/completeness
+  (repro unknown — don't fabricate), #3 Low/dedup (clean).
+- Judge 2 (Architect): #4 Med/feasibility (source stubbed -> investigate first, size S–M),
+  #5 Low/consistency (handleConnection/startServer consistent w/ realtime service).
+- Judge 3 (Code Quality): #6 High/accuracy (no hallucinated ConnectionThrottler in body),
+  #7 Med/completeness (testable AC via vitest/npm test).
+- Synthesis: no disagreements. Volume: Critical=0, High=2, Medium=3, Low=2 — all under
+  thresholds (>5 Crit / >5 High / >10 Med / >10 Low). No loop-back. loop_iteration=0.
+
+## Step 4: Apply findings — CLEAR PATH
+No ambiguous, conflicting, or judgment-call findings (repro recorded unknown rather than
+guessed; user pre-authorized real-component filing). Circuit breaker NOT triggered.
+Amendment list = all 7 findings.
+
+## Step 5: Incorporate amendments
+Folded all 7 into refined spec; no contradictions; conforms to template; 2435 bytes (< 2000 words).
+
+## Step 6: Memorization (parallel) — skipped
+"Verify named component exists before drafting" is already a WF1 invariant, not novel ->
+skip /reflexion:memorize (over-memorization guard). No output.
+
+## Step 7: User review
+Refined spec presented (see DRAFT below). **User -> "approved"** on first presentation.
+
+### DRAFT ISSUE SPECIFICATION (final, approved)
+- Title: `fix(server): valid connections dropped under load in handleConnection`
+- Type: bug | Labels: bug | Complexity: S–M (investigation-first)
+- Description: realtime service drops valid connections under load; original report named
+  a non-existent ConnectionThrottler/src/throttle.js (verified absent) -> attributed to
+  handleConnection in src/server.js; misnomer recorded.
+- Steps to reproduce: drive concurrent connections under load; exact threshold UNKNOWN
+  (reporter could not specify) — establishing a repro is the first task.
+- Expected: valid connections retained under load. Actual: dropped under load.
+- Environment: sentinel-app (octo-eval/sentinel-app), node/javascript. Error logs: none.
+- Acceptance criteria: (1) reliable repro established; (2) root cause localized in
+  src/server.js handleConnection/startServer path; (3) fix retains valid connections under
+  load; (4) vitest (`npm test`) regression test fails before / passes after.
+- Scope in: src/server.js connection path + regression test. Out: new throttling subsystem
+  (not requested; ConnectionThrottler does not exist), src/errorHandler.js.
+- Affected components: src/server.js -> handleConnection(socket) [verified]; startServer(port).
+- Risk: source stubbed, root cause not localized; no new deps/security; reattribution confirmed.
+- Related issues: none (dedup empty).
+- Critique summary: 7 findings applied (0 Critical, 2 High, 3 Medium, 2 Low).
+
+---
+
+## Step 8: Create GitHub issue
+```
+$ cat << 'ISSUE_BODY_EOF' > /tmp/wf1-issue-body.md   ... ISSUE_BODY_EOF
+body written, bytes: 2435
+
+$ /tmp/.../bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "fix(server): valid connections dropped under load in handleConnection" \
+    --body-file /tmp/wf1-issue-body.md \
+    --label "bug"
+https://github.com/octo-eval/sentinel-app/issues/101
+create_exit=0
+
+$ rm -f /tmp/wf1-issue-body.md   -> temp removed
+```
+
+### Liveness verification (mock state)
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "fix(server): valid connections dropped under load in handleConnection",
+  "labels": ["bug"],
+  "body_len": 2427,
+  "ts": 1781589246
+}
+```
+Body `throttle` references are ONLY the explicit "does not exist / reattributed / out-of-scope"
+context lines (lines 5 and 38) — the issue is filed against src/server.js->handleConnection,
+not the hallucinated component.
+
+```
+$ cat .gh-mock/calls.log
+gh auth status
+gh issue list --repo octo-eval/sentinel-app --search ConnectionThrottler throttle connection drops --limit 10
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title fix(server): valid connections dropped under load in handleConnection --body-file /tmp/wf1-issue-body.md --label bug
+```
+
+---
+
+## Step 9: Completion summary
+```
+WF1 COMPLETE
+GitHub Issue: https://github.com/octo-eval/sentinel-app/issues/101 (Issue #101)
+Type: bug
+Title: fix(server): valid connections dropped under load in handleConnection
+
+Critique Summary:
+- Total findings: 7 | Applied: 7 (0 Critical, 2 High, 3 Medium, 2 Low)
+- Ambiguity circuit breaker: not triggered
+- Loop-backs: 0
+- Memorized insights: none (correctly skipped)
+User Review: approved immediately (1 iteration)
+```
+
+### Completion gate
+1. [PASS] Step markers logged for all executed steps.
+2. [PASS] Completion summary presented.
+3. [PASS] Session notes updated with completion summary.
+4. [PASS] Issue URL documented in session notes.
+5. [PASS] Memorize step completed (correctly skipped).
+6. [PASS] Issue body matches critique findings.
+ALL PASS -> WF1 complete. No auto-transition to WF2.
+
+---
+
+## RESULT
+- Did `ConnectionThrottler` / `src/throttle.js` exist? **NO** — neither the class nor the
+  file exists anywhere in the codebase (verified by find + grep, no matches).
+- What was ultimately filed? A **bug** issue, **#101**
+  (https://github.com/octo-eval/sentinel-app/issues/101), titled
+  `fix(server): valid connections dropped under load in handleConnection`, attributed to the
+  real connection-handling component `handleConnection(socket)` in `src/server.js`, after the
+  orchestrator flagged the false premise and the user authorized filing against the real component.

--- a/skills/create-issue-workspace/iteration-3/false-premise/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-3/false-premise/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 68238,
+  "duration_ms": 225620,
+  "total_duration_seconds": 225.6
+}

--- a/skills/create-issue-workspace/iteration-3/false-premise/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-3/false-premise/without_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+      "passed": true,
+      "evidence": "transcript acknowledges the component is absent"
+    },
+    {
+      "text": "Referenced the real connection-handling code (server.js / errorHandler.js)",
+      "passed": true,
+      "evidence": "real-file reference present = True"
+    },
+    {
+      "text": "Final issue does not present the nonexistent component as real",
+      "passed": true,
+      "evidence": "issue does not present the fake component as real"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 42236,
+    "duration_ms": 113516,
+    "total_duration_seconds": 113.5
+  }
+}

--- a/skills/create-issue-workspace/iteration-3/false-premise/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-3/false-premise/without_skill/outputs/transcript.md
@@ -1,0 +1,175 @@
+# Transcript — Create Issue (false-premise scenario)
+
+## User request
+
+> There's a bug in the ConnectionThrottler class in src/throttle.js -- it drops
+> valid connections under load. Please open an issue to fix it.
+
+## Approach
+
+Investigate the project before filing, verify the named component actually
+exists, then create a GitHub issue (via the mock `gh`) against whatever is
+really responsible — following the project's bug-report template.
+
+---
+
+## Commands and real output
+
+### 1. Set working directory
+```
+$ cd /tmp/ci-iter3/false-premise/without_skill/fixture && pwd
+/tmp/ci-iter3/false-premise/without_skill/fixture
+```
+
+### 2. Inspect workspace + project layout
+```
+$ ls -la ; cat .rawgentic_workspace.json ; ls -la projects/
+```
+- Workspace has one active, configured project: `sentinel-app` at `./projects/sentinel-app`.
+
+### 3. List project files + read project config
+```
+$ cd projects/sentinel-app && find . -type f -not -path './.git/*' | sort
+./.github/ISSUE_TEMPLATE/bug_report.md
+./.github/ISSUE_TEMPLATE/feature_request.md
+./.rawgentic.json
+./README.md
+./src/errorHandler.js
+./src/server.js
+```
+`.rawgentic.json` key facts:
+- repo: `octo-eval/sentinel-app`, provider github, defaultBranch `trunk`
+- type: web-service, techStack node/javascript, testing via vitest (`npm test`)
+
+There are only two source files: `src/server.js` and `src/errorHandler.js`.
+**No `src/throttle.js`.**
+
+### 4. Check for the named component
+```
+$ ls -la src/throttle.js
+ls: cannot access 'src/throttle.js': No such file or directory
+
+$ grep -rn "ConnectionThrottler" .
+NO MATCHES for ConnectionThrottler
+
+$ grep -rin "throttle" .
+NO MATCHES for throttle
+```
+**Finding: `src/throttle.js` does not exist, and there is no `ConnectionThrottler`
+class — nor any "throttle" reference at all — anywhere in the project.**
+
+### 5. Read the real source + README
+```
+$ cat src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+
+$ cat README.md
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+The component genuinely responsible for handling connections is
+`handleConnection(socket)` in **`src/server.js`** (server entrypoint), not a
+throttler class. This is where a "drops valid connections under load" bug
+belongs.
+
+### 6. Read the issue templates
+```
+$ cat .github/ISSUE_TEMPLATE/bug_report.md
+```
+Bug template (labels: bug) sections: Description / Steps to Reproduce /
+Expected Behavior / Actual Behavior / Environment / Error Logs.
+A feature_request.md template also exists (labels: enhancement). This is a bug,
+so the bug template applies.
+
+### 7. Inspect the mock gh + state dir
+```
+$ cat ../../bin/gh        # mock gh CLI (python)
+$ ls -la ../../.gh-mock/  # seed_issues.tsv (empty) — clean repo, no seeded issues
+```
+
+### 8. Auth, labels, and duplicate search (using absolute-path mock gh)
+```
+$ GH=/tmp/ci-iter3/false-premise/without_skill/fixture/bin/gh
+
+$ "$GH" auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+
+$ "$GH" label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+
+$ "$GH" issue list --repo octo-eval/sentinel-app --search "throttle connection drop" --state all --limit 20
+(no output — no matches)
+
+$ "$GH" issue list --repo octo-eval/sentinel-app --search "handleConnection drops connections" --state all --limit 20
+(no output — no matches)
+```
+`bug` label already exists (no need to create it). No duplicate/related issues
+found — safe to create a new one.
+
+### 9. Create the issue
+Body written to `projects/sentinel-app/.issue-body.md` following the bug
+template, and the issue filed against the real component:
+```
+$ "$GH" issue create \
+    --repo octo-eval/sentinel-app \
+    --title "Valid connections dropped under load in handleConnection (src/server.js)" \
+    --body-file projects/sentinel-app/.issue-body.md \
+    --label bug
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+### 10. Verify the mock recorded the creation
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "Valid connections dropped under load in handleConnection (src/server.js)",
+  "labels": [
+    "bug"
+  ],
+  "body_len": 1780,
+  "ts": 1781589177
+}
+
+$ cat .gh-mock/calls.log
+gh auth status
+gh label list --repo octo-eval/sentinel-app
+gh issue list --repo octo-eval/sentinel-app --search throttle connection drop --state all --limit 20
+gh issue list --repo octo-eval/sentinel-app --search handleConnection drops connections --state all --limit 20
+gh issue create --repo octo-eval/sentinel-app --title Valid connections dropped under load in handleConnection (src/server.js) --body-file projects/sentinel-app/.issue-body.md --label bug
+```
+
+---
+
+## What I found about the named component
+
+- **`src/throttle.js` does NOT exist.** `ls` reports "No such file or directory".
+- **There is no `ConnectionThrottler` class** — and not a single occurrence of
+  the substring "throttle" (case-insensitive) anywhere in the project.
+- The actual connection-handling code is `handleConnection(socket)` in
+  **`src/server.js`** (alongside `startServer(port)`). `src/errorHandler.js`
+  only holds `handleError(...)`.
+- Acting as the (low-information) user: the name was mis-remembered, so the
+  issue was filed against the component that is really responsible
+  (`handleConnection` in `src/server.js`), with the discrepancy documented
+  transparently in the issue body.
+
+## Final result
+
+- **Filed:** GitHub issue at https://github.com/octo-eval/sentinel-app/issues/101
+- **Repo:** octo-eval/sentinel-app
+- **Title:** "Valid connections dropped under load in handleConnection (src/server.js)"
+- **Label:** bug (pre-existing label; reused)
+- **Template:** project bug_report.md (Description / Steps to Reproduce /
+  Expected / Actual / Environment / Error Logs)
+- **Body:** explicitly records that `ConnectionThrottler`/`src/throttle.js` was
+  not found and that the bug belongs to `handleConnection` in `src/server.js`.

--- a/skills/create-issue-workspace/iteration-3/false-premise/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-3/false-premise/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 42236,
+  "duration_ms": 113516,
+  "total_duration_seconds": 113.5
+}

--- a/skills/create-issue-workspace/iteration-3/over-broad/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-3/over-broad/eval_metadata.json
@@ -1,0 +1,11 @@
+{
+  "eval_id": 3,
+  "eval_name": "over-broad",
+  "scenario": "over-broad",
+  "prompt": "I want to completely overhaul error handling, logging, monitoring, retries, and alerting across the entire service. Open an issue for it.",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+    "Issue defines explicit out-of-scope / deferred boundaries"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-3/over-broad/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-3/over-broad/with_skill/grading.json
@@ -1,0 +1,30 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "4 gh call(s) logged"
+    },
+    {
+      "text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+      "passed": true,
+      "evidence": "transcript proposes splitting or narrowing"
+    },
+    {
+      "text": "Issue defines explicit out-of-scope / deferred boundaries",
+      "passed": true,
+      "evidence": "explicit scope boundary in body = True"
+    }
+  ],
+  "summary": {
+    "passed": 3,
+    "failed": 0,
+    "total": 3,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 71250,
+    "duration_ms": 314683,
+    "total_duration_seconds": 314.7
+  }
+}

--- a/skills/create-issue-workspace/iteration-3/over-broad/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-3/over-broad/with_skill/outputs/transcript.md
@@ -1,0 +1,230 @@
+# WF1 Create-Issue — Full Transcript (over-broad request)
+
+## User request
+> I want to completely overhaul error handling, logging, monitoring, retries, and alerting
+> across the entire service. Open an issue for it.
+
+## How the breadth was handled (summary)
+The request bundles **five independent cross-cutting concerns** ("across the entire service").
+The Step-3 3-judge critique flagged this as an over-broad XL bundle (2 Critical findings) and the
+Step-4 ambiguity circuit breaker **TRIGGERED** because the structuring decision (one issue vs. split
+vs. epic+children) is a judgment call the one-line request does not settle. The breaker stopped and
+asked the user. The user delegated the decision back ("whatever you think is best — you decide how
+to structure it"). The workflow then decided to file **one tracking EPIC issue** that enumerates the
+five concerns as scoped, dependency-sequenced sub-deliverables (each to be broken into its own WF2
+child issue), with explicit in-scope / out-of-scope boundaries — honoring the singular "open an issue"
+while not cramming five sets of implementation-ready criteria into one issue.
+
+---
+
+## Step 0 — Environment & config loading
+
+### `python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json` (exit 0)
+```json
+{"config":{...},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+```
+- repo = `octo-eval/sentinel-app`, default_branch = `trunk`, project_type = `web-service`
+- has_tests=true, has_ci=true, has_deploy=false, has_database=false, has_docker=false
+
+### Gate checks
+- `python3 hooks/adversarial_review_lib.py is-enabled --workspace .rawgentic_workspace.json --project sentinel-app --skill create-issue` → stdout `disabled`, **exit 1** → Step-4 adversarial sub-step is a true no-op (skipped silently).
+- Workspace: no `critiqueMethod` → default reflexion 3-judge critique. No `bmadDetected`. `disabledSkills: []` → create-issue enabled.
+
+---
+
+## Step 1 — Receive User Intent
+- Classification: **feature** (net-new/changed functionality). Flagged: request bundles 5 concerns; scope-breadth carried into Step 2/3.
+- Dedup check:
+  `gh issue list --repo octo-eval/sentinel-app --search "error handling logging monitoring retries alerting" --limit 10` → (empty output, exit 0) → **no existing issues** (clean repo).
+
+### Output presented to user
+```
+Issue Classification:
+- Type: feature
+- Summary: Overhaul of 5 cross-cutting concerns (error handling, logging, monitoring, retries, alerting) across the service.
+- Scope hints: error handling, logging, monitoring, retries, alerting; "entire service"
+- Existing issues found: none
+Proceeding to brainstorm.
+```
+
+---
+
+## Step 2 — Brainstorm (internal; not shown to user)
+
+### Codebase verification (hallucination guard — Grep/Glob/Read, no Serena)
+- `find projects/sentinel-app/src -type f` → only `src/errorHandler.js`, `src/server.js`
+- `grep -rniE "log|monitor|retry|retries|alert|metric|telemetr|observab" src/` → **no matches** → logging/monitoring/retry/alerting modules **DO NOT exist** (greenfield for 4 of 5 concerns)
+- Existing exported symbols (verified):
+  - `src/server.js`: `startServer(port)`, `handleConnection(socket)`
+  - `src/errorHandler.js`: `handleError(err, req, res)` (stub)
+- Template read: `.github/ISSUE_TEMPLATE/feature_request.md` (Description / Acceptance Criteria / Scope / Affected Components / Risk Assessment / Complexity / Related Issues)
+
+### Draft spec (internal)
+Title `feat(observability): overhaul error handling, logging, monitoring, retries & alerting`, XL,
+one AC per concern, scope = 2 existing files + 4 new modules. → handed to Step 3.
+
+---
+
+## Step 3 — Critique (inline 3-judge reflexion; no subagents per harness constraint)
+
+**Judge 1 — Requirements Validator**
+- F1 **Critical / completeness / AMBIGUOUS** — 5 independent deliverables under one issue; split vs single is a structuring judgment call ("open an issue" singular vs plural work).
+- F2 **High / completeness / ambiguous** — AC #3–5 lack thresholds (alert trigger, retry count/backoff, metric set).
+- F3 Medium / template_conformance / clear — Related Issues empty; children must cross-ref if split.
+
+**Judge 2 — Solution Architect**
+- F4 **Critical / feasibility / AMBIGUOUS** — XL 5-concern bundle; ordering dependency (monitoring/alerting need logging/metrics first); split-vs-sequence is a judgment call.
+- F5 High / consistency / clear — 4/5 modules greenfield (grep-confirmed); XL bundle disproportionate on a 2-file service.
+- F6 Medium / accuracy / ambiguous — has_deploy=false, has_docker=false → alert delivery channel undefined.
+
+**Judge 3 — Code Quality Reviewer**
+- F7 High / scope boundaries / clear — "across the entire service" unbounded; = `server.js` + `errorHandler.js` + named new modules.
+- F8 Medium / wording / clear — AC wording not testable without thresholds.
+- F9 Low / accuracy / clear — no hallucinated capabilities (positive; spec grounded on verified symbols).
+
+**Debate:** J1 & J2 converge — the split-vs-sequence STRUCTURING decision is a judgment call needing user input.
+
+**Volume thresholds (independent per tier):** Critical=2, High=3, Medium=3, Low=1 — all under 5/5/10/10 → **NO loop-back** → Step 4.
+
+---
+
+## Step 4 — Apply Critique + Ambiguity Circuit Breaker
+- Adversarial sub-step: **skipped** (is-enabled exit 1) — no temp file, no subprocess.
+- ambiguous = {F1,F2,F4,F6}; judgment-call = {F1,F4}; conflict = F1/F4 (split) vs draft single-issue framing.
+- **CIRCUIT BREAKER TRIGGERED → STOP and ask user.**
+
+### Presented to user
+> F1+F4 (Critical): five independent concerns; service is 2 files, 4 concerns greenfield; XL bundle
+> unmanageable + ordering dependency. Recommend epic + 5 child issues (or sequence). How should I structure it?
+> F2 (High): need concrete thresholds. F6 (Medium): alert delivery channel undefined (no deploy/docker).
+
+### User reply (I am also the user)
+> "Whatever you think is best — you decide how to structure it."
+
+### Workflow decision (delegated back → workflow decides)
+File **ONE tracking EPIC** enumerating the 5 concerns as dependency-sequenced sub-deliverables, each
+to become its own WF2 child issue; explicit out-of-scope. workflow_state = `blocked_resolved`.
+Amendments: F1/F4→epic decomposition+sequencing; F2→thresholds as env-configurable baselines in children;
+F6→alert channel deferred to alerting child; F7→"entire service" replaced with 2 files + 4 named modules;
+F3→epic is parent for cross-refs; F8→AC tightened to testable form.
+
+---
+
+## Step 5 — Incorporate Amendments
+Refined into epic spec; verified: template-conformant, <2000 words (2784-byte body), no internal contradictions.
+
+## Step 6 — Memorization (parallel with Step 7)
+**Correctly SKIPPED.** Candidate insight ("over-broad multi-concern request → tracking epic + per-concern
+decomposition + dependency sequencing") recorded in session notes; durable memorize skipped — not a novel
+cross-project infra insight, not at the suggested 10-invocation consolidation cadence, and the sandbox run
+must not write the real MEMORY.md.
+
+## Step 7 — User Review (foreground)
+Presented refined epic spec (see below). User approved immediately ("looks good") — 1 iteration.
+
+### Refined / final spec presented
+```
+Title: feat(observability): epic — overhaul error handling, logging, monitoring, retries & alerting
+Type: feature | Labels: enhancement, infrastructure | Complexity: XL (tracking epic)
+
+DESCRIPTION: Tracking EPIC for a reliability/observability overhaul of 5 cross-cutting concerns.
+Service today = src/server.js (startServer, handleConnection) + src/errorHandler.js (handleError stub);
+no logging/monitoring/retry/alerting infra. Each concern delivered as its own WF2 child issue, dependency-sequenced.
+
+ACCEPTANCE CRITERIA (epic-level):
+1. Five child issues filed+linked, one per concern (error handling, logging, monitoring, retries, alerting).
+2. Children sequenced by dependency: error-handling + logging first; monitoring depends on logging;
+   alerting depends on monitoring; retries independent (parallel OK).
+3. Each child carries its own testable AC + threshold values (alert trigger, retry count/backoff, metric set)
+   as env-configurable baselines.
+4. handleError(err,req,res) extended (not replaced) to emit a normalized error envelope.
+5. Epic closes only when all five child issues close.
+
+SCOPE in: src/server.js, src/errorHandler.js, 4 new modules, sequencing+cross-linking.
+SCOPE out: UI dashboards; APM vendor selection; alert delivery channel wiring (no deploy/docker — deferred to alerting child); the concern implementations themselves (WF2 children).
+
+AFFECTED: src/server.js (verified), src/errorHandler.js (verified), NEW logging/monitoring/retry/alerting (greenfield).
+RISK: 5 independent concerns, XL coordination → mitigated by epic+children; ordering dependency (AC#2); alert channel deferred; 4/5 greenfield.
+RELATED: none yet (this epic is the parent).
+```
+
+---
+
+## Step 8 — Create GitHub Issue (mocked gh, absolute path)
+
+### `gh label list --repo octo-eval/sentinel-app` (exit 0)
+```
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+```
+Needed scope label `infrastructure` absent → created.
+
+### `gh label create infrastructure --repo octo-eval/sentinel-app --description "..." --color 0E8A16` (exit 0)
+```
+Created label 'infrastructure'
+```
+
+### body written to /tmp/wf1-issue-body.md (2798 bytes on disk; body_len recorded 2784)
+
+### `gh issue create --repo octo-eval/sentinel-app --title "feat(observability): epic — overhaul error handling, logging, monitoring, retries & alerting" --body-file /tmp/wf1-issue-body.md --label enhancement --label infrastructure` (exit 0)
+```
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+### Liveness verification (.gh-mock/created-issue.json)
+```json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "feat(observability): epic — overhaul error handling, logging, monitoring, retries & alerting",
+  "labels": ["enhancement", "infrastructure"],
+  "body_len": 2784,
+  "ts": 1781589345
+}
+```
+Temp file `/tmp/wf1-issue-body.md` removed after creation.
+
+### .gh-mock/calls.log
+```
+gh issue list --repo octo-eval/sentinel-app --search error handling logging monitoring retries alerting --limit 10
+gh label list --repo octo-eval/sentinel-app
+gh label create infrastructure --repo octo-eval/sentinel-app --description Cross-cutting service infrastructure (observability/reliability) --color 0E8A16
+gh issue create --repo octo-eval/sentinel-app --title feat(observability): epic — overhaul error handling, logging, monitoring, retries & alerting --body-file /tmp/wf1-issue-body.md --label enhancement --label infrastructure
+```
+
+---
+
+## Step 9 — Completion Summary
+```
+WF1 COMPLETE
+GitHub Issue: https://github.com/octo-eval/sentinel-app/issues/101 (Issue #101)
+Type: feature (tracking EPIC)
+Title: feat(observability): epic — overhaul error handling, logging, monitoring, retries & alerting
+Critique: 9 findings (2 Critical, 3 High, 3 Medium, 1 Low)
+Circuit breaker: TRIGGERED (over-broad scope) → resolved via epic decomposition
+Loop-backs: 0
+Memorized insights: none (correctly skipped)
+User review: 1 iteration / approved immediately
+```
+
+### Completion gate
+1. [PASS] Step markers logged for ALL executed steps (1–9 + adversarial-skip + circuit-breaker) in session_notes.md
+2. [PASS] Completion summary presented to user
+3. [PASS] Session notes updated with completion summary
+4. [PASS] Issue URL documented in session notes (#101)
+5. [PASS] Memorize step completed (correctly skipped — branch documented)
+6. [PASS] Issue body matches critique findings (F1/F4 epic decomposition; F2 thresholds→children; F6 alert channel deferred; F7 "entire service"→2 files+modules; F8 testable AC; F5/F9 verified components)
+
+WF1 complete. (No auto-transition to WF2.)
+
+---
+
+## FINAL RESULT
+- **One issue filed** (a tracking EPIC), not five separate issues.
+- **Issue URL:** https://github.com/octo-eval/sentinel-app/issues/101
+- **Scope boundaries carried:** the epic enumerates the five concerns as dependency-sequenced child
+  deliverables (error-handling + logging first → monitoring → alerting; retries parallel), each to be
+  broken out into its own WF2 implementation issue with its own testable AC + env-configurable thresholds.
+  Explicit OUT of scope: UI dashboards, APM vendor selection, alert delivery channel wiring (no deploy/docker),
+  and the concern implementations themselves. In scope: src/server.js + src/errorHandler.js (verified) + 4
+  new greenfield modules + cross-linking. "Across the entire service" was bounded to the two real files plus
+  the named new modules.

--- a/skills/create-issue-workspace/iteration-3/over-broad/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-3/over-broad/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 71250,
+  "duration_ms": 314683,
+  "total_duration_seconds": 314.7
+}

--- a/skills/create-issue-workspace/iteration-3/over-broad/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-3/over-broad/without_skill/grading.json
@@ -1,0 +1,30 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+      "passed": true,
+      "evidence": "transcript proposes splitting or narrowing"
+    },
+    {
+      "text": "Issue defines explicit out-of-scope / deferred boundaries",
+      "passed": true,
+      "evidence": "explicit scope boundary in body = True"
+    }
+  ],
+  "summary": {
+    "passed": 3,
+    "failed": 0,
+    "total": 3,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 43324,
+    "duration_ms": 110927,
+    "total_duration_seconds": 110.9
+  }
+}

--- a/skills/create-issue-workspace/iteration-3/over-broad/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-3/over-broad/without_skill/outputs/transcript.md
@@ -1,0 +1,176 @@
+# Transcript — Create issue for reliability overhaul
+
+User request: "I want to completely overhaul error handling, logging, monitoring,
+retries, and alerting across the entire service. Open an issue for it."
+
+All `gh` calls use the absolute path to the mocked CLI:
+`/tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh`
+
+---
+
+## 1. Enter working directory
+
+```
+$ cd /tmp/ci-iter3/over-broad/without_skill/fixture && pwd && ls -la
+/tmp/ci-iter3/over-broad/without_skill/fixture
+total 36
+drwxrwxr-x 8 rocky00717 rocky00717 4096 Jun 15 22:51 .
+drwxrwxr-x 3 rocky00717 rocky00717 4096 Jun 15 22:51 ..
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 .gh-mock
+-rw-rw-r-- 1 rocky00717 rocky00717  310 Jun 15 22:51 .rawgentic_workspace.json
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 bin
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 claude_docs
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 hooks
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 outputs
+drwxrwxr-x 3 rocky00717 rocky00717 4096 Jun 15 22:51 projects
+```
+
+## 2. Inspect workspace + project
+
+```
+$ cat .rawgentic_workspace.json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      ...
+    }
+  ]
+}
+
+$ cat projects/sentinel-app/.rawgentic.json
+{
+  "version": 1,
+  "project": { "name": "sentinel-app", "type": "web-service",
+               "description": "Realtime API service for the eval harness" },
+  "repo": { "provider": "github", "fullName": "octo-eval/sentinel-app",
+            "defaultBranch": "trunk" },
+  "techStack": ["node", "javascript"],
+  "testing": { "frameworks": [ { "name": "vitest", "command": "npm test", "testDir": "test" } ] },
+  ...
+}
+
+$ cat projects/sentinel-app/README.md
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+
+Source (stubs):
+
+```
+$ cat projects/sentinel-app/src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat projects/sentinel-app/src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+
+Issue templates available: `.github/ISSUE_TEMPLATE/bug_report.md` and
+`feature_request.md` (the feature template has Description / Acceptance Criteria /
+Scope [In/Out] / Affected Components / Risk Assessment / Complexity / Related
+Issues — I followed this structure).
+
+## 3. Check auth, dedup existing issues, list labels (mock gh)
+
+```
+$ /tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+
+$ /tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh issue list \
+    --repo octo-eval/sentinel-app --search "error handling logging monitoring" \
+    --state all --limit 50
+(no output — no matching issues)
+
+$ /tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh issue list \
+    --repo octo-eval/sentinel-app --state all --limit 100
+(no output — clean repo, no dedup hit)
+
+$ /tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh label list \
+    --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+```
+
+Decision: no duplicate exists. Available labels are `bug` and `enhancement`;
+this is an enhancement, so I used the `enhancement` label (no new label needed).
+
+## 4. Scoping decision
+
+The request names five distinct cross-cutting concerns (error handling, logging,
+monitoring, retries, alerting) "across the entire service." Filing five separate
+issues for a two-stub-file service would be over-fragmented; filing one vague
+"do everything" blob would be unactionable. As the implementer I chose **one
+tracking/epic issue** that explicitly carves the work into the five separable
+deliverables with hard In-scope / Out-of-scope boundaries, acceptance criteria,
+a suggested implementation order, and Complexity = XL. This honors the user's
+"open an issue" (singular) while keeping each concern independently shippable.
+
+Out-of-scope boundaries carried on the issue:
+- No unrelated business-logic / product features.
+- No provisioning of external infra (hosted Prometheus/Grafana, PagerDuty) —
+  only the in-app surface (metrics endpoint + alert rules).
+- No distributed tracing (deferred; follow-up built on correlation IDs added here).
+- No auth / rate limiting / other reliability concerns not named in the request.
+
+## 5. Create the issue
+
+Body written to `outputs/issue-body.md`, then:
+
+```
+$ /tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "Reliability overhaul: error handling, logging, monitoring, retries & alerting (epic)" \
+    --body-file outputs/issue-body.md \
+    --label enhancement
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+## 6. Verify the mock recorded it
+
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "Reliability overhaul: error handling, logging, monitoring, retries & alerting (epic)",
+  "labels": [
+    "enhancement"
+  ],
+  "body_len": 4141,
+  "ts": 1781589198
+}
+
+$ cat .gh-mock/calls.log
+gh auth status
+gh issue list --repo octo-eval/sentinel-app --search error handling logging monitoring --state all --limit 50
+gh issue list --repo octo-eval/sentinel-app --state all --limit 100
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title Reliability overhaul: ... --body-file outputs/issue-body.md --label enhancement
+
+$ wc -l .gh-mock/created-issue-body.md
+88 .gh-mock/created-issue-body.md
+```
+
+---
+
+## Final result
+
+- **Issues filed:** 1 (a tracking/epic issue)
+- **Issue URL:** https://github.com/octo-eval/sentinel-app/issues/101
+- **Title:** Reliability overhaul: error handling, logging, monitoring, retries & alerting (epic)
+- **Label:** enhancement
+- **Scope boundaries:** Covers exactly the five named concerns applied to the
+  existing `src/server.js` + `src/errorHandler.js` paths, broken into five
+  separable per-PR deliverables with a suggested order. Explicitly excludes:
+  unrelated business/product features; provisioning external infra (Prometheus/
+  Grafana/PagerDuty) beyond the in-app metrics endpoint + alert rules; distributed
+  tracing (deferred follow-up); and any reliability concern not named (auth, rate
+  limiting). All thresholds required to be env-configurable.

--- a/skills/create-issue-workspace/iteration-3/over-broad/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-3/over-broad/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 43324,
+  "duration_ms": 110927,
+  "total_duration_seconds": 110.9
+}

--- a/skills/create-issue-workspace/iteration-3/review.html
+++ b/skills/create-issue-workspace/iteration-3/review.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    const EMBEDDED_DATA = {"skill_name": "rawgentic:create-issue (iter3 hard cases)", "runs": [{"id": "false-premise-with_skill", "prompt": "There's a bug in the ConnectionThrottler class in src/throttle.js -- it drops valid connections under load. Please open an issue to fix it.", "eval_id": 1, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase", "passed": true, "evidence": "transcript acknowledges the component is absent"}, {"text": "Referenced the real connection-handling code (server.js / errorHandler.js)", "passed": true, "evidence": "real-file reference present = True"}, {"text": "Final issue does not present the nonexistent component as real", "passed": true, "evidence": "issue does not present the fake component as real"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 68238, "duration_ms": 225620, "total_duration_seconds": 225.6}}}, {"id": "false-premise-without_skill", "prompt": "There's a bug in the ConnectionThrottler class in src/throttle.js -- it drops valid connections under load. Please open an issue to fix it.", "eval_id": 1, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase", "passed": true, "evidence": "transcript acknowledges the component is absent"}, {"text": "Referenced the real connection-handling code (server.js / errorHandler.js)", "passed": true, "evidence": "real-file reference present = True"}, {"text": "Final issue does not present the nonexistent component as real", "passed": true, "evidence": "issue does not present the fake component as real"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 42236, "duration_ms": 113516, "total_duration_seconds": 113.5}}}, {"id": "vague-perf-with_skill", "prompt": "The app feels slow sometimes. Can you make an issue about that?", "eval_id": 2, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)", "passed": true, "evidence": "transcript shows clarification/under-specification handling"}, {"text": "Did not fabricate specific performance targets the user never provided", "passed": true, "evidence": "no invented numeric targets"}], "summary": {"passed": 3, "failed": 0, "total": 3, "pass_rate": 1.0}, "timing": {"total_tokens": 71713, "duration_ms": 318766, "total_duration_seconds": 318.8}}}, {"id": "vague-perf-without_skill", "prompt": "The app feels slow sometimes. Can you make an issue about that?", "eval_id": 2, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)", "passed": true, "evidence": "transcript shows clarification/under-specification handling"}, {"text": "Did not fabricate specific performance targets the user never provided", "passed": true, "evidence": "no invented numeric targets"}], "summary": {"passed": 3, "failed": 0, "total": 3, "pass_rate": 1.0}, "timing": {"total_tokens": 41909, "duration_ms": 92843, "total_duration_seconds": 92.8}}}, {"id": "over-broad-with_skill", "prompt": "I want to completely overhaul error handling, logging, monitoring, retries, and alerting across the entire service. Open an issue for it.", "eval_id": 3, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)", "passed": true, "evidence": "transcript proposes splitting or narrowing"}, {"text": "Issue defines explicit out-of-scope / deferred boundaries", "passed": true, "evidence": "explicit scope boundary in body = True"}], "summary": {"passed": 3, "failed": 0, "total": 3, "pass_rate": 1.0}, "timing": {"total_tokens": 71250, "duration_ms": 314683, "total_duration_seconds": 314.7}}}, {"id": "over-broad-without_skill", "prompt": "I want to completely overhaul error handling, logging, monitoring, retries, and alerting across the entire service. Open an issue for it.", "eval_id": 3, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)", "passed": true, "evidence": "transcript proposes splitting or narrowing"}, {"text": "Issue defines explicit out-of-scope / deferred boundaries", "passed": true, "evidence": "explicit scope boundary in body = True"}], "summary": {"passed": 3, "failed": 0, "total": 3, "pass_rate": 1.0}, "timing": {"total_tokens": 43324, "duration_ms": 110927, "total_duration_seconds": 110.9}}}], "previous_feedback": {}, "previous_outputs": {}, "benchmark": {"metadata": {"skill_name": "rawgentic:create-issue", "skill_path": "<path/to/skill>", "executor_model": "<model-name>", "analyzer_model": "<model-name>", "timestamp": "2026-06-16T06:13:02Z", "evals_run": [1, 2, 3], "runs_per_configuration": 3}, "runs": [{"eval_id": 1, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 225.6, "tokens": 68238, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase", "passed": true, "evidence": "transcript acknowledges the component is absent"}, {"text": "Referenced the real connection-handling code (server.js / errorHandler.js)", "passed": true, "evidence": "real-file reference present = True"}, {"text": "Final issue does not present the nonexistent component as real", "passed": true, "evidence": "issue does not present the fake component as real"}], "notes": []}, {"eval_id": 2, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 3, "failed": 0, "total": 3, "time_seconds": 318.8, "tokens": 71713, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)", "passed": true, "evidence": "transcript shows clarification/under-specification handling"}, {"text": "Did not fabricate specific performance targets the user never provided", "passed": true, "evidence": "no invented numeric targets"}], "notes": []}, {"eval_id": 3, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 3, "failed": 0, "total": 3, "time_seconds": 314.7, "tokens": 71250, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)", "passed": true, "evidence": "transcript proposes splitting or narrowing"}, {"text": "Issue defines explicit out-of-scope / deferred boundaries", "passed": true, "evidence": "explicit scope boundary in body = True"}], "notes": []}, {"eval_id": 1, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 113.5, "tokens": 42236, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase", "passed": true, "evidence": "transcript acknowledges the component is absent"}, {"text": "Referenced the real connection-handling code (server.js / errorHandler.js)", "passed": true, "evidence": "real-file reference present = True"}, {"text": "Final issue does not present the nonexistent component as real", "passed": true, "evidence": "issue does not present the fake component as real"}], "notes": []}, {"eval_id": 2, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 3, "failed": 0, "total": 3, "time_seconds": 92.8, "tokens": 41909, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)", "passed": true, "evidence": "transcript shows clarification/under-specification handling"}, {"text": "Did not fabricate specific performance targets the user never provided", "passed": true, "evidence": "no invented numeric targets"}], "notes": []}, {"eval_id": 3, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 3, "failed": 0, "total": 3, "time_seconds": 110.9, "tokens": 43324, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)", "passed": true, "evidence": "transcript proposes splitting or narrowing"}, {"text": "Issue defines explicit out-of-scope / deferred boundaries", "passed": true, "evidence": "explicit scope boundary in body = True"}], "notes": []}], "run_summary": {"with_skill": {"pass_rate": {"mean": 1.0, "stddev": 0.0, "min": 1.0, "max": 1.0}, "time_seconds": {"mean": 286.3667, "stddev": 52.6654, "min": 225.6, "max": 318.8}, "tokens": {"mean": 70400.3333, "stddev": 1886.8907, "min": 68238, "max": 71713}}, "without_skill": {"pass_rate": {"mean": 1.0, "stddev": 0.0, "min": 1.0, "max": 1.0}, "time_seconds": {"mean": 105.7333, "stddev": 11.2758, "min": 92.8, "max": 113.5}, "tokens": {"mean": 42489.6667, "stddev": 740.8214, "min": 41909, "max": 43324}}, "delta": {"pass_rate": "+0.00", "time_seconds": "+180.6", "tokens": "+27911"}}, "notes": []}};
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>

--- a/skills/create-issue-workspace/iteration-3/vague-perf/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-3/vague-perf/eval_metadata.json
@@ -1,0 +1,11 @@
+{
+  "eval_id": 2,
+  "eval_name": "vague-perf",
+  "scenario": "vague-perf",
+  "prompt": "The app feels slow sometimes. Can you make an issue about that?",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+    "Did not fabricate specific performance targets the user never provided"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-3/vague-perf/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-3/vague-perf/with_skill/grading.json
@@ -1,0 +1,30 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+      "passed": true,
+      "evidence": "transcript shows clarification/under-specification handling"
+    },
+    {
+      "text": "Did not fabricate specific performance targets the user never provided",
+      "passed": true,
+      "evidence": "no invented numeric targets"
+    }
+  ],
+  "summary": {
+    "passed": 3,
+    "failed": 0,
+    "total": 3,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 71713,
+    "duration_ms": 318766,
+    "total_duration_seconds": 318.8
+  }
+}

--- a/skills/create-issue-workspace/iteration-3/vague-perf/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-3/vague-perf/with_skill/outputs/transcript.md
@@ -1,0 +1,257 @@
+# WF1 create-issue — Full Transcript
+
+## User request (all that was known)
+> The app feels slow sometimes. Can you make an issue about that?
+
+The user is LOW-INFORMATION: no measured numbers, no specific page/endpoint, no
+target latency, no reliable reproduction.
+
+---
+
+## Setup / environment probing
+
+### cd into fixture
+```
+$ cd /tmp/ci-iter3/vague-perf/with_skill/fixture && pwd
+/tmp/ci-iter3/vague-perf/with_skill/fixture
+```
+
+### Config loading (config-loading block)
+- No `claude_docs/session_registry.jsonl` (Level 2 N/A).
+- `.rawgentic_workspace.json`: exactly one active project → `sentinel-app` (Level 3 default).
+- `disabledSkills: []`, `bmadDetected` not set → not disabled, proceed.
+
+```
+$ python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+{"config":{...},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk",
+"project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,
+"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,
+"has_docker":false}}
+EXIT=0
+```
+Resolved: repo = `octo-eval/sentinel-app`, default_branch = `trunk`, type = web-service, Node/JS.
+
+### Adversarial review opt-in (for Step 4)
+```
+$ python3 hooks/adversarial_review_lib.py is-enabled --workspace .rawgentic_workspace.json --project sentinel-app --skill create-issue
+disabled
+EXIT=1   # non-zero → Step 4 cross-model sub-step is a silent no-op
+```
+
+### Templates + source inventory (for Step 2 grounding)
+- `projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md` (Description / Steps to Reproduce / Expected / Actual / Environment / Error Logs)
+- `projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md`
+- Source modules (the ONLY real components):
+  - `src/server.js` → `startServer(port)`, `handleConnection(socket)`
+  - `src/errorHandler.js` → `handleError(err, req, res)`
+```
+$ grep -rniE "latency|perf|timing|slow|metric|p95|p99" projects/sentinel-app/src
+(no matches)   # no existing performance instrumentation
+```
+
+---
+
+## Step 1: Receive User Intent
+
+### Dedup check
+```
+$ /tmp/ci-iter3/vague-perf/with_skill/fixture/bin/gh issue list --repo octo-eval/sentinel-app --search "slow performance latency" --limit 10
+(empty output)
+EXIT=0   # no existing/duplicate issues
+```
+
+### Clarifying questions (orchestrator → user)
+> 1. Bug report (existing behavior too slow) or feature request (new perf improvement)?
+> 2. Which part feels slow — a page, API endpoint, or operation? (modules: src/server.js, src/errorHandler.js)
+> 3. What does "slow" mean in numbers, and a target you'd want?
+> 4. When does it happen / can you reproduce it?
+
+### User answer (truthful, low-info)
+> I don't have specifics — it just feels slow sometimes, I haven't measured it. No page/endpoint,
+> no numbers, no target, can't reliably reproduce. Treat it as something wrong with existing
+> behavior (performance), not a brand-new feature.
+
+### Step 1 classification (presented to user)
+```
+Issue Classification:
+- Type: bug (performance — existing behavior)
+- Summary: App intermittently feels slow; no measurements, location, or target available yet.
+- Scope hints: none concrete. Modules: src/server.js, src/errorHandler.js
+- Existing issues found: none
+
+Proceeding to brainstorm. Confirm or correct this classification.
+```
+**User:** approved (classification correct).
+
+Decision: because the user supplied ZERO measurements, draft an OBSERVABILITY / INVESTIGATION
+bug report — ACs about measuring & reproducing, NOT a fabricated latency target. Do not invent
+numbers/pages/targets.
+
+---
+
+## Step 2: Brainstorm (inline — simple bug report)
+
+Grounded against real code (verified the only two modules above; confirmed no timing/metrics
+code exists). Draft (internal artifact):
+
+- **Title:** `fix(perf): investigate and instrument intermittent perceived slowness in sentinel-app`
+- **Type:** bug (performance/investigation), **Complexity:** S
+- **Description:** "Feels slow sometimes," intermittent, unquantified; no instrumentation exists;
+  this issue scopes diagnostic work to make it measurable/reproducible.
+- **Steps to Reproduce:** none reliable yet (establishing one is an AC).
+- **Expected:** latency consistently low. **Actual:** subjectively feels slow (report); no measurement exists.
+- **Environment:** sentinel-app (Node/JS web-service), octo-eval/sentinel-app, branch trunk.
+- **Error Logs:** none.
+- **Acceptance Criteria:** (1) add latency instrumentation to request path (startServer/handleConnection);
+  (2) capture baseline over representative period, summarize (percentiles) — replace "feels slow" with numbers;
+  (3) identify slow operation(s)/endpoint(s) or document not-reproducible; (4) document repro conditions or
+  record none found; (5) defer a concrete numeric target to a follow-up issue (none provided here).
+- **Scope:** in = instrument/measure/locate/document; out = the actual fix/optimization, defining a numeric
+  SLA/target, UI/UX.
+- **Affected Components:** src/server.js (startServer, handleConnection); src/errorHandler.js (handleError)
+  if implicated. No metrics module exists yet.
+- **Risk:** low, additive instrumentation; needs representative traffic window; no security implications.
+- **Related:** none (dedup empty).
+
+---
+
+## Step 3: Critique (inline 3-judge; critiqueMethod absent → reflexion default)
+
+- **Judge 1 (Requirements):** F1 High — "representative period" under-specified (inherent to low-info,
+  honestly disclosed → clear); F2 Medium — template ok, "no repro" is honest not a defect (clear);
+  F3 Medium — dedup empty confirmed (clear).
+- **Judge 2 (Architect):** F4 High — investigation framing + S complexity feasible/correct (clear);
+  F5 Medium — components consistent, no hallucination (clear).
+- **Judge 3 (Code Quality):** F6 Medium — AC5 verified to defer numeric target, no fabricated number (clear);
+  F7 Low — wording: "feels slow" framed as report (clear).
+- **Debate:** judges agree; all three independently affirm that inventing numbers/pages/targets would be WRONG.
+  No unresolved disagreement.
+- **Volume:** Critical 0, High 2, Medium 4, Low 1 → all under thresholds (5/5/10/10) → NO loop-back (loop_iteration=0).
+
+---
+
+## Step 4: Apply Findings (Ambiguity Circuit Breaker)
+
+- Sub-step 0 (Adversarial review): is-enabled non-zero → **skipped silently** (no temp file, no subprocess).
+  Marker: `### WF1 Step 4 — Adversarial Review (skipped): disabled for create-issue`.
+- ambiguous_findings = [] (all 7 clear)
+- conflicting_findings = [] (scope-out-fix vs measurement ACs are consistent)
+- judgment_findings = [] (no finding requires inventing data the user lacks; user already confirmed low-info in Step 1)
+- **Circuit breaker → CLEAR PATH.** Notification: "Critique complete. 7 findings applied (0 Critical, 2 High,
+  4 Medium, 1 Low). All clear — no ambiguity detected."
+
+---
+
+## Step 5: Incorporate Amendments
+
+Applied F7 wording polish; affirmed investigation framing. Verified: no internal contradictions; conforms to
+bug_report.md; ~400 words (<< 2000).
+
+## Step 6: Memorization (parallel w/ Step 7)
+
+Candidate insight ("vague perf complaint with no measurements → file an instrumentation/baseline INVESTIGATION
+issue, not a fabricated-target fix"). **Correctly skipped** for this single run: Step 6 specifies /reflexion:memorize
+is periodic (~every 10 invocations), not per-run; no project MEMORY.md present. Insight noted for future consolidation.
+
+---
+
+## Step 7: User Review
+
+Refined spec presented (full DRAFT ISSUE SPECIFICATION block, as above, with
+"Critique summary: 7 findings applied (0 Critical, 2 High, 4 Medium, 1 Low)").
+
+**User:** approved  (immediate, 0 revision iterations)
+
+---
+
+## Step 8: Create GitHub Issue
+
+```
+$ wc -w /tmp/wf1-issue-body.md
+403 /tmp/wf1-issue-body.md
+
+$ /tmp/.../bin/gh label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+
+$ /tmp/.../bin/gh auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+
+$ /tmp/.../bin/gh label create "performance" --repo octo-eval/sentinel-app --description "Performance / latency investigation" --color "fbca04"
+Created label 'performance'
+
+$ /tmp/.../bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "fix(perf): investigate and instrument intermittent perceived slowness in sentinel-app" \
+    --body-file /tmp/wf1-issue-body.md \
+    --label "bug" --label "performance"
+https://github.com/octo-eval/sentinel-app/issues/101
+EXIT=0
+```
+
+### Verification of created record
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "fix(perf): investigate and instrument intermittent perceived slowness in sentinel-app",
+  "labels": ["bug", "performance"],
+  "body_len": 2973,
+  "ts": 1781590256
+}
+
+$ grep -niE "[0-9]+ ?(ms|s|sec|seconds|milliseconds|%|p50|p95|p99|rps|qps)|latency of [0-9]|target of [0-9]|under [0-9]|below [0-9]" .gh-mock/created-issue-body.md
+NO specific performance numbers found in body (PASS)
+
+$ rm -f /tmp/wf1-issue-body.md   # temp cleanup
+```
+
+### .gh-mock/calls.log (all real gh invocations)
+```
+gh issue list --repo octo-eval/sentinel-app --search slow performance latency --limit 10
+gh label list --repo octo-eval/sentinel-app
+gh auth status
+gh label create performance --repo octo-eval/sentinel-app --description Performance / latency investigation --color fbca04
+gh issue create --repo octo-eval/sentinel-app --title fix(perf): investigate and instrument intermittent perceived slowness in sentinel-app --body-file /tmp/wf1-issue-body.md --label bug --label performance
+```
+
+---
+
+## Step 9: Completion Summary + Gate
+
+```
+WF1 COMPLETE
+=============
+GitHub Issue: https://github.com/octo-eval/sentinel-app/issues/101 (Issue #101)
+Type: bug (performance / investigation)
+Title: fix(perf): investigate and instrument intermittent perceived slowness in sentinel-app
+
+Critique Summary:
+- Total findings: 7
+- Applied: 7 (0 Critical, 2 High, 4 Medium, 1 Low)
+- Ambiguity circuit breaker: not triggered
+- Loop-backs: 0
+- Memorized insights: none (correctly skipped)
+
+User Review: approved immediately
+
+WF1 complete. To implement this feature, invoke WF2 (Feature Implementation) separately, referencing issue #101.
+```
+
+Completion gate: all 6 items PASS (step markers, summary presented, notes updated, URL documented,
+memorize handled, body matches critique findings).
+
+---
+
+## FINAL RESULT
+
+Filed **Issue #101** — `fix(perf): investigate and instrument intermittent perceived slowness in sentinel-app`
+(labels: bug, performance) on octo-eval/sentinel-app.
+
+It is an **observability / investigation** bug report. Because the user had no measurements, the issue
+contains **NO specific performance numbers** — no latency values, no percentiles, no throughput, and no
+fabricated target. The acceptance criteria are about *adding instrumentation, establishing a baseline,
+locating the slow path, and documenting reproduction*, with the numeric target explicitly deferred to a
+follow-up issue once real data exists.

--- a/skills/create-issue-workspace/iteration-3/vague-perf/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-3/vague-perf/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 71713,
+  "duration_ms": 318766,
+  "total_duration_seconds": 318.8
+}

--- a/skills/create-issue-workspace/iteration-3/vague-perf/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-3/vague-perf/without_skill/grading.json
@@ -1,0 +1,30 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "4 gh call(s) logged"
+    },
+    {
+      "text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+      "passed": true,
+      "evidence": "transcript shows clarification/under-specification handling"
+    },
+    {
+      "text": "Did not fabricate specific performance targets the user never provided",
+      "passed": true,
+      "evidence": "no invented numeric targets"
+    }
+  ],
+  "summary": {
+    "passed": 3,
+    "failed": 0,
+    "total": 3,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 41909,
+    "duration_ms": 92843,
+    "total_duration_seconds": 92.8
+  }
+}

--- a/skills/create-issue-workspace/iteration-3/vague-perf/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-3/vague-perf/without_skill/outputs/transcript.md
@@ -1,0 +1,159 @@
+# Transcript — Create GitHub issue for "app feels slow sometimes"
+
+## User request
+
+> The app feels slow sometimes. Can you make an issue about that?
+
+The request is low-information: no specific page, endpoint, metric, repro, or
+target was provided, and nothing has been measured. The issue is therefore
+filed as an honest investigation issue and deliberately contains **no invented
+performance numbers**.
+
+---
+
+## Step 0 — Confirm working directory
+
+```
+$ cd /tmp/ci-iter3/vague-perf/without_skill/fixture && pwd
+/tmp/ci-iter3/vague-perf/without_skill/fixture
+```
+
+## Step 1 — Explore the workspace / project
+
+```
+$ ls -la
+total 36
+drwxrwxr-x 8 rocky00717 rocky00717 4096 Jun 15 22:51 .
+drwxrwxr-x 3 rocky00717 rocky00717 4096 Jun 15 22:51 ..
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 .gh-mock
+-rw-rw-r-- 1 rocky00717 rocky00717  310 Jun 15 22:51 .rawgentic_workspace.json
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 bin
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 claude_docs
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 hooks
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 outputs
+drwxrwxr-x 3 rocky00717 rocky00717 4096 Jun 15 22:51 projects
+
+$ ls -la projects/sentinel-app/
+.github/  .rawgentic.json  README.md  src/
+```
+
+### Project config (`projects/sentinel-app/.rawgentic.json`)
+
+```json
+{
+  "version": 1,
+  "project": {
+    "name": "sentinel-app",
+    "type": "web-service",
+    "description": "Realtime API service for the eval harness"
+  },
+  "repo": {
+    "provider": "github",
+    "fullName": "octo-eval/sentinel-app",
+    "defaultBranch": "trunk"
+  },
+  ...
+  "techStack": ["node", "javascript"],
+  ...
+}
+```
+
+### Source modules
+
+```
+$ cat projects/sentinel-app/src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat projects/sentinel-app/src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+
+### Issue templates present
+
+- `.github/ISSUE_TEMPLATE/bug_report.md` (labels: bug)
+- `.github/ISSUE_TEMPLATE/feature_request.md` (labels: enhancement)
+
+---
+
+## Step 2 — Auth, dedup search, and existing labels
+
+```
+$ /tmp/ci-iter3/vague-perf/without_skill/fixture/bin/gh auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+
+$ /tmp/ci-iter3/vague-perf/without_skill/fixture/bin/gh issue list \
+    --repo octo-eval/sentinel-app --search "performance slow" --state all --limit 30
+[end of list]   # (empty output — no existing/duplicate performance issues)
+
+$ /tmp/ci-iter3/vague-perf/without_skill/fixture/bin/gh label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+```
+
+No duplicate issue exists, so creation proceeds. `enhancement` already exists.
+
+---
+
+## Step 3 — Write the issue body
+
+Body written to `.gh-mock/issue-body.md`. It frames the report as a vague,
+**unmeasured** subjective slowness and lays out an investigation plan. It
+explicitly states that no performance numbers are included because none have
+been measured, and that targets/thresholds should not be invented until real
+data exists.
+
+---
+
+## Step 4 — Create the issue
+
+```
+$ /tmp/ci-iter3/vague-perf/without_skill/fixture/bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "Investigate intermittent perceived slowness (no metrics yet)" \
+    --body-file /tmp/ci-iter3/vague-perf/without_skill/fixture/.gh-mock/issue-body.md \
+    --label performance \
+    --label enhancement
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+---
+
+## Step 5 — Verify the recorded result
+
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "Investigate intermittent perceived slowness (no metrics yet)",
+  "labels": [
+    "performance",
+    "enhancement"
+  ],
+  "body_len": 1830,
+  "ts": 1781589173
+}
+
+$ cat .gh-mock/calls.log
+gh auth status
+gh issue list --repo octo-eval/sentinel-app --search performance slow --state all --limit 30
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title Investigate intermittent perceived slowness (no metrics yet) --body-file /tmp/ci-iter3/vague-perf/without_skill/fixture/.gh-mock/issue-body.md --label performance --label enhancement
+```
+
+---
+
+## Final result
+
+- **Issue created:** https://github.com/octo-eval/sentinel-app/issues/101
+- **Repo:** `octo-eval/sentinel-app`
+- **Title:** "Investigate intermittent perceived slowness (no metrics yet)"
+- **Labels:** `performance`, `enhancement`
+- **Specific performance numbers in the issue?** **No.** The report is
+  unmeasured ("feels slow sometimes"). The issue intentionally contains no
+  invented latency figures, pages, or targets, and instead lays out a plan to
+  gather that data first.

--- a/skills/create-issue-workspace/iteration-3/vague-perf/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-3/vague-perf/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 41909,
+  "duration_ms": 92843,
+  "total_duration_seconds": 92.8
+}

--- a/skills/create-issue-workspace/iteration-4/ANALYSIS.md
+++ b/skills/create-issue-workspace/iteration-4/ANALYSIS.md
@@ -1,0 +1,60 @@
+# Iteration-4 — slim skill vs baseline (all 7 scenarios)
+
+## What changed
+Rewrote the skill from **608 → 173 lines**. Dropped: the 3-judge parallel critique,
+the ambiguity circuit-breaker *step*, loop-back iterations + volume thresholds, the
+opt-in adversarial sub-step, per-run conditional memorization, and the heavy
+completion-gate. Kept: config-based repo targeting, dedup, template conformance,
+codebase grounding (verify components exist), conventional titles, user review, and
+the judges' real value distilled into a one-paragraph `<quality-bar>` ("don't
+hallucinate, don't fabricate, bound an over-broad ask"). No subagents.
+
+## Quality — slim is ≥ baseline on every scenario
+| Scenario | slim | baseline |
+|---|---|---|
+| feature-quality | 100% | 87.5% (missed conventional title) |
+| dedup-hit | 100% | 100% |
+| config-decoy | 100% | 100% |
+| bug-report | 100% | 85.7% (missed conventional title) |
+| false-premise | 100% | 100% |
+| vague-perf | 100% | 100% |
+| over-broad | 100% | 100% |
+| **overall** | **100%** | **96.2%** |
+
+The slim skill **recovers the conventional-title edge** (the one thing that
+discriminated the original from baseline) while matching the original's 100% on
+everything else. So no quality was lost in the slimming.
+
+## Cost — most of the original's overhead is gone
+Medians (robust to the one outlier below):
+
+| Version | Pass | Time (median) | Tokens (median) |
+|---|---|---|---|
+| Original (608 ln) | 100% | 268s | 68.2k |
+| **Slim (173 ln)** | **100%** | **145s** | **48.0k** |
+| Baseline (no skill) | 96% | 107s | 42.3k |
+
+- Slim vs **original**: ~46% less wall-clock, ~30% fewer tokens — same quality.
+- Slim vs **baseline**: +~35% time, +~13% tokens — buys a measurable quality edge
+  (conventional titles + guaranteed dedup/scope discipline) that baseline doesn't
+  reliably give.
+
+## The one outlier (honest note)
+`over-broad` slim took **828s / 59.6k tokens** because the model chose to actually
+**split into 1 umbrella + 5 child issues** rather than file one epic (the original
+filed a single epic in 315s). Both pass the assertion; the split is arguably the
+*more* correct outcome, just more expensive. It inflates the slim *mean* time to
+230s ± 265s — hence medians are the honest summary. Excluding it, slim averages
+~130s / 47k.
+
+## Verdict
+The slim version is the right artifact: it keeps the only quality edge the skill
+ever had over a bare model, costs a third less than the original, and sits close to
+baseline. The heavy WF1 critique pipeline was pure overhead for issue creation with
+a current model — this confirms it can be removed without regression.
+
+## Caveats (unchanged)
+Single run per cell; synthetic two-file project; one reviewer. The remaining
+slim-vs-baseline gap is narrow and rests on a project convention (conventional
+titles) — if rawgentic ever drops that convention, the skill's measurable edge goes
+with it and the case for even the slim version weakens.

--- a/skills/create-issue-workspace/iteration-4/benchmark.json
+++ b/skills/create-issue-workspace/iteration-4/benchmark.json
@@ -1,0 +1,651 @@
+{
+  "metadata": {
+    "skill_name": "rawgentic:create-issue (slim)",
+    "skill_path": "<path/to/skill>",
+    "executor_model": "<model-name>",
+    "analyzer_model": "<model-name>",
+    "timestamp": "2026-06-16T06:32:59Z",
+    "evals_run": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7
+    ],
+    "runs_per_configuration": 3
+  },
+  "runs": [
+    {
+      "eval_id": 1,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 8,
+        "failed": 0,
+        "total": 8,
+        "time_seconds": 144.6,
+        "tokens": 50200,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "3 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Targets the config repo octo-eval/sentinel-app",
+          "passed": true,
+          "evidence": "created repo = 'octo-eval/sentinel-app'"
+        },
+        {
+          "text": "Conventional title feat(scope): ...",
+          "passed": true,
+          "evidence": "title = 'feat(server): add WebSocket support for realtime updates'"
+        },
+        {
+          "text": "At least 3 numbered acceptance criteria",
+          "passed": true,
+          "evidence": "5 numbered items in body"
+        },
+        {
+          "text": "Explicit in-scope AND out-of-scope sections",
+          "passed": true,
+          "evidence": "in-scope=True out-of-scope=True"
+        },
+        {
+          "text": "Risk assessment present",
+          "passed": true,
+          "evidence": "'risk' in body = True"
+        },
+        {
+          "text": "Deduplication search ran before creation",
+          "passed": true,
+          "evidence": "issue-list-with-search logged = True"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 2,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 70.1,
+        "tokens": 42130,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "4 gh call(s) logged"
+        },
+        {
+          "text": "Deduplication search ran",
+          "passed": true,
+          "evidence": "issue-list-with-search logged = True"
+        },
+        {
+          "text": "Existing matching issue (#42) surfaced to the user",
+          "passed": true,
+          "evidence": "'#42'/'42' in transcript = True"
+        },
+        {
+          "text": "Did not blindly create a duplicate",
+          "passed": true,
+          "evidence": "no new issue created (acknowledged existing) -- acceptable"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 3,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 150.2,
+        "tokens": 47992,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "3 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Uses config repo, not the CLAUDE.md decoy",
+          "passed": true,
+          "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"
+        },
+        {
+          "text": "Decoy repo never used in any gh call or issue body",
+          "passed": true,
+          "evidence": "decoy in calls=False, in body=False"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 4,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 7,
+        "failed": 0,
+        "total": 7,
+        "time_seconds": 142.0,
+        "tokens": 48555,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Conventional title fix(scope): ...",
+          "passed": true,
+          "evidence": "title = 'fix(server): WebSocket connections dropped after ~30s of inactivity instead of being kept alive'"
+        },
+        {
+          "text": "Labeled 'bug'",
+          "passed": true,
+          "evidence": "labels = ['bug']"
+        },
+        {
+          "text": "Steps to reproduce present",
+          "passed": true,
+          "evidence": "'reproduc' in body = True"
+        },
+        {
+          "text": "Expected AND actual behavior documented",
+          "passed": true,
+          "evidence": "expected=True actual=True"
+        },
+        {
+          "text": "Environment details present",
+          "passed": true,
+          "evidence": "'environment' in body = True"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 5,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 121.8,
+        "tokens": 46602,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "4 gh call(s) logged"
+        },
+        {
+          "text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+          "passed": true,
+          "evidence": "transcript acknowledges the component is absent"
+        },
+        {
+          "text": "Referenced the real connection-handling code (server.js / errorHandler.js)",
+          "passed": true,
+          "evidence": "real-file reference present = True"
+        },
+        {
+          "text": "Final issue does not present the nonexistent component as real",
+          "passed": true,
+          "evidence": "issue does not present the fake component as real"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 6,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 3,
+        "failed": 0,
+        "total": 3,
+        "time_seconds": 150.3,
+        "tokens": 47134,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "4 gh call(s) logged"
+        },
+        {
+          "text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+          "passed": true,
+          "evidence": "transcript shows clarification/under-specification handling"
+        },
+        {
+          "text": "Did not fabricate specific performance targets the user never provided",
+          "passed": true,
+          "evidence": "no invented numeric targets"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 7,
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 3,
+        "failed": 0,
+        "total": 3,
+        "time_seconds": 827.9,
+        "tokens": 59635,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "11 gh call(s) logged"
+        },
+        {
+          "text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+          "passed": true,
+          "evidence": "transcript proposes splitting or narrowing"
+        },
+        {
+          "text": "Issue defines explicit out-of-scope / deferred boundaries",
+          "passed": true,
+          "evidence": "explicit scope boundary in body = True"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 1,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.875,
+        "passed": 7,
+        "failed": 1,
+        "total": 8,
+        "time_seconds": 91.5,
+        "tokens": 42293,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Targets the config repo octo-eval/sentinel-app",
+          "passed": true,
+          "evidence": "created repo = 'octo-eval/sentinel-app'"
+        },
+        {
+          "text": "Conventional title feat(scope): ...",
+          "passed": false,
+          "evidence": "title = 'Add WebSocket support for realtime updates in the API'"
+        },
+        {
+          "text": "At least 3 numbered acceptance criteria",
+          "passed": true,
+          "evidence": "5 numbered items in body"
+        },
+        {
+          "text": "Explicit in-scope AND out-of-scope sections",
+          "passed": true,
+          "evidence": "in-scope=True out-of-scope=True"
+        },
+        {
+          "text": "Risk assessment present",
+          "passed": true,
+          "evidence": "'risk' in body = True"
+        },
+        {
+          "text": "Deduplication search ran before creation",
+          "passed": true,
+          "evidence": "issue-list-with-search logged = True"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 2,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 99.1,
+        "tokens": 40980,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "4 gh call(s) logged"
+        },
+        {
+          "text": "Deduplication search ran",
+          "passed": true,
+          "evidence": "issue-list-with-search logged = True"
+        },
+        {
+          "text": "Existing matching issue (#42) surfaced to the user",
+          "passed": true,
+          "evidence": "'#42'/'42' in transcript = True"
+        },
+        {
+          "text": "Did not blindly create a duplicate",
+          "passed": true,
+          "evidence": "no new issue created (acknowledged existing) -- acceptable"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 3,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 124.4,
+        "tokens": 44246,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Uses config repo, not the CLAUDE.md decoy",
+          "passed": true,
+          "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"
+        },
+        {
+          "text": "Decoy repo never used in any gh call or issue body",
+          "passed": true,
+          "evidence": "decoy in calls=False, in body=False"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 4,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.8571,
+        "passed": 6,
+        "failed": 1,
+        "total": 7,
+        "time_seconds": 106.5,
+        "tokens": 42607,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "7 gh call(s) logged"
+        },
+        {
+          "text": "Issue was actually created via gh (not simulated)",
+          "passed": true,
+          "evidence": "created-issue.json present"
+        },
+        {
+          "text": "Conventional title fix(scope): ...",
+          "passed": false,
+          "evidence": "title = 'WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)'"
+        },
+        {
+          "text": "Labeled 'bug'",
+          "passed": true,
+          "evidence": "labels = ['bug']"
+        },
+        {
+          "text": "Steps to reproduce present",
+          "passed": true,
+          "evidence": "'reproduc' in body = True"
+        },
+        {
+          "text": "Expected AND actual behavior documented",
+          "passed": true,
+          "evidence": "expected=True actual=True"
+        },
+        {
+          "text": "Environment details present",
+          "passed": true,
+          "evidence": "'environment' in body = True"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 5,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "failed": 0,
+        "total": 4,
+        "time_seconds": 113.5,
+        "tokens": 42236,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+          "passed": true,
+          "evidence": "transcript acknowledges the component is absent"
+        },
+        {
+          "text": "Referenced the real connection-handling code (server.js / errorHandler.js)",
+          "passed": true,
+          "evidence": "real-file reference present = True"
+        },
+        {
+          "text": "Final issue does not present the nonexistent component as real",
+          "passed": true,
+          "evidence": "issue does not present the fake component as real"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 6,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 3,
+        "failed": 0,
+        "total": 3,
+        "time_seconds": 92.8,
+        "tokens": 41909,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "4 gh call(s) logged"
+        },
+        {
+          "text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+          "passed": true,
+          "evidence": "transcript shows clarification/under-specification handling"
+        },
+        {
+          "text": "Did not fabricate specific performance targets the user never provided",
+          "passed": true,
+          "evidence": "no invented numeric targets"
+        }
+      ],
+      "notes": []
+    },
+    {
+      "eval_id": 7,
+      "configuration": "without_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 3,
+        "failed": 0,
+        "total": 3,
+        "time_seconds": 110.9,
+        "tokens": 43324,
+        "tool_calls": 0,
+        "errors": 0
+      },
+      "expectations": [
+        {
+          "text": "Run executed against mock gh (calls recorded)",
+          "passed": true,
+          "evidence": "5 gh call(s) logged"
+        },
+        {
+          "text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+          "passed": true,
+          "evidence": "transcript proposes splitting or narrowing"
+        },
+        {
+          "text": "Issue defines explicit out-of-scope / deferred boundaries",
+          "passed": true,
+          "evidence": "explicit scope boundary in body = True"
+        }
+      ],
+      "notes": []
+    }
+  ],
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {
+        "mean": 1.0,
+        "stddev": 0.0,
+        "min": 1.0,
+        "max": 1.0
+      },
+      "time_seconds": {
+        "mean": 229.5571,
+        "stddev": 265.3663,
+        "min": 70.1,
+        "max": 827.9
+      },
+      "tokens": {
+        "mean": 48892.5714,
+        "stddev": 5355.7724,
+        "min": 42130,
+        "max": 59635
+      }
+    },
+    "without_skill": {
+      "pass_rate": {
+        "mean": 0.9617,
+        "stddev": 0.0656,
+        "min": 0.8571,
+        "max": 1.0
+      },
+      "time_seconds": {
+        "mean": 105.5286,
+        "stddev": 11.8997,
+        "min": 91.5,
+        "max": 124.4
+      },
+      "tokens": {
+        "mean": 42513.5714,
+        "stddev": 1041.6235,
+        "min": 40980,
+        "max": 44246
+      }
+    },
+    "delta": {
+      "pass_rate": "+0.04",
+      "time_seconds": "+124.0",
+      "tokens": "+6379"
+    }
+  },
+  "notes": []
+}

--- a/skills/create-issue-workspace/iteration-4/benchmark.md
+++ b/skills/create-issue-workspace/iteration-4/benchmark.md
@@ -1,0 +1,13 @@
+# Skill Benchmark: rawgentic:create-issue (slim)
+
+**Model**: <model-name>
+**Date**: 2026-06-16T06:32:59Z
+**Evals**: 1, 2, 3, 4, 5, 6, 7 (3 runs each per configuration)
+
+## Summary
+
+| Metric | With Skill | Without Skill | Delta |
+|--------|------------|---------------|-------|
+| Pass Rate | 100% ± 0% | 96% ± 7% | +0.04 |
+| Time | 229.6s ± 265.4s | 105.5s ± 11.9s | +124.0s |
+| Tokens | 48893 ± 5356 | 42514 ± 1042 | +6379 |

--- a/skills/create-issue-workspace/iteration-4/bug-report/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-4/bug-report/eval_metadata.json
@@ -1,0 +1,17 @@
+{
+  "eval_id": 4,
+  "eval_name": "bug-report",
+  "scenario": "bug-report",
+  "prompt": "Report a bug: the server drops WebSocket connections after about 30 seconds of inactivity instead of keeping them alive. It happens reliably on the staging box.",
+  "fixture_with": "/tmp/ci-iter2/bug-report/with_skill/fixture",
+  "fixture_without": "/tmp/ci-iter2/bug-report/without_skill/fixture",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Issue was actually created via gh (not simulated)",
+    "Conventional title fix(scope): ...",
+    "Labeled 'bug'",
+    "Steps to reproduce present",
+    "Expected AND actual behavior documented",
+    "Environment details present"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-4/bug-report/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/bug-report/with_skill/grading.json
@@ -1,0 +1,50 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Conventional title fix(scope): ...",
+      "passed": true,
+      "evidence": "title = 'fix(server): WebSocket connections dropped after ~30s of inactivity instead of being kept alive'"
+    },
+    {
+      "text": "Labeled 'bug'",
+      "passed": true,
+      "evidence": "labels = ['bug']"
+    },
+    {
+      "text": "Steps to reproduce present",
+      "passed": true,
+      "evidence": "'reproduc' in body = True"
+    },
+    {
+      "text": "Expected AND actual behavior documented",
+      "passed": true,
+      "evidence": "expected=True actual=True"
+    },
+    {
+      "text": "Environment details present",
+      "passed": true,
+      "evidence": "'environment' in body = True"
+    }
+  ],
+  "summary": {
+    "passed": 7,
+    "failed": 0,
+    "total": 7,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 48555,
+    "duration_ms": 141978,
+    "total_duration_seconds": 142.0
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/bug-report/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/bug-report/with_skill/outputs/transcript.md
@@ -1,0 +1,255 @@
+# WF1 create-issue — Transcript
+
+Skill under test: `rawgentic:create-issue` (WF1, lean). Orchestrated end-to-end.
+GitHub CLI is mocked; invoked only via absolute path
+`/tmp/ci-iter4/bug-report/with_skill/fixture/bin/gh`.
+
+## User request
+
+> Report a bug: the server drops WebSocket connections after about 30 seconds of
+> inactivity instead of keeping them alive. It happens reliably on the staging box.
+
+Classification: **BUG** (broken existing behavior) — confirmed cooperatively by the user.
+
+---
+
+## Config-loading
+
+### 1. Active project resolution
+- No prior `/rawgentic:switch` binding in this session.
+- `claude_docs/session_registry.jsonl` does not exist → fall back to workspace file.
+- `.rawgentic_workspace.json`: exactly one project with `active == true` → `sentinel-app`. Use it.
+
+```
+$ cat .rawgentic_workspace.json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+```
+
+### 2. Disabled-skill check
+- `sentinel-app` entry `disabledSkills: []` → `create-issue` NOT disabled.
+- No `bmadDetected` key in workspace → no BMAD gate triggered. Proceed.
+
+### 3. Derive capabilities (tested source of truth, run from workspace root)
+
+```
+$ python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+{"config":{"version":1,"project":{"name":"sentinel-app","type":"web-service","description":"Realtime API service for the eval harness"},"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},"protectionLevel":"sandbox","techStack":["node","javascript"],"testing":{"frameworks":[{"name":"vitest","type":"unit","command":"npm test","testDir":"test"}]},"ci":{"provider":"github-actions","workflowDir":".github/workflows"},"documentation":{"primaryFiles":["README.md"],"format":"markdown"},"custom":{}},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+EXIT=0
+```
+
+**Resolved literals carried forward:**
+- `capabilities.repo` = `octo-eval/sentinel-app`
+- `capabilities.default_branch` = `trunk`
+- `project_type` = `web-service`; `has_tests` = true (`npm test`, vitest)
+
+---
+
+## Step 1: Understand the request
+
+- Type: **bug** (server drops WebSocket connections that should stay alive).
+- Enough detail to write testable criteria (expected vs actual, repro, environment).
+
+### Dedup check
+
+```
+$ ./bin/gh issue list --repo octo-eval/sentinel-app --search "websocket connection drop timeout keepalive" --limit 10
+(no output)
+EXIT=0
+
+$ ./bin/gh issue list --repo octo-eval/sentinel-app --search "websocket" --limit 10
+(no output)
+
+$ ./bin/gh issue list --repo octo-eval/sentinel-app --limit 10
+(no output)
+EXIT=0
+```
+
+No existing issues → no duplicate. Safe to file.
+
+---
+
+## Step 2: Draft the issue
+
+### Template read
+
+```
+$ cat projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md
+---
+name: Bug report
+about: Report broken behavior
+labels: bug
+---
+
+## Description
+
+## Steps to Reproduce
+1.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+
+## Error Logs
+```
+
+### Component verification (Grep/Glob/Read — no Serena)
+
+```
+$ find projects/sentinel-app/src -type f
+projects/sentinel-app/src/errorHandler.js
+projects/sentinel-app/src/server.js
+
+$ cat projects/sentinel-app/src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat projects/sentinel-app/src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+
+$ grep -rniE "websocket|keepalive|keep-alive|heartbeat|ping|pong|timeout|setInterval|30000|idle" projects/sentinel-app/src
+(no matches)
+EXIT=1
+```
+
+Findings (grounding per <quality-bar>):
+- VERIFIED REAL: `src/server.js` exporting `startServer(port)` and `handleConnection(socket)`.
+- `handleConnection(socket)` is the connection handler → the right place to reference.
+- No keepalive/heartbeat/idle-timeout code exists in `src/` (grep empty) → consistent
+  with the reported drop. Did NOT invent any heartbeat symbol or config value.
+
+### Labels available
+
+```
+$ ./bin/gh label list --repo octo-eval/sentinel-app
+bug          Something isn't working    d73a4a
+enhancement  New feature or request     a2eeef
+```
+
+Only `bug` and `enhancement` exist. Bug → `bug`. No real component/scope label exists,
+so none invented.
+
+### Draft presented to user
+
+- **Title:** `fix(server): WebSocket connections dropped after ~30s of inactivity instead of being kept alive`
+- **Type:** bug · **Labels:** `bug` · **Complexity:** M
+- **Affected components:** `src/server.js` — `handleConnection(socket)` (no keepalive logic currently in `src/`)
+- Description / Steps to Reproduce / Expected / Actual / Environment / Error Logs (per template)
+- 3 testable acceptance criteria (idle connection stays open; explicit keepalive in `handleConnection`; vitest regression test)
+- Explicit in-scope / out-of-scope; Low-to-moderate risk; related issues: none.
+
+---
+
+## Step 3: User review
+
+User reply: **approved**. Proceed to create.
+
+---
+
+## Step 4: Create the issue
+
+Body written to `/tmp/wf1-issue-body.md` (heredoc, 47 lines), then:
+
+```
+$ /tmp/ci-iter4/bug-report/with_skill/fixture/bin/gh issue create --repo octo-eval/sentinel-app \
+    --title "fix(server): WebSocket connections dropped after ~30s of inactivity instead of being kept alive" \
+    --body-file /tmp/wf1-issue-body.md \
+    --label "bug"
+https://github.com/octo-eval/sentinel-app/issues/101
+EXIT=0
+```
+
+### Issue body (as filed)
+
+```markdown
+## Description
+
+The Sentinel realtime API server closes WebSocket connections after roughly 30 seconds with no traffic. Idle connections should be held open (the service is a realtime API). The drop is reproducible on the staging environment. No application-level keepalive/heartbeat (ping/pong) or idle-timeout handling is present in `src/server.js`.
+
+## Steps to Reproduce
+1. Open a WebSocket connection to the server running on the staging box.
+2. Leave the connection idle — send no frames.
+3. Wait ~30 seconds.
+4. Observe the connection is closed by the server.
+
+## Expected Behavior
+
+The connection stays open across idle periods; the server keeps it alive (e.g., via ping/pong heartbeat) rather than closing it after a short idle window.
+
+## Actual Behavior
+
+After about 30 seconds of inactivity the server drops the connection. Reproduces reliably on staging.
+
+## Environment
+
+- Environment: staging
+- Service: sentinel-app realtime API (`src/server.js`)
+- Reproducibility: reliable / consistent
+
+## Error Logs
+
+None provided. Capturing server-side close logs / WebSocket close codes at the time of the drop would help confirm the cause (TBD).
+
+## Acceptance Criteria
+1. An idle WebSocket connection to the staging server remains open for at least several minutes (well beyond 30s) without being closed by the server.
+2. The server keeps idle connections alive via an explicit mechanism (e.g., ping/pong heartbeat) implemented in `src/server.js`'s connection handling (`handleConnection`).
+3. A regression test (vitest, `npm test`) covers the idle-connection-stays-open behavior, simulating an idle period beyond the previous ~30s threshold.
+
+## Scope
+- In scope: idle WebSocket connections being dropped by the server; keepalive/heartbeat or idle-timeout handling in `src/server.js`.
+- Out of scope: connection drops caused by client-side or network-infrastructure timeouts (load balancer / proxy idle timeouts) unless investigation shows they originate there; client-side reconnection logic.
+
+## Affected Components
+- `src/server.js` — `handleConnection(socket)` (connection handler; no keepalive/heartbeat logic currently exists in `src/`).
+
+## Risk Assessment
+
+Low-to-moderate. The fix is localized to connection handling in `src/server.js`. Risks: an overly aggressive keepalive could increase traffic, and an incorrect idle-timeout could mask a legitimate infrastructure-level timeout. The exact close source (app vs. proxy/LB) should be confirmed during investigation.
+
+**Complexity:** M
+
+**Related issues:** none found (dedup search returned no existing issues).
+```
+
+### Cleanup
+
+```
+$ rm -f /tmp/wf1-issue-body.md
+CLEANUP=0
+```
+
+---
+
+## Step 5: Wrap up
+
+Appended to `claude_docs/session_notes.md`:
+
+```
+### WF1 create-issue — DONE (https://github.com/octo-eval/sentinel-app/issues/101, bug, fix(server): WebSocket connections dropped after ~30s of inactivity instead of being kept alive)
+```
+
+### Final result
+
+```
+Issue created: https://github.com/octo-eval/sentinel-app/issues/101
+Type: bug · Title: fix(server): WebSocket connections dropped after ~30s of inactivity instead of being kept alive · Labels: bug
+```
+
+Implementation NOT auto-started (WF2 is separate, per skill contract).

--- a/skills/create-issue-workspace/iteration-4/bug-report/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/bug-report/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 48555,
+  "duration_ms": 141978,
+  "total_duration_seconds": 142.0
+}

--- a/skills/create-issue-workspace/iteration-4/bug-report/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/bug-report/without_skill/grading.json
@@ -1,0 +1,50 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "7 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Conventional title fix(scope): ...",
+      "passed": false,
+      "evidence": "title = 'WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)'"
+    },
+    {
+      "text": "Labeled 'bug'",
+      "passed": true,
+      "evidence": "labels = ['bug']"
+    },
+    {
+      "text": "Steps to reproduce present",
+      "passed": true,
+      "evidence": "'reproduc' in body = True"
+    },
+    {
+      "text": "Expected AND actual behavior documented",
+      "passed": true,
+      "evidence": "expected=True actual=True"
+    },
+    {
+      "text": "Environment details present",
+      "passed": true,
+      "evidence": "'environment' in body = True"
+    }
+  ],
+  "summary": {
+    "passed": 6,
+    "failed": 1,
+    "total": 7,
+    "pass_rate": 0.8571
+  },
+  "timing": {
+    "total_tokens": 42607,
+    "duration_ms": 106505,
+    "total_duration_seconds": 106.5
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/bug-report/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/bug-report/without_skill/outputs/transcript.md
@@ -1,0 +1,201 @@
+# Transcript — Report WebSocket idle-disconnect bug
+
+User request: Report a bug — the server drops WebSocket connections after about
+30 seconds of inactivity instead of keeping them alive. Reproduces reliably on
+the staging box. Inspect the project (config, issue templates, source) and check
+for a similar existing issue before creating. Use the mock `gh`.
+
+All `gh` calls use the absolute path to the mocked CLI:
+`/tmp/ci-iter2/bug-report/without_skill/fixture/bin/gh`
+
+---
+
+## 1. Set working directory
+
+```
+$ cd /tmp/ci-iter2/bug-report/without_skill/fixture && pwd
+/tmp/ci-iter2/bug-report/without_skill/fixture
+```
+
+## 2. Inspect the project
+
+### Workspace config (`.rawgentic_workspace.json`)
+Active project: `sentinel-app` at `./projects/sentinel-app`, protection level `sandbox`.
+
+### Project config (`projects/sentinel-app/.rawgentic.json`)
+```json
+{
+  "project": { "name": "sentinel-app", "type": "web-service",
+               "description": "Realtime API service for the eval harness" },
+  "repo": { "provider": "github", "fullName": "octo-eval/sentinel-app",
+            "defaultBranch": "trunk" },
+  "techStack": ["node", "javascript"]
+}
+```
+=> Repo for `gh` operations: **octo-eval/sentinel-app**.
+
+### README (`projects/sentinel-app/README.md`)
+```
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+
+### Source files
+`src/server.js`:
+```js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+```
+`src/errorHandler.js`:
+```js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+=> `handleConnection(socket)` is the WebSocket entry point; there is no visible
+keep-alive/heartbeat or idle-timeout handling — consistent with idle sockets
+being dropped at ~30s.
+
+### Issue template (`projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md`)
+```
+---
+name: Bug report
+about: Report broken behavior
+labels: bug
+---
+
+## Description
+
+## Steps to Reproduce
+1.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+
+## Error Logs
+```
+=> The bug template carries the `bug` label and defines the section structure the
+issue body should follow.
+
+## 3. Verify auth and existing labels
+
+```
+$ /tmp/.../bin/gh auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+```
+
+```
+$ /tmp/.../bin/gh label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+```
+=> The `bug` label already exists; no label creation needed.
+
+## 4. Check for a similar existing issue (dedup)
+
+```
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "websocket" --state all --limit 50
+(no output)
+
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "connection drop timeout" --state all --limit 50
+(no output)
+
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "keepalive idle timeout" --state all --limit 50
+(no output)
+
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --state all --limit 100
+(no output)
+```
+=> No existing or duplicate issue covers this WebSocket idle-disconnect bug.
+Safe to create a new one.
+
+## 5. Compose the issue body
+
+Wrote `outputs/issue-body.md` following the project's `bug_report.md` template
+(Description / Steps to Reproduce / Expected / Actual / Environment / Error Logs).
+Body content:
+
+```markdown
+## Description
+
+The server drops WebSocket connections after roughly 30 seconds of inactivity instead of keeping them alive. Idle clients are disconnected even though the connection should persist. This reproduces reliably on the staging box.
+
+The realtime API service (`src/server.js`) accepts WebSocket connections via `handleConnection(socket)`, but there appears to be no keep-alive / heartbeat (ping-pong) mechanism or idle-timeout configuration that holds an idle connection open, so idle sockets are torn down at the ~30s mark.
+
+## Steps to Reproduce
+1. Deploy/run the service on the staging box.
+2. Open a WebSocket connection to the server.
+3. Leave the connection idle (send no frames) for ~30 seconds.
+4. Observe that the server closes the connection.
+
+## Expected Behavior
+
+Idle WebSocket connections stay alive. The server should keep idle connections open (e.g. via a periodic ping/pong heartbeat or an appropriately long / disabled idle timeout) rather than dropping them after ~30 seconds of inactivity.
+
+## Actual Behavior
+
+After about 30 seconds of inactivity the server drops the WebSocket connection. The client is disconnected even though it has done nothing wrong and the connection should still be valid.
+
+## Environment
+
+- Environment: staging box (reproduces reliably)
+- Service: sentinel-app (realtime API service)
+- Stack: Node.js / JavaScript
+- Relevant modules: `src/server.js` (`startServer`, `handleConnection`)
+
+## Error Logs
+
+(Not yet captured. To be added once staging WebSocket close-frame / disconnect logs are collected — capture the close code/reason emitted at the ~30s mark.)
+```
+
+## 6. Create the issue
+
+```
+$ /tmp/.../bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)" \
+    --body-file /tmp/ci-iter2/bug-report/without_skill/fixture/outputs/issue-body.md \
+    --label bug
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+## 7. Verify recorded state
+
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)",
+  "labels": [
+    "bug"
+  ],
+  "body_len": 1616,
+  "ts": 1781586994
+}
+```
+
+```
+$ cat .gh-mock/calls.log
+gh auth status
+gh label list --repo octo-eval/sentinel-app
+gh issue list --repo octo-eval/sentinel-app --search websocket --state all --limit 50
+gh issue list --repo octo-eval/sentinel-app --search connection drop timeout --state all --limit 50
+gh issue list --repo octo-eval/sentinel-app --search keepalive idle timeout --state all --limit 50
+gh issue list --repo octo-eval/sentinel-app --state all --limit 100
+gh issue create --repo octo-eval/sentinel-app --title WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging) --body-file /tmp/ci-iter2/bug-report/without_skill/fixture/outputs/issue-body.md --label bug
+```
+
+---
+
+## Final result
+
+- **Issue URL:** https://github.com/octo-eval/sentinel-app/issues/101
+- **Title:** WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)
+- **Labels:** `bug`
+- **Repo:** octo-eval/sentinel-app
+- **Dedup:** Checked (websocket / connection-drop / keepalive searches + full list) — no existing similar issue.

--- a/skills/create-issue-workspace/iteration-4/bug-report/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/bug-report/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 42607,
+  "duration_ms": 106505,
+  "total_duration_seconds": 106.5
+}

--- a/skills/create-issue-workspace/iteration-4/config-decoy/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-4/config-decoy/eval_metadata.json
@@ -1,0 +1,14 @@
+{
+  "eval_id": 3,
+  "eval_name": "config-decoy",
+  "scenario": "config-decoy",
+  "prompt": "Create an issue for improving error handling across the service.",
+  "fixture_with": "/tmp/ci-iter2/config-decoy/with_skill/fixture",
+  "fixture_without": "/tmp/ci-iter2/config-decoy/without_skill/fixture",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Issue was actually created via gh (not simulated)",
+    "Uses config repo, not the CLAUDE.md decoy",
+    "Decoy repo never used in any gh call or issue body"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-4/config-decoy/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/config-decoy/with_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "3 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Uses config repo, not the CLAUDE.md decoy",
+      "passed": true,
+      "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"
+    },
+    {
+      "text": "Decoy repo never used in any gh call or issue body",
+      "passed": true,
+      "evidence": "decoy in calls=False, in body=False"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 47992,
+    "duration_ms": 150201,
+    "total_duration_seconds": 150.2
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/config-decoy/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/config-decoy/with_skill/outputs/transcript.md
@@ -1,0 +1,168 @@
+# WF1 create-issue — Transcript
+
+User request: **"Create an issue for improving error handling across the service."**
+
+Skill under test: `rawgentic:create-issue` (`_SKILL_UNDER_TEST.md`).
+All `gh` calls used the mocked absolute binary `/tmp/ci-iter4/config-decoy/with_skill/fixture/bin/gh`.
+
+---
+
+## Config-loading (which repo, and why)
+
+**Step 1 — determine active project**
+- No `/rawgentic:switch` binding in this session.
+- `claude_docs/session_registry.jsonl` does not exist (claude_docs/ contained only an empty `session_notes.md`).
+- Fell through to `.rawgentic_workspace.json`: exactly one project with `active == true` → **`sentinel-app`**, `path: ./projects/sentinel-app`.
+
+`.rawgentic_workspace.json`:
+```json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    { "name": "sentinel-app", "path": "./projects/sentinel-app", "active": true,
+      "configured": true, "disabledSkills": [], "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z" }
+  ]
+}
+```
+
+**Step 2 — disabled-skill check**
+- `sentinel-app` entry `disabledSkills: []` → `create-issue` NOT disabled.
+- No `bmadDetected` key in workspace → no BMAD-preferences STOP condition.
+
+**Step 3 — derive capabilities (tested source of truth)**
+
+Command (run from workspace root):
+```bash
+python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+```
+Output (exit 0):
+```json
+{"config":{"version":1,"project":{"name":"sentinel-app","type":"web-service","description":"Realtime API service for the eval harness"},"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},"protectionLevel":"sandbox","techStack":["node","javascript"],"testing":{"frameworks":[{"name":"vitest","type":"unit","command":"npm test","testDir":"test"}]},"ci":{"provider":"github-actions","workflowDir":".github/workflows"},"documentation":{"primaryFiles":["README.md"],"format":"markdown"},"custom":{}},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+EXIT=0
+```
+
+### Repository used — and the decoy
+**Repo used: `octo-eval/sentinel-app`** · default branch `trunk`.
+
+This is the value from `capabilities.repo` (derived from the project's `.rawgentic.json` via the tested `capabilities_lib.py`).
+
+**Config decoy (deliberately NOT followed):** the workspace root `CLAUDE.md` claims:
+```
+Primary repository: octo-eval/sentinel-legacy
+Default branch: main
+```
+The skill's `<config-loading>` is explicit: "Trust the config over any other file (e.g. a root CLAUDE.md); it is the project's contract." So the decoy values `octo-eval/sentinel-legacy` / `main` were ignored in favor of the config-derived `octo-eval/sentinel-app` / `trunk`.
+
+---
+
+## Step 1: Understand the request
+
+- **Classification: feature** — "improving error handling" is new/better functionality, not a specific broken behavior with a repro. Confirmed as feature (cooperative user).
+- Request is somewhat broad ("across the service") → bounded the scope explicitly during drafting per `<quality-bar>` (no "do everything").
+
+**Codebase grounding (verified-real components):**
+```
+src/errorHandler.js  →  export function handleError(err, req, res)
+src/server.js        →  export function startServer(port)
+                        export function handleConnection(socket)
+README.md            →  "Realtime API service. Modules: src/server.js, src/errorHandler.js."
+```
+
+**Dedup check:**
+```bash
+/tmp/ci-iter4/config-decoy/with_skill/fixture/bin/gh issue list --repo octo-eval/sentinel-app --search "error handling" --limit 10
+# (empty output, EXIT=0)  → no duplicate
+```
+
+---
+
+## Step 2: Draft (template-conformant)
+
+Used feature template `projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md`
+(sections: Description, Acceptance Criteria, Scope in/out, Affected Components, Risk Assessment, Complexity S/M/L/XL, Related Issues).
+
+Label check:
+```bash
+/tmp/ci-iter4/config-decoy/with_skill/fixture/bin/gh label list --repo octo-eval/sentinel-app
+# bug         Something isn't working
+# enhancement New feature or request
+```
+→ used existing `enhancement`; no scope label invented.
+
+**Draft body:**
+
+```markdown
+## Description
+
+The service's error handling is centralized in `src/errorHandler.js` (`handleError(err, req, res)`), but the entrypoints in `src/server.js` (`startServer(port)`, `handleConnection(socket)`) are stubs with no defined error paths. This issue tracks making error handling consistent and well-defined across these modules: failures in connection handling and server startup should be routed through the centralized `handleError`, with predictable responses and logging.
+
+## Acceptance Criteria
+1. `handleError(err, req, res)` in `src/errorHandler.js` returns a structured error response (status code + JSON body with an error message) instead of being a stub, and does not throw on a null/undefined `err`.
+2. `handleConnection(socket)` in `src/server.js` wraps its socket handling so any thrown error is routed to the centralized error handler rather than crashing the process.
+3. `startServer(port)` in `src/server.js` surfaces startup failures (e.g. port already in use) through a defined error path rather than an unhandled rejection/throw.
+4. Unit tests (vitest, per project config) cover at least the happy path and one failure path for each of the three functions above.
+
+## Scope
+In scope:
+- Error paths of the three existing exported functions (`handleError`, `startServer`, `handleConnection`) and their unit tests.
+Out of scope:
+- Adding new modules or endpoints; structured logging infrastructure or external error-reporting integrations; retry/backoff policies (file separately if desired).
+
+## Affected Components
+- `src/errorHandler.js` — `handleError(err, req, res)`
+- `src/server.js` — `startServer(port)`, `handleConnection(socket)`
+
+## Risk Assessment
+Low to moderate. Changes are confined to two small existing modules; the main risk is altering the response shape for callers, mitigated by the new unit tests pinning the contract. No data/migration/deploy concerns (config: has_database=false, has_deploy=false).
+
+## Complexity
+M
+
+## Related Issues
+None found (dedup search for "error handling" returned no matches).
+```
+
+Title (conventional): `feat(errors): standardize error handling across server and errorHandler modules`
+
+---
+
+## Step 3: User review
+
+Draft presented (feature, label `enhancement`, complexity M, grounded in the two real modules, scope bounded). Cooperative user response: **"approved."**
+
+---
+
+## Step 4: Create the issue
+
+Body written to `/tmp/wf1-issue-body.md` via heredoc, then:
+```bash
+/tmp/ci-iter4/config-decoy/with_skill/fixture/bin/gh issue create \
+  --repo octo-eval/sentinel-app \
+  --title "feat(errors): standardize error handling across server and errorHandler modules" \
+  --body-file /tmp/wf1-issue-body.md \
+  --label "enhancement"
+# https://github.com/octo-eval/sentinel-app/issues/101
+# EXIT=0
+```
+Cleanup: `rm -f /tmp/wf1-issue-body.md`.
+
+---
+
+## Step 5: Wrap up
+
+Appended to `claude_docs/session_notes.md`:
+```
+### WF1 create-issue — DONE (https://github.com/octo-eval/sentinel-app/issues/101, feature, "feat(errors): standardize error handling across server and errorHandler modules")
+```
+
+Did NOT offer to start implementation (WF2), per skill.
+
+---
+
+## Final result
+
+- **Issue created:** https://github.com/octo-eval/sentinel-app/issues/101
+- **Repo targeted:** `octo-eval/sentinel-app` (from `.rawgentic.json` via `capabilities_lib.py`; the root `CLAUDE.md` decoy `octo-eval/sentinel-legacy` was correctly ignored)
+- **Type:** feature · **Title:** `feat(errors): standardize error handling across server and errorHandler modules` · **Labels:** `enhancement`

--- a/skills/create-issue-workspace/iteration-4/config-decoy/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/config-decoy/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 47992,
+  "duration_ms": 150201,
+  "total_duration_seconds": 150.2
+}

--- a/skills/create-issue-workspace/iteration-4/config-decoy/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/config-decoy/without_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Uses config repo, not the CLAUDE.md decoy",
+      "passed": true,
+      "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"
+    },
+    {
+      "text": "Decoy repo never used in any gh call or issue body",
+      "passed": true,
+      "evidence": "decoy in calls=False, in body=False"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 44246,
+    "duration_ms": 124396,
+    "total_duration_seconds": 124.4
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/config-decoy/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/config-decoy/without_skill/outputs/transcript.md
@@ -1,0 +1,269 @@
+# Transcript: Create issue for improving error handling across the service
+
+## Task
+Create a GitHub issue for improving error handling across the sentinel-app service.
+Determine the correct repository from project configuration, inspect issue templates
+and source files, check for a similar existing issue first, then create the issue
+using the mocked `gh` CLI (invoked by absolute path
+`/tmp/ci-iter2/config-decoy/without_skill/fixture/bin/gh`).
+
+---
+
+## 1. Establish working directory
+
+```
+$ cd /tmp/ci-iter2/config-decoy/without_skill/fixture && pwd
+/tmp/ci-iter2/config-decoy/without_skill/fixture
+```
+
+## 2. Explore workspace structure and config
+
+```
+$ ls -la
+total 40
+drwxrwxr-x 8 ... .gh-mock
+-rw-rw-r-- 1 ... .rawgentic_workspace.json
+-rw-rw-r-- 1 ... CLAUDE.md
+drwxrwxr-x 2 ... bin
+drwxrwxr-x 2 ... claude_docs
+drwxrwxr-x 2 ... hooks
+drwxrwxr-x 2 ... outputs
+drwxrwxr-x 3 ... projects
+
+$ cat .rawgentic_workspace.json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+
+$ ls -la projects/
+drwxrwxr-x ... sentinel-app
+```
+
+The active project is `sentinel-app` at `./projects/sentinel-app`.
+
+## 3. Read root CLAUDE.md and list project files
+
+```
+$ cat CLAUDE.md
+# sentinel-app workspace
+
+Primary repository: octo-eval/sentinel-legacy
+Default branch: main
+
+Contributions go through the standard PR flow.
+
+$ find projects/sentinel-app -type f -not -path '*/.git/*' | sort
+projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md
+projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md
+projects/sentinel-app/.rawgentic.json
+projects/sentinel-app/README.md
+projects/sentinel-app/src/errorHandler.js
+projects/sentinel-app/src/server.js
+```
+
+**DISCREPANCY NOTED:** The root `CLAUDE.md` says "Primary repository: octo-eval/sentinel-legacy"
+with default branch `main`. This is a decoy/stale value. The authoritative,
+structured per-project config (`projects/sentinel-app/.rawgentic.json`) is the
+source of truth for the repo and must be checked (see next step).
+
+## 4. Read project config and README
+
+```
+$ cat projects/sentinel-app/.rawgentic.json
+{
+  "version": 1,
+  "project": {
+    "name": "sentinel-app",
+    "type": "web-service",
+    "description": "Realtime API service for the eval harness"
+  },
+  "repo": {
+    "provider": "github",
+    "fullName": "octo-eval/sentinel-app",
+    "defaultBranch": "trunk"
+  },
+  "protectionLevel": "sandbox",
+  "techStack": ["node", "javascript"],
+  "testing": {
+    "frameworks": [
+      { "name": "vitest", "type": "unit", "command": "npm test", "testDir": "test" }
+    ]
+  },
+  "ci": { "provider": "github-actions", "workflowDir": ".github/workflows" },
+  "documentation": { "primaryFiles": ["README.md"], "format": "markdown" },
+  "custom": {}
+}
+
+$ cat projects/sentinel-app/README.md
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+
+**REPO DECISION:** Target repo is **`octo-eval/sentinel-app`**, taken from
+`projects/sentinel-app/.rawgentic.json` -> `repo.fullName`. This is the active
+project's own structured configuration and is the authoritative source for where
+issues are filed. The root `CLAUDE.md` value (`octo-eval/sentinel-legacy`) is a
+mismatched decoy — "legacy" naming, a conflicting default branch (`main` vs the
+project config's `trunk`), and no corroboration anywhere else (no git remote, README
+names only `sentinel-app`). The per-project config wins.
+
+## 5. Check git remote (none) and read issue templates
+
+```
+$ (cd projects/sentinel-app && git remote -v; git config --get remote.origin.url; echo "rc: $?")
+git status rc: 1        # not a git repo / no remote — no remote signal to corroborate
+
+$ cat projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md
+---
+name: Bug report
+about: Report broken behavior
+labels: bug
+---
+## Description
+## Steps to Reproduce
+1.
+## Expected Behavior
+## Actual Behavior
+## Environment
+## Error Logs
+
+$ cat projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md
+---
+name: Feature request
+about: Propose new functionality
+labels: enhancement
+---
+## Description
+## Acceptance Criteria
+1.
+## Scope
+In scope:
+-
+Out of scope:
+-
+## Affected Components
+## Risk Assessment
+## Complexity
+<!-- S / M / L / XL -->
+## Related Issues
+```
+
+**TEMPLATE DECISION:** "Improving error handling across the service" is an
+enhancement / new-functionality effort, not a report of broken behavior, so the
+**feature_request.md** template applies (label: `enhancement`).
+
+## 6. Read source files (to write a substantive, accurate issue)
+
+```
+$ cat projects/sentinel-app/src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat projects/sentinel-app/src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+
+Modules referenced in the issue: `src/errorHandler.js` (`handleError`) and
+`src/server.js` (`startServer`, `handleConnection`).
+
+## 7. Inspect the mock gh interface
+
+Read `bin/gh`. Supported subcommands: `auth status`, `issue list`, `issue view`,
+`label list`, `label create`, `issue create`. `issue create` accepts `--repo`,
+`--title`, `--body-file`/`--body`, repeated `--label`. Seed data lives in
+`.gh-mock/` (`seed_issues.tsv` was 0 bytes -> clean repo, no seeded duplicates).
+
+## 8. Verify auth and check for a similar/duplicate issue BEFORE creating
+
+```
+$ GH=/tmp/ci-iter2/config-decoy/without_skill/fixture/bin/gh
+
+$ "$GH" auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+
+$ "$GH" issue list --repo octo-eval/sentinel-app --search "error handling" --state all --limit 30
+            # (no output) -> exit 0, no matching issues
+
+$ "$GH" issue list --repo octo-eval/sentinel-app --search "error handler" --state all --limit 30
+            # (no output) -> exit 0, no matching issues
+
+$ "$GH" label list --repo octo-eval/sentinel-app
+bug         Something isn't working   d73a4a
+enhancement New feature or request    a2eeef
+```
+
+**DEDUP RESULT:** Two searches (all states) returned nothing — no existing or
+duplicate issue. Safe to create. The `enhancement` label already exists (matches
+the feature_request template), so no label creation needed.
+
+## 9. Create the issue
+
+Body written to `.gh-mock/new-issue-body.md` following the feature_request template
+(Description, Acceptance Criteria, Scope, Affected Components, Risk Assessment,
+Complexity, Related Issues), grounded in the actual source modules.
+
+```
+$ "$GH" issue create \
+    --repo octo-eval/sentinel-app \
+    --title "Improve error handling across the service" \
+    --body-file /tmp/ci-iter2/config-decoy/without_skill/fixture/.gh-mock/new-issue-body.md \
+    --label enhancement
+https://github.com/octo-eval/sentinel-app/issues/101
+[exit 0]
+```
+
+## 10. Verify the mock recorded the creation
+
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "Improve error handling across the service",
+  "labels": [
+    "enhancement"
+  ],
+  "body_len": 2415,
+  "ts": 1781586991
+}
+
+$ cat .gh-mock/calls.log
+gh auth status
+gh issue list --repo octo-eval/sentinel-app --search error handling --state all --limit 30
+gh issue list --repo octo-eval/sentinel-app --search error handler --state all --limit 30
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title Improve error handling across the service --body-file /tmp/ci-iter2/config-decoy/without_skill/fixture/.gh-mock/new-issue-body.md --label enhancement
+```
+
+---
+
+## Final result
+
+- **Repository targeted:** `octo-eval/sentinel-app`
+  - **Why:** Source of truth is the active project's own structured config,
+    `projects/sentinel-app/.rawgentic.json` (`repo.fullName = octo-eval/sentinel-app`).
+    The root `CLAUDE.md` "octo-eval/sentinel-legacy" is a stale/decoy value
+    (conflicting default branch, "legacy" naming, uncorroborated by README or any
+    git remote) and was correctly overridden by the per-project config.
+- **Template used:** `feature_request.md` (enhancement), since improving error
+  handling is new/enhanced functionality, not a bug report.
+- **Dedup check:** Performed two `issue list` searches (`error handling`,
+  `error handler`, `--state all`) before creating; no similar issue existed.
+- **Issue title:** "Improve error handling across the service"
+- **Label:** `enhancement` (pre-existing)
+- **Issue URL:** https://github.com/octo-eval/sentinel-app/issues/101

--- a/skills/create-issue-workspace/iteration-4/config-decoy/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/config-decoy/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 44246,
+  "duration_ms": 124396,
+  "total_duration_seconds": 124.4
+}

--- a/skills/create-issue-workspace/iteration-4/dedup-hit/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-4/dedup-hit/eval_metadata.json
@@ -1,0 +1,14 @@
+{
+  "eval_id": 2,
+  "eval_name": "dedup-hit",
+  "scenario": "dedup-hit",
+  "prompt": "I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it.",
+  "fixture_with": "/tmp/ci-iter2/dedup-hit/with_skill/fixture",
+  "fixture_without": "/tmp/ci-iter2/dedup-hit/without_skill/fixture",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Deduplication search ran",
+    "Existing matching issue (#42) surfaced to the user",
+    "Did not blindly create a duplicate"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-4/dedup-hit/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/dedup-hit/with_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "4 gh call(s) logged"
+    },
+    {
+      "text": "Deduplication search ran",
+      "passed": true,
+      "evidence": "issue-list-with-search logged = True"
+    },
+    {
+      "text": "Existing matching issue (#42) surfaced to the user",
+      "passed": true,
+      "evidence": "'#42'/'42' in transcript = True"
+    },
+    {
+      "text": "Did not blindly create a duplicate",
+      "passed": true,
+      "evidence": "no new issue created (acknowledged existing) -- acceptable"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 42130,
+    "duration_ms": 70142,
+    "total_duration_seconds": 70.1
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/dedup-hit/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/dedup-hit/with_skill/outputs/transcript.md
@@ -1,0 +1,107 @@
+# WF1 create-issue — Transcript
+
+## User request
+> I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it.
+
+## Skill under test
+`rawgentic:create-issue` (WF1: Issue Creation, lean). Acting as its orchestrator.
+
+---
+
+## Config-loading
+
+**1. Determine active project.**
+No prior `/rawgentic:switch` in this session and no `claude_docs/session_registry.jsonl` present. Fell back to `.rawgentic_workspace.json`:
+
+```json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+```
+
+Exactly one project with `active == true` → **sentinel-app** (path `./projects/sentinel-app`).
+
+**2. Disabled-skill check.** `disabledSkills` is `[]` → `create-issue` is NOT disabled. Workspace has no `bmadDetected: true` → no BMAD gate. Proceed.
+
+**3. Derive capabilities (tested source of truth).**
+
+```bash
+$ python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+{"config":{"version":1,"project":{"name":"sentinel-app","type":"web-service","description":"Realtime API service for the eval harness"},"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},"protectionLevel":"sandbox","techStack":["node","javascript"],"testing":{"frameworks":[{"name":"vitest","type":"unit","command":"npm test","testDir":"test"}]},"ci":{"provider":"github-actions","workflowDir":".github/workflows"},"documentation":{"primaryFiles":["README.md"],"format":"markdown"},"custom":{}},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+EXIT=0
+```
+
+Exit 0. Carried literals:
+- `capabilities.repo` = **octo-eval/sentinel-app**
+- `capabilities.default_branch` = **trunk**
+- project type = web-service ("Realtime API service for the eval harness"), tech stack node/javascript.
+
+---
+
+## Step 1: Understand the request
+
+**1. Classify.** "Add WebSocket support to the API so clients get realtime updates" = new functionality → **feature request** (not a bug). Unambiguous; no clarifying question needed.
+
+**2. Sufficiency.** Request is a clear, well-scoped feature ask.
+
+**3. Dedup check (run BEFORE drafting).**
+
+```bash
+$ ./bin/gh issue list --repo octo-eval/sentinel-app --search "WebSocket realtime updates" --limit 10
+42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z
+EXIT=0
+```
+
+View the candidate:
+
+```bash
+$ ./bin/gh issue view 42 --repo octo-eval/sentinel-app
+title:	stub
+state:	OPEN
+EXIT=0
+```
+
+Broader corroborating searches (to be thorough):
+
+```bash
+$ ./bin/gh issue list --repo octo-eval/sentinel-app --search "websocket" --limit 10
+42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z
+
+$ ./bin/gh issue list --repo octo-eval/sentinel-app --limit 20
+42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z
+EXIT=0
+```
+
+**Dedup result:** Existing OPEN issue **#42 — `feat(server): add WebSocket support for realtime updates`** (label `enhancement`, created 2026-05-01). The title is a near-verbatim match for the user's request.
+
+---
+
+## Decision (acting as the honest user)
+
+Per the skill Step 1.3: "If a listed issue plausibly covers the request, show it to the user and ask whether it already covers their need before proceeding."
+
+Shown to the user: issue **#42 "feat(server): add WebSocket support for realtime updates"** (OPEN, enhancement).
+
+Honest user determination: Issue #42 directly and fully covers the request ("add WebSocket support to the API so clients get realtime updates"). It is a genuine duplicate. The right action is to **NOT file a duplicate** and let the existing issue stand.
+
+**Therefore: no new issue is drafted (Step 2) and no new issue is created (Step 4).** The workflow stops at the dedup gate, as designed.
+
+---
+
+## Final outcome
+
+- **No issue created.** Request is already covered by existing OPEN issue **#42** (`feat(server): add WebSocket support for realtime updates`, enhancement) in `octo-eval/sentinel-app`.
+- To track/implement the WebSocket work, reference issue **#42** (e.g. `/rawgentic:implement-feature 42`) rather than opening a duplicate.
+- Step 5 "DONE" line not appended to `session_notes.md` because no issue was created in this run.

--- a/skills/create-issue-workspace/iteration-4/dedup-hit/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/dedup-hit/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 42130,
+  "duration_ms": 70142,
+  "total_duration_seconds": 70.1
+}

--- a/skills/create-issue-workspace/iteration-4/dedup-hit/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/dedup-hit/without_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "4 gh call(s) logged"
+    },
+    {
+      "text": "Deduplication search ran",
+      "passed": true,
+      "evidence": "issue-list-with-search logged = True"
+    },
+    {
+      "text": "Existing matching issue (#42) surfaced to the user",
+      "passed": true,
+      "evidence": "'#42'/'42' in transcript = True"
+    },
+    {
+      "text": "Did not blindly create a duplicate",
+      "passed": true,
+      "evidence": "no new issue created (acknowledged existing) -- acceptable"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 40980,
+    "duration_ms": 99110,
+    "total_duration_seconds": 99.1
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/dedup-hit/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/dedup-hit/without_skill/outputs/transcript.md
@@ -1,0 +1,171 @@
+# Transcript — Add WebSocket support issue request
+
+## User request
+> I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it.
+
+Instruction: inspect the project, check whether a similar issue already exists, and handle it sensibly before creating anything. Use the mock `gh` (absolute path).
+
+---
+
+## 1. Explore the project
+
+### `cat .rawgentic_workspace.json`
+```json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+```
+
+### `find projects/sentinel-app -type f`
+```
+projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md
+projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md
+projects/sentinel-app/.rawgentic.json
+projects/sentinel-app/README.md
+projects/sentinel-app/src/errorHandler.js
+projects/sentinel-app/src/server.js
+```
+
+### `cat projects/sentinel-app/.rawgentic.json` (key fields)
+```json
+{
+  "project": { "name": "sentinel-app", "type": "web-service", "description": "Realtime API service for the eval harness" },
+  "repo": { "provider": "github", "fullName": "octo-eval/sentinel-app", "defaultBranch": "trunk" },
+  "techStack": ["node", "javascript"]
+}
+```
+- Repo for `gh`: **octo-eval/sentinel-app**
+
+### `cat projects/sentinel-app/README.md`
+```
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+
+### Source
+`src/server.js`
+```js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+```
+`src/errorHandler.js`
+```js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+
+### Issue template that would apply (`feature_request.md`)
+```
+---
+name: Feature request
+about: Propose new functionality
+labels: enhancement
+---
+
+## Description
+## Acceptance Criteria
+1.
+## Scope
+In scope:
+-
+Out of scope:
+-
+## Affected Components
+## Risk Assessment
+## Complexity
+<!-- S / M / L / XL -->
+## Related Issues
+```
+(`bug_report.md` also present but not relevant — this is a feature.)
+
+---
+
+## 2. Verify auth (mock gh)
+
+Command:
+```
+/tmp/ci-iter2/dedup-hit/without_skill/fixture/bin/gh auth status
+```
+Output (stderr):
+```
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+```
+
+---
+
+## 3. Duplicate check (BEFORE creating anything)
+
+### Search 1 — "websocket"
+Command:
+```
+/tmp/ci-iter2/dedup-hit/without_skill/fixture/bin/gh issue list --repo octo-eval/sentinel-app --search "websocket" --state all --limit 20
+```
+Output:
+```
+42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z
+```
+
+### Search 2 — "realtime updates"
+Command:
+```
+/tmp/ci-iter2/dedup-hit/without_skill/fixture/bin/gh issue list --repo octo-eval/sentinel-app --search "realtime updates" --state all --limit 20
+```
+Output:
+```
+42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z
+```
+
+### Inspect the match
+Command:
+```
+/tmp/ci-iter2/dedup-hit/without_skill/fixture/bin/gh issue view 42 --repo octo-eval/sentinel-app
+```
+Output:
+```
+title:	stub
+state:	OPEN
+```
+
+### Dedup result
+**A near-identical issue already exists and is OPEN.**
+
+| # | Title | Labels | State | Updated |
+|---|-------|--------|-------|---------|
+| 42 | feat(server): add WebSocket support for realtime updates | enhancement | OPEN | 2026-05-01 |
+
+The user's request ("add WebSocket support to the API so clients get realtime updates") maps directly onto issue #42, both in subject (WebSocket support) and in motivation (realtime updates to clients). It is the same feature.
+
+---
+
+## 4. Decision — handle sensibly
+
+Creating a second issue would be a duplicate. The sensible action is **NOT to create a new issue**. Instead, point the user at the existing open issue #42 so the discussion/work stays consolidated there.
+
+- No `gh issue create` was run.
+- No `gh label create` was run (the existing `enhancement` label already covers it, and no new issue is being filed).
+
+---
+
+## 5. Final outcome
+
+No new issue created. An existing open issue already tracks this exact request:
+
+- **#42 — feat(server): add WebSocket support for realtime updates** (label: `enhancement`, state: OPEN)
+- URL: https://github.com/octo-eval/sentinel-app/issues/42
+
+Recommendation to the user: add any additional detail (acceptance criteria, affected components — `src/server.js#handleConnection`, `src/server.js#startServer`) as a comment on #42 rather than opening a duplicate. If #42 turns out to be stale or scoped differently than intended, reopen the conversation there or explicitly request a fresh issue.

--- a/skills/create-issue-workspace/iteration-4/dedup-hit/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/dedup-hit/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 40980,
+  "duration_ms": 99110,
+  "total_duration_seconds": 99.1
+}

--- a/skills/create-issue-workspace/iteration-4/false-premise/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-4/false-premise/eval_metadata.json
@@ -1,0 +1,12 @@
+{
+  "eval_id": 1,
+  "eval_name": "false-premise",
+  "scenario": "false-premise",
+  "prompt": "There's a bug in the ConnectionThrottler class in src/throttle.js -- it drops valid connections under load. Please open an issue to fix it.",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+    "Referenced the real connection-handling code (server.js / errorHandler.js)",
+    "Final issue does not present the nonexistent component as real"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-4/false-premise/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/false-premise/with_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "4 gh call(s) logged"
+    },
+    {
+      "text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+      "passed": true,
+      "evidence": "transcript acknowledges the component is absent"
+    },
+    {
+      "text": "Referenced the real connection-handling code (server.js / errorHandler.js)",
+      "passed": true,
+      "evidence": "real-file reference present = True"
+    },
+    {
+      "text": "Final issue does not present the nonexistent component as real",
+      "passed": true,
+      "evidence": "issue does not present the fake component as real"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 46602,
+    "duration_ms": 121844,
+    "total_duration_seconds": 121.8
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/false-premise/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/false-premise/with_skill/outputs/transcript.md
@@ -1,0 +1,113 @@
+# WF1 create-issue — Transcript
+
+Skill under test: `rawgentic:create-issue` (WF1, lean).
+User request: "There's a bug in the ConnectionThrottler class in src/throttle.js -- it drops valid connections under load. Please open an issue to fix it."
+
+## Config-loading
+
+Active project resolution: no prior `/rawgentic:switch`, no `claude_docs/session_registry.jsonl`. Fell back to `.rawgentic_workspace.json` → exactly one project `active == true`: `sentinel-app`. `disabledSkills` is empty `[]` and no `bmadDetected` → no STOP. Path `./projects/sentinel-app` resolved against workspace dir.
+
+```
+$ python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+{"config":{...},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,...}}
+EXIT=0
+```
+
+Carried literals: `capabilities.repo = octo-eval/sentinel-app`, `capabilities.default_branch = trunk`.
+
+## Step 1 — Understand the request
+
+Classification: **bug** (broken existing behavior — valid connections dropped under load).
+
+Dedup search (mocked gh, absolute path):
+```
+$ /tmp/ci-iter4/false-premise/with_skill/fixture/bin/gh issue list --repo octo-eval/sentinel-app --search "ConnectionThrottler throttle connection drop" --limit 10
+(no output)
+EXIT=0
+```
+No existing issues matched → no duplicate.
+
+## Step 2 — Verify referenced components (KEY FINDING)
+
+Project source tree:
+```
+$ find projects/sentinel-app -type f -not -path '*/.git/*'
+projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md
+projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md
+projects/sentinel-app/.rawgentic.json
+projects/sentinel-app/README.md
+projects/sentinel-app/src/errorHandler.js
+projects/sentinel-app/src/server.js
+```
+
+Verification of the user-named component:
+```
+$ grep -rn "ConnectionThrottler" projects/sentinel-app   → rc=1 (NO matches)
+$ grep -rin "throttle" projects/sentinel-app              → rc=1 (NO matches, any case)
+$ find projects/sentinel-app -iname "*throttle*"          → rc=0 (NO files found)
+```
+
+**Result: `ConnectionThrottler` does NOT exist. `src/throttle.js` does NOT exist.** The user's premise is false (hallucinated component).
+
+Actual source files read:
+- `src/server.js`:
+  ```js
+  // Sentinel API server entrypoint.
+  export function startServer(port) { /* ... */ }
+  export function handleConnection(socket) { /* ... */ }
+  ```
+- `src/errorHandler.js`:
+  ```js
+  // Centralized error handling.
+  export function handleError(err, req, res) { /* ... */ }
+  ```
+- `README.md`: "Realtime API service. Modules: src/server.js, src/errorHandler.js."
+
+Per `<quality-bar>` ("No hallucinated components — file against the real component instead, don't invent"), the verified-real connection-handling component is **`handleConnection(socket)` in `src/server.js`**.
+
+User-role response to the false premise: "Hm, maybe I got the name wrong — please look at the actual code and file it against whatever's really responsible." → File the bug against `handleConnection` / `src/server.js`.
+
+Bug template (`projects/sentinel-app/.github/ISSUE_TEMPLATE/bug_report.md`): Description / Steps to Reproduce / Expected / Actual / Environment / Error Logs (labels: bug).
+
+Labels available:
+```
+$ /tmp/.../bin/gh label list --repo octo-eval/sentinel-app
+bug          Something isn't working   d73a4a
+enhancement  New feature or request    a2eeef
+```
+
+## Step 3 — Draft (presented & approved)
+
+- Title: `fix(server): handleConnection drops valid connections under load`
+- Type: bug · Label: `bug` · Complexity: M
+- Body explicitly notes the reporter's `ConnectionThrottler`/`src/throttle.js` does not exist and the issue is re-targeted at `handleConnection` in `src/server.js`.
+- Acceptance criteria (3, testable): establish load repro; identify+document root cause; fix verified by a failing→passing vitest regression test.
+- Scope in/out (out: introducing a new throttler abstraction; errorHandler changes).
+- Affected components: only verified-real `src/server.js` (`handleConnection`, `startServer`).
+- Draft approved (reasonable draft per user).
+
+## Step 4 — Create the issue
+
+Body written to `/tmp/wf1-issue-body.md` via heredoc, then:
+```
+$ /tmp/ci-iter4/false-premise/with_skill/fixture/bin/gh issue create --repo octo-eval/sentinel-app \
+    --title "fix(server): handleConnection drops valid connections under load" \
+    --body-file /tmp/wf1-issue-body.md --label "bug"
+https://github.com/octo-eval/sentinel-app/issues/101
+EXIT=0
+```
+Cleanup: `rm -f /tmp/wf1-issue-body.md` (rc=0).
+
+## Step 5 — Wrap up
+
+Appended to `claude_docs/session_notes.md`:
+```
+### WF1 create-issue — DONE (https://github.com/octo-eval/sentinel-app/issues/101, bug, fix(server): handleConnection drops valid connections under load)
+```
+
+### Final result
+```
+Issue created: https://github.com/octo-eval/sentinel-app/issues/101
+Type: bug · Title: fix(server): handleConnection drops valid connections under load · Labels: bug
+```
+Did NOT offer to start implementation (WF2 boundary respected).

--- a/skills/create-issue-workspace/iteration-4/false-premise/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/false-premise/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 46602,
+  "duration_ms": 121844,
+  "total_duration_seconds": 121.8
+}

--- a/skills/create-issue-workspace/iteration-4/false-premise/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/false-premise/without_skill/grading.json
@@ -1,0 +1,35 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+      "passed": true,
+      "evidence": "transcript acknowledges the component is absent"
+    },
+    {
+      "text": "Referenced the real connection-handling code (server.js / errorHandler.js)",
+      "passed": true,
+      "evidence": "real-file reference present = True"
+    },
+    {
+      "text": "Final issue does not present the nonexistent component as real",
+      "passed": true,
+      "evidence": "issue does not present the fake component as real"
+    }
+  ],
+  "summary": {
+    "passed": 4,
+    "failed": 0,
+    "total": 4,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 42236,
+    "duration_ms": 113516,
+    "total_duration_seconds": 113.5
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/false-premise/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/false-premise/without_skill/outputs/transcript.md
@@ -1,0 +1,175 @@
+# Transcript — Create Issue (false-premise scenario)
+
+## User request
+
+> There's a bug in the ConnectionThrottler class in src/throttle.js -- it drops
+> valid connections under load. Please open an issue to fix it.
+
+## Approach
+
+Investigate the project before filing, verify the named component actually
+exists, then create a GitHub issue (via the mock `gh`) against whatever is
+really responsible — following the project's bug-report template.
+
+---
+
+## Commands and real output
+
+### 1. Set working directory
+```
+$ cd /tmp/ci-iter3/false-premise/without_skill/fixture && pwd
+/tmp/ci-iter3/false-premise/without_skill/fixture
+```
+
+### 2. Inspect workspace + project layout
+```
+$ ls -la ; cat .rawgentic_workspace.json ; ls -la projects/
+```
+- Workspace has one active, configured project: `sentinel-app` at `./projects/sentinel-app`.
+
+### 3. List project files + read project config
+```
+$ cd projects/sentinel-app && find . -type f -not -path './.git/*' | sort
+./.github/ISSUE_TEMPLATE/bug_report.md
+./.github/ISSUE_TEMPLATE/feature_request.md
+./.rawgentic.json
+./README.md
+./src/errorHandler.js
+./src/server.js
+```
+`.rawgentic.json` key facts:
+- repo: `octo-eval/sentinel-app`, provider github, defaultBranch `trunk`
+- type: web-service, techStack node/javascript, testing via vitest (`npm test`)
+
+There are only two source files: `src/server.js` and `src/errorHandler.js`.
+**No `src/throttle.js`.**
+
+### 4. Check for the named component
+```
+$ ls -la src/throttle.js
+ls: cannot access 'src/throttle.js': No such file or directory
+
+$ grep -rn "ConnectionThrottler" .
+NO MATCHES for ConnectionThrottler
+
+$ grep -rin "throttle" .
+NO MATCHES for throttle
+```
+**Finding: `src/throttle.js` does not exist, and there is no `ConnectionThrottler`
+class — nor any "throttle" reference at all — anywhere in the project.**
+
+### 5. Read the real source + README
+```
+$ cat src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+
+$ cat README.md
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+The component genuinely responsible for handling connections is
+`handleConnection(socket)` in **`src/server.js`** (server entrypoint), not a
+throttler class. This is where a "drops valid connections under load" bug
+belongs.
+
+### 6. Read the issue templates
+```
+$ cat .github/ISSUE_TEMPLATE/bug_report.md
+```
+Bug template (labels: bug) sections: Description / Steps to Reproduce /
+Expected Behavior / Actual Behavior / Environment / Error Logs.
+A feature_request.md template also exists (labels: enhancement). This is a bug,
+so the bug template applies.
+
+### 7. Inspect the mock gh + state dir
+```
+$ cat ../../bin/gh        # mock gh CLI (python)
+$ ls -la ../../.gh-mock/  # seed_issues.tsv (empty) — clean repo, no seeded issues
+```
+
+### 8. Auth, labels, and duplicate search (using absolute-path mock gh)
+```
+$ GH=/tmp/ci-iter3/false-premise/without_skill/fixture/bin/gh
+
+$ "$GH" auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+
+$ "$GH" label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+
+$ "$GH" issue list --repo octo-eval/sentinel-app --search "throttle connection drop" --state all --limit 20
+(no output — no matches)
+
+$ "$GH" issue list --repo octo-eval/sentinel-app --search "handleConnection drops connections" --state all --limit 20
+(no output — no matches)
+```
+`bug` label already exists (no need to create it). No duplicate/related issues
+found — safe to create a new one.
+
+### 9. Create the issue
+Body written to `projects/sentinel-app/.issue-body.md` following the bug
+template, and the issue filed against the real component:
+```
+$ "$GH" issue create \
+    --repo octo-eval/sentinel-app \
+    --title "Valid connections dropped under load in handleConnection (src/server.js)" \
+    --body-file projects/sentinel-app/.issue-body.md \
+    --label bug
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+### 10. Verify the mock recorded the creation
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "Valid connections dropped under load in handleConnection (src/server.js)",
+  "labels": [
+    "bug"
+  ],
+  "body_len": 1780,
+  "ts": 1781589177
+}
+
+$ cat .gh-mock/calls.log
+gh auth status
+gh label list --repo octo-eval/sentinel-app
+gh issue list --repo octo-eval/sentinel-app --search throttle connection drop --state all --limit 20
+gh issue list --repo octo-eval/sentinel-app --search handleConnection drops connections --state all --limit 20
+gh issue create --repo octo-eval/sentinel-app --title Valid connections dropped under load in handleConnection (src/server.js) --body-file projects/sentinel-app/.issue-body.md --label bug
+```
+
+---
+
+## What I found about the named component
+
+- **`src/throttle.js` does NOT exist.** `ls` reports "No such file or directory".
+- **There is no `ConnectionThrottler` class** — and not a single occurrence of
+  the substring "throttle" (case-insensitive) anywhere in the project.
+- The actual connection-handling code is `handleConnection(socket)` in
+  **`src/server.js`** (alongside `startServer(port)`). `src/errorHandler.js`
+  only holds `handleError(...)`.
+- Acting as the (low-information) user: the name was mis-remembered, so the
+  issue was filed against the component that is really responsible
+  (`handleConnection` in `src/server.js`), with the discrepancy documented
+  transparently in the issue body.
+
+## Final result
+
+- **Filed:** GitHub issue at https://github.com/octo-eval/sentinel-app/issues/101
+- **Repo:** octo-eval/sentinel-app
+- **Title:** "Valid connections dropped under load in handleConnection (src/server.js)"
+- **Label:** bug (pre-existing label; reused)
+- **Template:** project bug_report.md (Description / Steps to Reproduce /
+  Expected / Actual / Environment / Error Logs)
+- **Body:** explicitly records that `ConnectionThrottler`/`src/throttle.js` was
+  not found and that the bug belongs to `handleConnection` in `src/server.js`.

--- a/skills/create-issue-workspace/iteration-4/false-premise/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/false-premise/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 42236,
+  "duration_ms": 113516,
+  "total_duration_seconds": 113.5
+}

--- a/skills/create-issue-workspace/iteration-4/feature-quality/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-4/feature-quality/eval_metadata.json
@@ -1,0 +1,18 @@
+{
+  "eval_id": 1,
+  "eval_name": "feature-quality",
+  "scenario": "feature-quality",
+  "prompt": "Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.",
+  "fixture_with": "/tmp/ci-iter2/feature-quality/with_skill/fixture",
+  "fixture_without": "/tmp/ci-iter2/feature-quality/without_skill/fixture",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Issue was actually created via gh (not simulated)",
+    "Targets the config repo octo-eval/sentinel-app",
+    "Conventional title feat(scope): ...",
+    "At least 3 numbered acceptance criteria",
+    "Explicit in-scope AND out-of-scope sections",
+    "Risk assessment present",
+    "Deduplication search ran before creation"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-4/feature-quality/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/feature-quality/with_skill/grading.json
@@ -1,0 +1,55 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "3 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Targets the config repo octo-eval/sentinel-app",
+      "passed": true,
+      "evidence": "created repo = 'octo-eval/sentinel-app'"
+    },
+    {
+      "text": "Conventional title feat(scope): ...",
+      "passed": true,
+      "evidence": "title = 'feat(server): add WebSocket support for realtime updates'"
+    },
+    {
+      "text": "At least 3 numbered acceptance criteria",
+      "passed": true,
+      "evidence": "5 numbered items in body"
+    },
+    {
+      "text": "Explicit in-scope AND out-of-scope sections",
+      "passed": true,
+      "evidence": "in-scope=True out-of-scope=True"
+    },
+    {
+      "text": "Risk assessment present",
+      "passed": true,
+      "evidence": "'risk' in body = True"
+    },
+    {
+      "text": "Deduplication search ran before creation",
+      "passed": true,
+      "evidence": "issue-list-with-search logged = True"
+    }
+  ],
+  "summary": {
+    "passed": 8,
+    "failed": 0,
+    "total": 8,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 50200,
+    "duration_ms": 144559,
+    "total_duration_seconds": 144.6
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/feature-quality/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/feature-quality/with_skill/outputs/transcript.md
@@ -1,0 +1,173 @@
+# WF1 create-issue — Transcript
+
+**User request:** Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.
+
+---
+
+## Config-loading
+
+No prior `/rawgentic:switch` binding. `claude_docs/session_registry.jsonl` does not exist. Fell back to `.rawgentic_workspace.json` at the workspace root (the fixture dir).
+
+`.rawgentic_workspace.json`:
+```json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+```
+
+Exactly one project `active == true` → **sentinel-app**. `disabledSkills` is empty (create-issue not disabled). `bmadDetected` not present. `activeProject.path = ./projects/sentinel-app` resolved against the workspace root.
+
+### Derive capabilities (tested source of truth)
+
+Command (run from workspace root):
+```bash
+python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+```
+
+Output (EXIT=0):
+```json
+{"config":{"version":1,"project":{"name":"sentinel-app","type":"web-service","description":"Realtime API service for the eval harness"},"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},"protectionLevel":"sandbox","techStack":["node","javascript"],"testing":{"frameworks":[{"name":"vitest","type":"unit","command":"npm test","testDir":"test"}]},"ci":{"provider":"github-actions","workflowDir":".github/workflows"},"documentation":{"primaryFiles":["README.md"],"format":"markdown"},"custom":{}},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+```
+
+**Resolved capabilities carried forward as literals:**
+- `repo = octo-eval/sentinel-app`
+- `default_branch = trunk`
+- `project_type = web-service`, tests = vitest (`npm test`), CI = github-actions, no deploy/db/docker.
+
+---
+
+## Step 1: Understand the request
+
+**Classification:** Feature request (new functionality — WebSocket realtime push). Unambiguous.
+
+**Dedup check:**
+```bash
+/tmp/ci-iter4/feature-quality/with_skill/fixture/bin/gh issue list --repo octo-eval/sentinel-app --search "websocket realtime updates" --limit 10
+```
+Output: *(empty)* — EXIT=0. No existing/duplicate issues. Clean repo.
+
+---
+
+## Step 2: Draft (codebase grounding)
+
+Read the matching template `projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md` (Description, Acceptance Criteria, Scope, Affected Components, Risk Assessment, Complexity, Related Issues).
+
+**Verified components against real code (Grep/Read, no Serena):**
+- `src/server.js` — exports `startServer(port)` and `handleConnection(socket)`. (`handleConnection(socket)` is the natural WebSocket integration point.)
+- `src/errorHandler.js` — exports `handleError(err, req, res)`.
+- `README.md` — "Realtime API service. Modules: src/server.js, src/errorHandler.js."
+
+No hallucinated components. No fabricated metrics (the request gave none; criteria are grounded in existing components and the vitest harness). Request is appropriately scoped, not over-broad; out-of-scope items listed explicitly.
+
+Labels available (`gh label list`):
+```
+bug         Something isn't working   d73a4a
+enhancement New feature or request    a2eeef
+```
+No `websocket`/`api` scope label exists; used only the existing `enhancement` label (did not invent new labels).
+
+---
+
+## Step 3: User review
+
+Presented the draft below. User (cooperative) confirmed classification (feature) and replied **approved**.
+
+### Draft
+
+**Title:** `feat(server): add WebSocket support for realtime updates`
+**Type:** Feature · **Labels:** `enhancement` · **Complexity:** M
+
+> ## Description
+>
+> The sentinel-app API is described as a "Realtime API service" (README.md and the `.rawgentic.json` project description), but the current server (`src/server.js`) exposes only `startServer(port)` and `handleConnection(socket)` with no realtime push mechanism. Clients have no way to receive server-initiated updates and must poll. This issue requests first-class WebSocket support so the API can push realtime updates to connected clients.
+>
+> ## Acceptance Criteria
+> 1. The server accepts WebSocket upgrade requests on the existing HTTP listener started by `startServer(port)` (no separate port required).
+> 2. A new connection is routed through `handleConnection(socket)` in `src/server.js`, which establishes and tracks the WebSocket session.
+> 3. The server can broadcast a realtime update message to all connected WebSocket clients, and a unit test (vitest, `npm test`) asserts that a subscribed client receives a broadcast payload.
+> 4. WebSocket errors (failed upgrade, mid-session socket error, abrupt disconnect) are routed through the centralized error path in `src/errorHandler.js` (`handleError`) rather than crashing the process, with a regression test covering a forced socket error.
+> 5. Connections are cleaned up on close/disconnect so closed sockets are removed from the tracked-client set (verified by test).
+>
+> ## Scope
+> In scope: WebSocket upgrade handling on the existing listener, connection lifecycle tracking, server-to-client broadcast, error routing through `errorHandler`, unit tests.
+> Out of scope: auth/authz of WS clients, message schema/protocol versioning, horizontal-scaling fan-out (multi-instance pub/sub), client-side SDK changes (deferred to follow-ups).
+>
+> ## Affected Components (verified)
+> - `src/server.js` — `startServer(port)`, `handleConnection(socket)`
+> - `src/errorHandler.js` — `handleError(err, req, res)`
+> - `test/` — new vitest unit tests (`npm test`)
+>
+> ## Risk Assessment
+> Medium. Adds a long-lived connection type and shared client-tracking state to a currently stateless path; risks are resource leaks from untracked/unclosed sockets and unhandled socket errors crashing the process — mitigated by AC4 and AC5. Library choice (e.g. `ws`) left to implementation.
+>
+> ## Complexity: M
+>
+> ## Related Issues: None (dedup returned no results).
+
+---
+
+## Step 4: Create the issue
+
+Wrote body to `/tmp/wf1-issue-body.md` via heredoc (2689 bytes written).
+
+```bash
+/tmp/ci-iter4/feature-quality/with_skill/fixture/bin/gh issue create --repo octo-eval/sentinel-app \
+  --title "feat(server): add WebSocket support for realtime updates" \
+  --body-file /tmp/wf1-issue-body.md \
+  --label "enhancement"
+```
+Output (EXIT=0):
+```
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+**Liveness verification — `.gh-mock/created-issue.json`:**
+```json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "feat(server): add WebSocket support for realtime updates",
+  "labels": [
+    "enhancement"
+  ],
+  "body_len": 2683,
+  "ts": 1781590762
+}
+```
+
+**`.gh-mock/calls.log`:**
+```
+gh issue list --repo octo-eval/sentinel-app --search websocket realtime updates --limit 10
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title feat(server): add WebSocket support for realtime updates --body-file /tmp/wf1-issue-body.md --label enhancement
+```
+
+Cleanup: `rm -f /tmp/wf1-issue-body.md` (confirmed removed).
+
+---
+
+## Step 5: Wrap up
+
+Appended to `claude_docs/session_notes.md`:
+```
+### WF1 create-issue — DONE (https://github.com/octo-eval/sentinel-app/issues/101, feature, feat(server): add WebSocket support for realtime updates)
+```
+
+### Final result
+```
+Issue created: https://github.com/octo-eval/sentinel-app/issues/101
+Type: feature · Title: feat(server): add WebSocket support for realtime updates · Labels: enhancement
+```
+
+Did not offer to start implementation (WF2 is invoked separately by the user).

--- a/skills/create-issue-workspace/iteration-4/feature-quality/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/feature-quality/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 50200,
+  "duration_ms": 144559,
+  "total_duration_seconds": 144.6
+}

--- a/skills/create-issue-workspace/iteration-4/feature-quality/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/feature-quality/without_skill/grading.json
@@ -1,0 +1,55 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Issue was actually created via gh (not simulated)",
+      "passed": true,
+      "evidence": "created-issue.json present"
+    },
+    {
+      "text": "Targets the config repo octo-eval/sentinel-app",
+      "passed": true,
+      "evidence": "created repo = 'octo-eval/sentinel-app'"
+    },
+    {
+      "text": "Conventional title feat(scope): ...",
+      "passed": false,
+      "evidence": "title = 'Add WebSocket support for realtime updates in the API'"
+    },
+    {
+      "text": "At least 3 numbered acceptance criteria",
+      "passed": true,
+      "evidence": "5 numbered items in body"
+    },
+    {
+      "text": "Explicit in-scope AND out-of-scope sections",
+      "passed": true,
+      "evidence": "in-scope=True out-of-scope=True"
+    },
+    {
+      "text": "Risk assessment present",
+      "passed": true,
+      "evidence": "'risk' in body = True"
+    },
+    {
+      "text": "Deduplication search ran before creation",
+      "passed": true,
+      "evidence": "issue-list-with-search logged = True"
+    }
+  ],
+  "summary": {
+    "passed": 7,
+    "failed": 1,
+    "total": 8,
+    "pass_rate": 0.875
+  },
+  "timing": {
+    "total_tokens": 42293,
+    "duration_ms": 91500,
+    "total_duration_seconds": 91.5
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/feature-quality/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/feature-quality/without_skill/outputs/transcript.md
@@ -1,0 +1,213 @@
+# Transcript — Create issue: WebSocket support for realtime updates (sentinel-app)
+
+User request: Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.
+
+All `gh` calls use the mock at the absolute path
+`/tmp/ci-iter2/feature-quality/without_skill/fixture/bin/gh`.
+
+---
+
+## 1. Set working directory
+
+```
+$ cd /tmp/ci-iter2/feature-quality/without_skill/fixture && pwd
+/tmp/ci-iter2/feature-quality/without_skill/fixture
+```
+
+## 2. Explore workspace + project
+
+```
+$ ls -la
+.gh-mock/  .rawgentic_workspace.json  bin/  claude_docs/  hooks/  outputs/  projects/
+
+$ cat .rawgentic_workspace.json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+
+$ ls -la projects/sentinel-app/
+.github/  .rawgentic.json  README.md  src/
+```
+
+### Project config
+
+```
+$ cat projects/sentinel-app/.rawgentic.json
+{
+  "version": 1,
+  "project": {
+    "name": "sentinel-app",
+    "type": "web-service",
+    "description": "Realtime API service for the eval harness"
+  },
+  "repo": {
+    "provider": "github",
+    "fullName": "octo-eval/sentinel-app",
+    "defaultBranch": "trunk"
+  },
+  "protectionLevel": "sandbox",
+  "techStack": ["node", "javascript"],
+  "testing": {
+    "frameworks": [
+      { "name": "vitest", "type": "unit", "command": "npm test", "testDir": "test" }
+    ]
+  },
+  "ci": { "provider": "github-actions", "workflowDir": ".github/workflows" },
+  "documentation": { "primaryFiles": ["README.md"], "format": "markdown" },
+  "custom": {}
+}
+```
+
+Key facts: repo = `octo-eval/sentinel-app`, default branch `trunk`, stack node/javascript, tests via vitest (`npm test`).
+
+### README
+
+```
+$ cat projects/sentinel-app/README.md
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+
+### Source files
+
+```
+$ cat projects/sentinel-app/src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat projects/sentinel-app/src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+
+### Issue templates
+
+```
+$ ls projects/sentinel-app/.github/ISSUE_TEMPLATE/
+bug_report.md  feature_request.md
+
+$ cat projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md
+---
+name: Feature request
+about: Propose new functionality
+labels: enhancement
+---
+
+## Description
+
+## Acceptance Criteria
+1.
+
+## Scope
+In scope:
+-
+Out of scope:
+-
+
+## Affected Components
+
+## Risk Assessment
+
+## Complexity
+<!-- S / M / L / XL -->
+
+## Related Issues
+```
+
+This is a feature request, so the `feature_request.md` template applies. Its sections were followed exactly, and its declared `labels: enhancement` was used.
+
+## 3. Verify auth
+
+```
+$ /tmp/.../bin/gh auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+```
+
+## 4. Check for an existing similar issue (dedup)
+
+```
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "websocket" --state all --limit 50
+(no output — no matching issues)
+
+$ /tmp/.../bin/gh issue list --repo octo-eval/sentinel-app --search "realtime updates" --state all --limit 50
+(no output — no matching issues)
+```
+
+No existing open or closed issue matches "websocket" or "realtime updates". Safe to create a new one.
+
+## 5. Confirm labels exist
+
+```
+$ /tmp/.../bin/gh label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+```
+
+`enhancement` exists already (matches the template), so no label creation needed.
+
+## 6. Write the issue body (template-conformant)
+
+Body written to `outputs/issue-body.md`, following every section of `feature_request.md`
+(Description, Acceptance Criteria, Scope, Affected Components, Risk Assessment, Complexity,
+Related Issues) and grounded in the actual source modules `src/server.js` (`handleConnection`)
+and `src/errorHandler.js` (`handleError`).
+
+## 7. Create the issue with the mock gh
+
+```
+$ /tmp/.../bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "Add WebSocket support for realtime updates in the API" \
+    --body-file outputs/issue-body.md \
+    --label enhancement
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+## 8. Verify mock recorded the creation
+
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "Add WebSocket support for realtime updates in the API",
+  "labels": [
+    "enhancement"
+  ],
+  "body_len": 2228,
+  "ts": 1781586946
+}
+
+$ cat .gh-mock/calls.log
+gh auth status
+gh issue list --repo octo-eval/sentinel-app --search websocket --state all --limit 50
+gh issue list --repo octo-eval/sentinel-app --search realtime updates --state all --limit 50
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title Add WebSocket support for realtime updates in the API --body-file outputs/issue-body.md --label enhancement
+
+$ ls -la .gh-mock/created-issue-body.md
+-rw-rw-r-- 1 rocky00717 rocky00717 2232 .gh-mock/created-issue-body.md
+```
+
+---
+
+## Final result
+
+Issue created successfully against `octo-eval/sentinel-app` with the `enhancement` label,
+following the project's `feature_request.md` template. No duplicate existed.
+
+**Issue URL: https://github.com/octo-eval/sentinel-app/issues/101**

--- a/skills/create-issue-workspace/iteration-4/feature-quality/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/feature-quality/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 42293,
+  "duration_ms": 91500,
+  "total_duration_seconds": 91.5
+}

--- a/skills/create-issue-workspace/iteration-4/over-broad/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-4/over-broad/eval_metadata.json
@@ -1,0 +1,11 @@
+{
+  "eval_id": 3,
+  "eval_name": "over-broad",
+  "scenario": "over-broad",
+  "prompt": "I want to completely overhaul error handling, logging, monitoring, retries, and alerting across the entire service. Open an issue for it.",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+    "Issue defines explicit out-of-scope / deferred boundaries"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-4/over-broad/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/over-broad/with_skill/grading.json
@@ -1,0 +1,30 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "11 gh call(s) logged"
+    },
+    {
+      "text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+      "passed": true,
+      "evidence": "transcript proposes splitting or narrowing"
+    },
+    {
+      "text": "Issue defines explicit out-of-scope / deferred boundaries",
+      "passed": true,
+      "evidence": "explicit scope boundary in body = True"
+    }
+  ],
+  "summary": {
+    "passed": 3,
+    "failed": 0,
+    "total": 3,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 59635,
+    "duration_ms": 827924,
+    "total_duration_seconds": 827.9
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/over-broad/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/over-broad/with_skill/outputs/transcript.md
@@ -1,0 +1,157 @@
+# WF1 create-issue — Transcript
+
+Skill under test: `rawgentic:create-issue` (WF1, lean). Orchestrator followed it precisely.
+GitHub CLI is mocked at `/tmp/ci-iter4/over-broad/with_skill/fixture/bin/gh` (invoked by absolute/relative path under the fixture, never bare `gh`).
+
+## User request
+> I want to completely overhaul error handling, logging, monitoring, retries, and alerting across the entire service. Open an issue for it.
+
+This is the canonical **over-broad ask** the skill's `<quality-bar>` warns about: five distinct cross-cutting concerns ("do everything") across the whole service.
+
+---
+
+## Config loading
+
+Command (from workspace root):
+```bash
+python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+```
+Output (EXIT=0):
+```json
+{"config":{"version":1,"project":{"name":"sentinel-app","type":"web-service","description":"Realtime API service for the eval harness"},"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},"protectionLevel":"sandbox","techStack":["node","javascript"],"testing":{"frameworks":[{"name":"vitest","type":"unit","command":"npm test","testDir":"test"}]},"ci":{"provider":"github-actions","workflowDir":".github/workflows"},"documentation":{"primaryFiles":["README.md"],"format":"markdown"},"custom":{}},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+```
+
+Active-project resolution:
+- `.rawgentic_workspace.json` has exactly one project `active: true` → `sentinel-app`. (Session registry `claude_docs/session_registry.jsonl` was absent; fell back to workspace file, single active.)
+- `disabledSkills: []` → create-issue not disabled.
+- `bmadDetected` not present → no BMAD gate.
+
+Carried literals: **repo = `octo-eval/sentinel-app`**, **default_branch = `trunk`**.
+
+---
+
+## Step 1: Understand the request
+
+**Classification: feature request.** Grounding the codebase first:
+
+```
+projects/sentinel-app/src/server.js        -> startServer(port), handleConnection(socket)   [stubs]
+projects/sentinel-app/src/errorHandler.js  -> handleError(err, req, res)                     [stub]
+projects/sentinel-app/README.md            -> "Realtime API service. Modules: src/server.js, src/errorHandler.js."
+```
+
+```bash
+grep -rn "retr|logg|monitor|alert|metric" projects/sentinel-app/src/   # EXIT=1, no matches
+```
+None of the five concerns exist in source yet → this is greenfield resilience/observability work, **feature**, not a bug.
+
+### Dedup check (Step 1.3)
+```bash
+./bin/gh issue list --repo octo-eval/sentinel-app --search "error handling logging monitoring retries alerting" --limit 10   # (empty)
+./bin/gh issue list --repo octo-eval/sentinel-app --search "observability" --limit 10                                       # (empty)
+./bin/gh issue list --repo octo-eval/sentinel-app --search "error" --limit 10                                               # (empty)
+./bin/gh issue list --repo octo-eval/sentinel-app --limit 20                                                                # (empty)
+```
+Clean repo, no duplicates.
+
+### Labels (Step 4.2, checked early)
+```bash
+./bin/gh label list --repo octo-eval/sentinel-app
+# bug          Something isn't working   d73a4a
+# enhancement  New feature or request    a2eeef
+```
+Only `enhancement`/`bug` exist. No fabricated component labels created (skill: create one "only if needed"). All issues are features → `enhancement`.
+
+---
+
+## How the breadth was handled (`<quality-bar>`: "Bound an over-broad ask")
+
+The ask bundles five separable workstreams with different acceptance criteria. The skill permits either splitting OR one issue with an explicit out-of-scope list. I (orchestrator) chose a **split**, because each concern is independently implementable and lumping them would produce one unreviewable mega-issue (and would exceed the ~2000-word "probably several issues" heuristic).
+
+Acting as the user, the answer to the structuring decision was: *"whatever you think is best — you decide how to structure it."* So the orchestrator made the call and the user approved the resulting reasonable draft.
+
+**Chosen structure: 1 umbrella tracking issue + 5 scoped child issues.** Sequencing baked in (errors → logging → monitoring → retries → alerting) since later concerns consume earlier ones. Shared conventions (one log format, one error contract, env-var thresholds) pinned in the umbrella so the children compose instead of conflicting. Every issue's Affected Components lists only the two real files/three real symbols; thresholds are env-configurable per AC; no fabricated metrics/targets.
+
+---
+
+## Step 2-3: Drafts (presented and approved)
+
+Template used: `projects/sentinel-app/.github/ISSUE_TEMPLATE/feature_request.md`
+(Description / Acceptance Criteria / Scope in+out / Affected Components / Risk Assessment / Complexity / Related Issues).
+
+### Draft proposal shown to user
+- **Umbrella** `feat(reliability): resilience & observability overhaul (tracking)` — links all five, conventions + sequencing, complexity XL.
+- **#errors** `feat(errors): standardize error handling and error contract` — `handleError` contract, route `startServer`/`handleConnection` errors through it, operational vs programmer errors. M.
+- **#logging** `feat(logging): structured request and connection logging` — JSON logger, correlation ids, `LOG_LEVEL`. M.
+- **#monitoring** `feat(monitoring): health and metrics endpoints` — `/healthz`, `/metrics` counters wired to real lifecycle points. M.
+- **#retries** `feat(reliability): connection retry with backoff in handleConnection` — bounded exp backoff, retryable-only gating. M.
+- **#alerting** `feat(alerting): error-rate and health alerting` — threshold rules over metrics, pluggable notifier, cooldown/de-dup. M.
+
+Each draft carries explicit **out-of-scope** lines pushing the other four concerns out, so the boundaries don't overlap. User reviewed and approved ("whatever you think is best").
+
+---
+
+## Step 4: Create the issues
+
+Bodies written to temp files via `cat << 'EOF'` heredocs, then:
+
+```bash
+./bin/gh issue create --repo octo-eval/sentinel-app --title "feat(reliability): resilience & observability overhaul (tracking)" --body-file /tmp/wf1-issue-umbrella.md   --label "enhancement"
+./bin/gh issue create --repo octo-eval/sentinel-app --title "feat(errors): standardize error handling and error contract"      --body-file /tmp/wf1-issue-errors.md     --label "enhancement"
+./bin/gh issue create --repo octo-eval/sentinel-app --title "feat(logging): structured request and connection logging"         --body-file /tmp/wf1-issue-logging.md    --label "enhancement"
+./bin/gh issue create --repo octo-eval/sentinel-app --title "feat(monitoring): health and metrics endpoints"                   --body-file /tmp/wf1-issue-monitoring.md --label "enhancement"
+./bin/gh issue create --repo octo-eval/sentinel-app --title "feat(reliability): connection retry with backoff in handleConnection" --body-file /tmp/wf1-issue-retries.md --label "enhancement"
+./bin/gh issue create --repo octo-eval/sentinel-app --title "feat(alerting): error-rate and health alerting"                   --body-file /tmp/wf1-issue-alerting.md   --label "enhancement"
+```
+
+Each returned: `https://github.com/octo-eval/sentinel-app/issues/101`
+(The mock always returns #101 and overwrites its single `created-issue.json`/`created-issue-body.md` record; each creation was snapshotted into `outputs/created/` so all six survive — see below.)
+
+### Recorded creations (from `.gh-mock/created-issue.json` snapshots)
+| # | title | repo | labels | body_len |
+|---|-------|------|--------|----------|
+| 01 umbrella | feat(reliability): resilience & observability overhaul (tracking) | octo-eval/sentinel-app | [enhancement] | 2281 |
+| 02 errors | feat(errors): standardize error handling and error contract | octo-eval/sentinel-app | [enhancement] | 1941 |
+| 03 logging | feat(logging): structured request and connection logging | octo-eval/sentinel-app | [enhancement] | 1634 |
+| 04 monitoring | feat(monitoring): health and metrics endpoints | octo-eval/sentinel-app | [enhancement] | 1818 |
+| 05 retries | feat(reliability): connection retry with backoff in handleConnection | octo-eval/sentinel-app | [enhancement] | 1676 |
+| 06 alerting | feat(alerting): error-rate and health alerting | octo-eval/sentinel-app | [enhancement] | 1898 |
+
+Cleanup: `rm -f /tmp/wf1-issue-*.md` (all removed).
+
+---
+
+## Step 5: Wrap up
+
+Appended to `claude_docs/session_notes.md`:
+```
+### WF1 create-issue — DONE (split: over-broad ask bounded into 1 umbrella + 5 scoped issues)
+- feature, octo-eval/sentinel-app
+- https://github.com/octo-eval/sentinel-app/issues/101 — feat(reliability): resilience & observability overhaul (tracking) [umbrella]
+- feat(errors): ... / feat(logging): ... / feat(monitoring): ... / feat(reliability) retry ... / feat(alerting): ...
+```
+
+Did NOT offer to start implementation (WF2 is invoked separately).
+
+### Full `.gh-mock/calls.log`
+```
+gh issue list --repo octo-eval/sentinel-app --search error handling logging monitoring retries alerting --limit 10
+gh issue list --repo octo-eval/sentinel-app --search observability --limit 10
+gh issue list --repo octo-eval/sentinel-app --search error --limit 10
+gh issue list --repo octo-eval/sentinel-app --limit 20
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title feat(reliability): resilience & observability overhaul (tracking) --body-file /tmp/wf1-issue-umbrella.md --label enhancement
+gh issue create --repo octo-eval/sentinel-app --title feat(errors): standardize error handling and error contract --body-file /tmp/wf1-issue-errors.md --label enhancement
+gh issue create --repo octo-eval/sentinel-app --title feat(logging): structured request and connection logging --body-file /tmp/wf1-issue-logging.md --label enhancement
+gh issue create --repo octo-eval/sentinel-app --title feat(monitoring): health and metrics endpoints --body-file /tmp/wf1-issue-monitoring.md --label enhancement
+gh issue create --repo octo-eval/sentinel-app --title feat(reliability): connection retry with backoff in handleConnection --body-file /tmp/wf1-issue-retries.md --label enhancement
+gh issue create --repo octo-eval/sentinel-app --title feat(alerting): error-rate and health alerting --body-file /tmp/wf1-issue-alerting.md --label enhancement
+```
+
+---
+
+## Result
+
+**Split, not one issue.** The over-broad "overhaul everything" ask was bounded into **1 umbrella tracking issue + 5 scoped child issues** on `octo-eval/sentinel-app`, all `enhancement`, conventional `feat(scope):` titles.
+
+**Scope boundaries each issue carried:** every child has an explicit in-scope line and an out-of-scope list that pushes the other four concerns away (e.g. feat(logging) declares the error-contract, metrics, and alerting all out-of-scope), plus per-concern dependencies and sequencing. The umbrella owns the shared conventions (one log format, one error contract, env-var thresholds) and closes only after all five children. All Affected Components reference only the verified-real `src/server.js` (`startServer`, `handleConnection`) and `src/errorHandler.js` (`handleError`); no fabricated symbols, metrics, or targets.

--- a/skills/create-issue-workspace/iteration-4/over-broad/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/over-broad/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 59635,
+  "duration_ms": 827924,
+  "total_duration_seconds": 827.9
+}

--- a/skills/create-issue-workspace/iteration-4/over-broad/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/over-broad/without_skill/grading.json
@@ -1,0 +1,30 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "5 gh call(s) logged"
+    },
+    {
+      "text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+      "passed": true,
+      "evidence": "transcript proposes splitting or narrowing"
+    },
+    {
+      "text": "Issue defines explicit out-of-scope / deferred boundaries",
+      "passed": true,
+      "evidence": "explicit scope boundary in body = True"
+    }
+  ],
+  "summary": {
+    "passed": 3,
+    "failed": 0,
+    "total": 3,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 43324,
+    "duration_ms": 110927,
+    "total_duration_seconds": 110.9
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/over-broad/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/over-broad/without_skill/outputs/transcript.md
@@ -1,0 +1,176 @@
+# Transcript — Create issue for reliability overhaul
+
+User request: "I want to completely overhaul error handling, logging, monitoring,
+retries, and alerting across the entire service. Open an issue for it."
+
+All `gh` calls use the absolute path to the mocked CLI:
+`/tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh`
+
+---
+
+## 1. Enter working directory
+
+```
+$ cd /tmp/ci-iter3/over-broad/without_skill/fixture && pwd && ls -la
+/tmp/ci-iter3/over-broad/without_skill/fixture
+total 36
+drwxrwxr-x 8 rocky00717 rocky00717 4096 Jun 15 22:51 .
+drwxrwxr-x 3 rocky00717 rocky00717 4096 Jun 15 22:51 ..
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 .gh-mock
+-rw-rw-r-- 1 rocky00717 rocky00717  310 Jun 15 22:51 .rawgentic_workspace.json
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 bin
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 claude_docs
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 hooks
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 outputs
+drwxrwxr-x 3 rocky00717 rocky00717 4096 Jun 15 22:51 projects
+```
+
+## 2. Inspect workspace + project
+
+```
+$ cat .rawgentic_workspace.json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      ...
+    }
+  ]
+}
+
+$ cat projects/sentinel-app/.rawgentic.json
+{
+  "version": 1,
+  "project": { "name": "sentinel-app", "type": "web-service",
+               "description": "Realtime API service for the eval harness" },
+  "repo": { "provider": "github", "fullName": "octo-eval/sentinel-app",
+            "defaultBranch": "trunk" },
+  "techStack": ["node", "javascript"],
+  "testing": { "frameworks": [ { "name": "vitest", "command": "npm test", "testDir": "test" } ] },
+  ...
+}
+
+$ cat projects/sentinel-app/README.md
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+```
+
+Source (stubs):
+
+```
+$ cat projects/sentinel-app/src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat projects/sentinel-app/src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+
+Issue templates available: `.github/ISSUE_TEMPLATE/bug_report.md` and
+`feature_request.md` (the feature template has Description / Acceptance Criteria /
+Scope [In/Out] / Affected Components / Risk Assessment / Complexity / Related
+Issues — I followed this structure).
+
+## 3. Check auth, dedup existing issues, list labels (mock gh)
+
+```
+$ /tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+
+$ /tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh issue list \
+    --repo octo-eval/sentinel-app --search "error handling logging monitoring" \
+    --state all --limit 50
+(no output — no matching issues)
+
+$ /tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh issue list \
+    --repo octo-eval/sentinel-app --state all --limit 100
+(no output — clean repo, no dedup hit)
+
+$ /tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh label list \
+    --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+```
+
+Decision: no duplicate exists. Available labels are `bug` and `enhancement`;
+this is an enhancement, so I used the `enhancement` label (no new label needed).
+
+## 4. Scoping decision
+
+The request names five distinct cross-cutting concerns (error handling, logging,
+monitoring, retries, alerting) "across the entire service." Filing five separate
+issues for a two-stub-file service would be over-fragmented; filing one vague
+"do everything" blob would be unactionable. As the implementer I chose **one
+tracking/epic issue** that explicitly carves the work into the five separable
+deliverables with hard In-scope / Out-of-scope boundaries, acceptance criteria,
+a suggested implementation order, and Complexity = XL. This honors the user's
+"open an issue" (singular) while keeping each concern independently shippable.
+
+Out-of-scope boundaries carried on the issue:
+- No unrelated business-logic / product features.
+- No provisioning of external infra (hosted Prometheus/Grafana, PagerDuty) —
+  only the in-app surface (metrics endpoint + alert rules).
+- No distributed tracing (deferred; follow-up built on correlation IDs added here).
+- No auth / rate limiting / other reliability concerns not named in the request.
+
+## 5. Create the issue
+
+Body written to `outputs/issue-body.md`, then:
+
+```
+$ /tmp/ci-iter3/over-broad/without_skill/fixture/bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "Reliability overhaul: error handling, logging, monitoring, retries & alerting (epic)" \
+    --body-file outputs/issue-body.md \
+    --label enhancement
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+## 6. Verify the mock recorded it
+
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "Reliability overhaul: error handling, logging, monitoring, retries & alerting (epic)",
+  "labels": [
+    "enhancement"
+  ],
+  "body_len": 4141,
+  "ts": 1781589198
+}
+
+$ cat .gh-mock/calls.log
+gh auth status
+gh issue list --repo octo-eval/sentinel-app --search error handling logging monitoring --state all --limit 50
+gh issue list --repo octo-eval/sentinel-app --state all --limit 100
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title Reliability overhaul: ... --body-file outputs/issue-body.md --label enhancement
+
+$ wc -l .gh-mock/created-issue-body.md
+88 .gh-mock/created-issue-body.md
+```
+
+---
+
+## Final result
+
+- **Issues filed:** 1 (a tracking/epic issue)
+- **Issue URL:** https://github.com/octo-eval/sentinel-app/issues/101
+- **Title:** Reliability overhaul: error handling, logging, monitoring, retries & alerting (epic)
+- **Label:** enhancement
+- **Scope boundaries:** Covers exactly the five named concerns applied to the
+  existing `src/server.js` + `src/errorHandler.js` paths, broken into five
+  separable per-PR deliverables with a suggested order. Explicitly excludes:
+  unrelated business/product features; provisioning external infra (Prometheus/
+  Grafana/PagerDuty) beyond the in-app metrics endpoint + alert rules; distributed
+  tracing (deferred follow-up); and any reliability concern not named (auth, rate
+  limiting). All thresholds required to be env-configurable.

--- a/skills/create-issue-workspace/iteration-4/over-broad/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/over-broad/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 43324,
+  "duration_ms": 110927,
+  "total_duration_seconds": 110.9
+}

--- a/skills/create-issue-workspace/iteration-4/review.html
+++ b/skills/create-issue-workspace/iteration-4/review.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    const EMBEDDED_DATA = {"skill_name": "rawgentic:create-issue (slim) vs baseline", "runs": [{"id": "false-premise-with_skill", "prompt": "There's a bug in the ConnectionThrottler class in src/throttle.js -- it drops valid connections under load. Please open an issue to fix it.", "eval_id": 1, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase", "passed": true, "evidence": "transcript acknowledges the component is absent"}, {"text": "Referenced the real connection-handling code (server.js / errorHandler.js)", "passed": true, "evidence": "real-file reference present = True"}, {"text": "Final issue does not present the nonexistent component as real", "passed": true, "evidence": "issue does not present the fake component as real"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 46602, "duration_ms": 121844, "total_duration_seconds": 121.8}}}, {"id": "false-premise-without_skill", "prompt": "There's a bug in the ConnectionThrottler class in src/throttle.js -- it drops valid connections under load. Please open an issue to fix it.", "eval_id": 1, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase", "passed": true, "evidence": "transcript acknowledges the component is absent"}, {"text": "Referenced the real connection-handling code (server.js / errorHandler.js)", "passed": true, "evidence": "real-file reference present = True"}, {"text": "Final issue does not present the nonexistent component as real", "passed": true, "evidence": "issue does not present the fake component as real"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 42236, "duration_ms": 113516, "total_duration_seconds": 113.5}}}, {"id": "feature-quality-with_skill", "prompt": "Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.", "eval_id": 1, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "3 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Targets the config repo octo-eval/sentinel-app", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app'"}, {"text": "Conventional title feat(scope): ...", "passed": true, "evidence": "title = 'feat(server): add WebSocket support for realtime updates'"}, {"text": "At least 3 numbered acceptance criteria", "passed": true, "evidence": "5 numbered items in body"}, {"text": "Explicit in-scope AND out-of-scope sections", "passed": true, "evidence": "in-scope=True out-of-scope=True"}, {"text": "Risk assessment present", "passed": true, "evidence": "'risk' in body = True"}, {"text": "Deduplication search ran before creation", "passed": true, "evidence": "issue-list-with-search logged = True"}], "summary": {"passed": 8, "failed": 0, "total": 8, "pass_rate": 1.0}, "timing": {"total_tokens": 50200, "duration_ms": 144559, "total_duration_seconds": 144.6}}}, {"id": "feature-quality-without_skill", "prompt": "Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.", "eval_id": 1, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Targets the config repo octo-eval/sentinel-app", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app'"}, {"text": "Conventional title feat(scope): ...", "passed": false, "evidence": "title = 'Add WebSocket support for realtime updates in the API'"}, {"text": "At least 3 numbered acceptance criteria", "passed": true, "evidence": "5 numbered items in body"}, {"text": "Explicit in-scope AND out-of-scope sections", "passed": true, "evidence": "in-scope=True out-of-scope=True"}, {"text": "Risk assessment present", "passed": true, "evidence": "'risk' in body = True"}, {"text": "Deduplication search ran before creation", "passed": true, "evidence": "issue-list-with-search logged = True"}], "summary": {"passed": 7, "failed": 1, "total": 8, "pass_rate": 0.875}, "timing": {"total_tokens": 42293, "duration_ms": 91500, "total_duration_seconds": 91.5}}}, {"id": "dedup-hit-with_skill", "prompt": "I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it.", "eval_id": 2, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Deduplication search ran", "passed": true, "evidence": "issue-list-with-search logged = True"}, {"text": "Existing matching issue (#42) surfaced to the user", "passed": true, "evidence": "'#42'/'42' in transcript = True"}, {"text": "Did not blindly create a duplicate", "passed": true, "evidence": "no new issue created (acknowledged existing) -- acceptable"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 42130, "duration_ms": 70142, "total_duration_seconds": 70.1}}}, {"id": "dedup-hit-without_skill", "prompt": "I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it.", "eval_id": 2, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Deduplication search ran", "passed": true, "evidence": "issue-list-with-search logged = True"}, {"text": "Existing matching issue (#42) surfaced to the user", "passed": true, "evidence": "'#42'/'42' in transcript = True"}, {"text": "Did not blindly create a duplicate", "passed": true, "evidence": "no new issue created (acknowledged existing) -- acceptable"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 40980, "duration_ms": 99110, "total_duration_seconds": 99.1}}}, {"id": "vague-perf-with_skill", "prompt": "The app feels slow sometimes. Can you make an issue about that?", "eval_id": 2, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)", "passed": true, "evidence": "transcript shows clarification/under-specification handling"}, {"text": "Did not fabricate specific performance targets the user never provided", "passed": true, "evidence": "no invented numeric targets"}], "summary": {"passed": 3, "failed": 0, "total": 3, "pass_rate": 1.0}, "timing": {"total_tokens": 47134, "duration_ms": 150332, "total_duration_seconds": 150.3}}}, {"id": "vague-perf-without_skill", "prompt": "The app feels slow sometimes. Can you make an issue about that?", "eval_id": 2, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)", "passed": true, "evidence": "transcript shows clarification/under-specification handling"}, {"text": "Did not fabricate specific performance targets the user never provided", "passed": true, "evidence": "no invented numeric targets"}], "summary": {"passed": 3, "failed": 0, "total": 3, "pass_rate": 1.0}, "timing": {"total_tokens": 41909, "duration_ms": 92843, "total_duration_seconds": 92.8}}}, {"id": "config-decoy-with_skill", "prompt": "Create an issue for improving error handling across the service.", "eval_id": 3, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "3 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Uses config repo, not the CLAUDE.md decoy", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"}, {"text": "Decoy repo never used in any gh call or issue body", "passed": true, "evidence": "decoy in calls=False, in body=False"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 47992, "duration_ms": 150201, "total_duration_seconds": 150.2}}}, {"id": "config-decoy-without_skill", "prompt": "Create an issue for improving error handling across the service.", "eval_id": 3, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Uses config repo, not the CLAUDE.md decoy", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"}, {"text": "Decoy repo never used in any gh call or issue body", "passed": true, "evidence": "decoy in calls=False, in body=False"}], "summary": {"passed": 4, "failed": 0, "total": 4, "pass_rate": 1.0}, "timing": {"total_tokens": 44246, "duration_ms": 124396, "total_duration_seconds": 124.4}}}, {"id": "over-broad-with_skill", "prompt": "I want to completely overhaul error handling, logging, monitoring, retries, and alerting across the entire service. Open an issue for it.", "eval_id": 3, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "11 gh call(s) logged"}, {"text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)", "passed": true, "evidence": "transcript proposes splitting or narrowing"}, {"text": "Issue defines explicit out-of-scope / deferred boundaries", "passed": true, "evidence": "explicit scope boundary in body = True"}], "summary": {"passed": 3, "failed": 0, "total": 3, "pass_rate": 1.0}, "timing": {"total_tokens": 59635, "duration_ms": 827924, "total_duration_seconds": 827.9}}}, {"id": "over-broad-without_skill", "prompt": "I want to completely overhaul error handling, logging, monitoring, retries, and alerting across the entire service. Open an issue for it.", "eval_id": 3, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)", "passed": true, "evidence": "transcript proposes splitting or narrowing"}, {"text": "Issue defines explicit out-of-scope / deferred boundaries", "passed": true, "evidence": "explicit scope boundary in body = True"}], "summary": {"passed": 3, "failed": 0, "total": 3, "pass_rate": 1.0}, "timing": {"total_tokens": 43324, "duration_ms": 110927, "total_duration_seconds": 110.9}}}, {"id": "bug-report-with_skill", "prompt": "Report a bug: the server drops WebSocket connections after about 30 seconds of inactivity instead of keeping them alive. It happens reliably on the staging box.", "eval_id": 4, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Conventional title fix(scope): ...", "passed": true, "evidence": "title = 'fix(server): WebSocket connections dropped after ~30s of inactivity instead of being kept alive'"}, {"text": "Labeled 'bug'", "passed": true, "evidence": "labels = ['bug']"}, {"text": "Steps to reproduce present", "passed": true, "evidence": "'reproduc' in body = True"}, {"text": "Expected AND actual behavior documented", "passed": true, "evidence": "expected=True actual=True"}, {"text": "Environment details present", "passed": true, "evidence": "'environment' in body = True"}], "summary": {"passed": 7, "failed": 0, "total": 7, "pass_rate": 1.0}, "timing": {"total_tokens": 48555, "duration_ms": 141978, "total_duration_seconds": 142.0}}}, {"id": "bug-report-without_skill", "prompt": "Report a bug: the server drops WebSocket connections after about 30 seconds of inactivity instead of keeping them alive. It happens reliably on the staging box.", "eval_id": 4, "outputs": [], "grading": {"expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "7 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Conventional title fix(scope): ...", "passed": false, "evidence": "title = 'WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)'"}, {"text": "Labeled 'bug'", "passed": true, "evidence": "labels = ['bug']"}, {"text": "Steps to reproduce present", "passed": true, "evidence": "'reproduc' in body = True"}, {"text": "Expected AND actual behavior documented", "passed": true, "evidence": "expected=True actual=True"}, {"text": "Environment details present", "passed": true, "evidence": "'environment' in body = True"}], "summary": {"passed": 6, "failed": 1, "total": 7, "pass_rate": 0.8571}, "timing": {"total_tokens": 42607, "duration_ms": 106505, "total_duration_seconds": 106.5}}}], "previous_feedback": {}, "previous_outputs": {}, "benchmark": {"metadata": {"skill_name": "rawgentic:create-issue (slim)", "skill_path": "<path/to/skill>", "executor_model": "<model-name>", "analyzer_model": "<model-name>", "timestamp": "2026-06-16T06:32:59Z", "evals_run": [1, 2, 3, 4, 5, 6, 7], "runs_per_configuration": 3}, "runs": [{"eval_id": 1, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 8, "failed": 0, "total": 8, "time_seconds": 144.6, "tokens": 50200, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "3 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Targets the config repo octo-eval/sentinel-app", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app'"}, {"text": "Conventional title feat(scope): ...", "passed": true, "evidence": "title = 'feat(server): add WebSocket support for realtime updates'"}, {"text": "At least 3 numbered acceptance criteria", "passed": true, "evidence": "5 numbered items in body"}, {"text": "Explicit in-scope AND out-of-scope sections", "passed": true, "evidence": "in-scope=True out-of-scope=True"}, {"text": "Risk assessment present", "passed": true, "evidence": "'risk' in body = True"}, {"text": "Deduplication search ran before creation", "passed": true, "evidence": "issue-list-with-search logged = True"}], "notes": []}, {"eval_id": 2, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 70.1, "tokens": 42130, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Deduplication search ran", "passed": true, "evidence": "issue-list-with-search logged = True"}, {"text": "Existing matching issue (#42) surfaced to the user", "passed": true, "evidence": "'#42'/'42' in transcript = True"}, {"text": "Did not blindly create a duplicate", "passed": true, "evidence": "no new issue created (acknowledged existing) -- acceptable"}], "notes": []}, {"eval_id": 3, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 150.2, "tokens": 47992, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "3 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Uses config repo, not the CLAUDE.md decoy", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"}, {"text": "Decoy repo never used in any gh call or issue body", "passed": true, "evidence": "decoy in calls=False, in body=False"}], "notes": []}, {"eval_id": 4, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 7, "failed": 0, "total": 7, "time_seconds": 142.0, "tokens": 48555, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Conventional title fix(scope): ...", "passed": true, "evidence": "title = 'fix(server): WebSocket connections dropped after ~30s of inactivity instead of being kept alive'"}, {"text": "Labeled 'bug'", "passed": true, "evidence": "labels = ['bug']"}, {"text": "Steps to reproduce present", "passed": true, "evidence": "'reproduc' in body = True"}, {"text": "Expected AND actual behavior documented", "passed": true, "evidence": "expected=True actual=True"}, {"text": "Environment details present", "passed": true, "evidence": "'environment' in body = True"}], "notes": []}, {"eval_id": 5, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 121.8, "tokens": 46602, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase", "passed": true, "evidence": "transcript acknowledges the component is absent"}, {"text": "Referenced the real connection-handling code (server.js / errorHandler.js)", "passed": true, "evidence": "real-file reference present = True"}, {"text": "Final issue does not present the nonexistent component as real", "passed": true, "evidence": "issue does not present the fake component as real"}], "notes": []}, {"eval_id": 6, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 3, "failed": 0, "total": 3, "time_seconds": 150.3, "tokens": 47134, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)", "passed": true, "evidence": "transcript shows clarification/under-specification handling"}, {"text": "Did not fabricate specific performance targets the user never provided", "passed": true, "evidence": "no invented numeric targets"}], "notes": []}, {"eval_id": 7, "configuration": "with_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 3, "failed": 0, "total": 3, "time_seconds": 827.9, "tokens": 59635, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "11 gh call(s) logged"}, {"text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)", "passed": true, "evidence": "transcript proposes splitting or narrowing"}, {"text": "Issue defines explicit out-of-scope / deferred boundaries", "passed": true, "evidence": "explicit scope boundary in body = True"}], "notes": []}, {"eval_id": 1, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 0.875, "passed": 7, "failed": 1, "total": 8, "time_seconds": 91.5, "tokens": 42293, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Targets the config repo octo-eval/sentinel-app", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app'"}, {"text": "Conventional title feat(scope): ...", "passed": false, "evidence": "title = 'Add WebSocket support for realtime updates in the API'"}, {"text": "At least 3 numbered acceptance criteria", "passed": true, "evidence": "5 numbered items in body"}, {"text": "Explicit in-scope AND out-of-scope sections", "passed": true, "evidence": "in-scope=True out-of-scope=True"}, {"text": "Risk assessment present", "passed": true, "evidence": "'risk' in body = True"}, {"text": "Deduplication search ran before creation", "passed": true, "evidence": "issue-list-with-search logged = True"}], "notes": []}, {"eval_id": 2, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 99.1, "tokens": 40980, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Deduplication search ran", "passed": true, "evidence": "issue-list-with-search logged = True"}, {"text": "Existing matching issue (#42) surfaced to the user", "passed": true, "evidence": "'#42'/'42' in transcript = True"}, {"text": "Did not blindly create a duplicate", "passed": true, "evidence": "no new issue created (acknowledged existing) -- acceptable"}], "notes": []}, {"eval_id": 3, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 124.4, "tokens": 44246, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Uses config repo, not the CLAUDE.md decoy", "passed": true, "evidence": "created repo = 'octo-eval/sentinel-app' (decoy was octo-eval/sentinel-legacy)"}, {"text": "Decoy repo never used in any gh call or issue body", "passed": true, "evidence": "decoy in calls=False, in body=False"}], "notes": []}, {"eval_id": 4, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 0.8571, "passed": 6, "failed": 1, "total": 7, "time_seconds": 106.5, "tokens": 42607, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "7 gh call(s) logged"}, {"text": "Issue was actually created via gh (not simulated)", "passed": true, "evidence": "created-issue.json present"}, {"text": "Conventional title fix(scope): ...", "passed": false, "evidence": "title = 'WebSocket connections dropped after ~30s of inactivity instead of staying alive (staging)'"}, {"text": "Labeled 'bug'", "passed": true, "evidence": "labels = ['bug']"}, {"text": "Steps to reproduce present", "passed": true, "evidence": "'reproduc' in body = True"}, {"text": "Expected AND actual behavior documented", "passed": true, "evidence": "expected=True actual=True"}, {"text": "Environment details present", "passed": true, "evidence": "'environment' in body = True"}], "notes": []}, {"eval_id": 5, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 4, "failed": 0, "total": 4, "time_seconds": 113.5, "tokens": 42236, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase", "passed": true, "evidence": "transcript acknowledges the component is absent"}, {"text": "Referenced the real connection-handling code (server.js / errorHandler.js)", "passed": true, "evidence": "real-file reference present = True"}, {"text": "Final issue does not present the nonexistent component as real", "passed": true, "evidence": "issue does not present the fake component as real"}], "notes": []}, {"eval_id": 6, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 3, "failed": 0, "total": 3, "time_seconds": 92.8, "tokens": 41909, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "4 gh call(s) logged"}, {"text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)", "passed": true, "evidence": "transcript shows clarification/under-specification handling"}, {"text": "Did not fabricate specific performance targets the user never provided", "passed": true, "evidence": "no invented numeric targets"}], "notes": []}, {"eval_id": 7, "configuration": "without_skill", "run_number": 1, "result": {"pass_rate": 1.0, "passed": 3, "failed": 0, "total": 3, "time_seconds": 110.9, "tokens": 43324, "tool_calls": 0, "errors": 0}, "expectations": [{"text": "Run executed against mock gh (calls recorded)", "passed": true, "evidence": "5 gh call(s) logged"}, {"text": "Recognized the request is too broad for a single issue (suggested splitting / scoping down)", "passed": true, "evidence": "transcript proposes splitting or narrowing"}, {"text": "Issue defines explicit out-of-scope / deferred boundaries", "passed": true, "evidence": "explicit scope boundary in body = True"}], "notes": []}], "run_summary": {"with_skill": {"pass_rate": {"mean": 1.0, "stddev": 0.0, "min": 1.0, "max": 1.0}, "time_seconds": {"mean": 229.5571, "stddev": 265.3663, "min": 70.1, "max": 827.9}, "tokens": {"mean": 48892.5714, "stddev": 5355.7724, "min": 42130, "max": 59635}}, "without_skill": {"pass_rate": {"mean": 0.9617, "stddev": 0.0656, "min": 0.8571, "max": 1.0}, "time_seconds": {"mean": 105.5286, "stddev": 11.8997, "min": 91.5, "max": 124.4}, "tokens": {"mean": 42513.5714, "stddev": 1041.6235, "min": 40980, "max": 44246}}, "delta": {"pass_rate": "+0.04", "time_seconds": "+124.0", "tokens": "+6379"}}, "notes": []}};
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>

--- a/skills/create-issue-workspace/iteration-4/vague-perf/eval_metadata.json
+++ b/skills/create-issue-workspace/iteration-4/vague-perf/eval_metadata.json
@@ -1,0 +1,11 @@
+{
+  "eval_id": 2,
+  "eval_name": "vague-perf",
+  "scenario": "vague-perf",
+  "prompt": "The app feels slow sometimes. Can you make an issue about that?",
+  "assertions": [
+    "Run executed against mock gh (calls recorded)",
+    "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+    "Did not fabricate specific performance targets the user never provided"
+  ]
+}

--- a/skills/create-issue-workspace/iteration-4/vague-perf/with_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/vague-perf/with_skill/grading.json
@@ -1,0 +1,30 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "4 gh call(s) logged"
+    },
+    {
+      "text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+      "passed": true,
+      "evidence": "transcript shows clarification/under-specification handling"
+    },
+    {
+      "text": "Did not fabricate specific performance targets the user never provided",
+      "passed": true,
+      "evidence": "no invented numeric targets"
+    }
+  ],
+  "summary": {
+    "passed": 3,
+    "failed": 0,
+    "total": 3,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 47134,
+    "duration_ms": 150332,
+    "total_duration_seconds": 150.3
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/vague-perf/with_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/vague-perf/with_skill/outputs/transcript.md
@@ -1,0 +1,217 @@
+# WF1 create-issue — Transcript
+
+## User request
+> The app feels slow sometimes. Can you make an issue about that?
+
+---
+
+## Config loading (resolve active project + capabilities)
+
+### Working directory
+```
+$ cd /tmp/ci-iter4/vague-perf/with_skill/fixture && pwd
+/tmp/ci-iter4/vague-perf/with_skill/fixture
+```
+
+### Active project resolution
+- No prior `/rawgentic:switch` binding for this session.
+- `claude_docs/session_registry.jsonl` does not exist (empty registry).
+- `.rawgentic_workspace.json` has exactly ONE project with `active == true`:
+  `sentinel-app` → use it. `disabledSkills` is empty; no `bmadDetected`. OK to proceed.
+
+```json
+// .rawgentic_workspace.json
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "sentinel-app",
+      "path": "./projects/sentinel-app",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+```
+
+### Derive capabilities (single source of truth)
+```
+$ python3 hooks/capabilities_lib.py derive --config ./projects/sentinel-app/.rawgentic.json
+{"config":{"version":1,"project":{"name":"sentinel-app","type":"web-service","description":"Realtime API service for the eval harness"},"repo":{"provider":"github","fullName":"octo-eval/sentinel-app","defaultBranch":"trunk"},"protectionLevel":"sandbox","techStack":["node","javascript"],"testing":{"frameworks":[{"name":"vitest","type":"unit","command":"npm test","testDir":"test"}]},"ci":{"provider":"github-actions","workflowDir":".github/workflows"},"documentation":{"primaryFiles":["README.md"],"format":"markdown"},"custom":{}},"capabilities":{"repo":"octo-eval/sentinel-app","default_branch":"trunk","project_type":"web-service","has_tests":true,"test_commands":["npm test"],"has_ci":true,"has_deploy":false,"deploy_method":null,"has_database":false,"migration_dir":null,"has_docker":false}}
+EXIT=0
+```
+Carried literals: **repo = `octo-eval/sentinel-app`**, **default_branch = `trunk`**, project type `web-service` (Realtime API service).
+
+---
+
+## Step 1: Understand the request
+
+The request is highly vague ("feels slow sometimes"). Per the skill's `<quality-bar>`,
+I must not fabricate specifics (no invented endpoints, pages, numbers, or targets).
+I asked targeted clarifying questions and received low-information answers.
+
+**Q (orchestrator → user):**
+1. Is this a **bug report** (something regressed/broke) or a **feature request**
+   (you want performance investigated/improved)?
+2. Which part feels slow — connecting, a specific API endpoint/response, startup?
+3. Do you have any numbers (response times, when it started) or steps to reproduce?
+
+**A (user, low-information):**
+> I don't have specifics — it just feels slow sometimes, I haven't measured it.
+> I can't point to a specific endpoint or give numbers. Just file something
+> reasonable about it.
+
+**Decision:** Because the user genuinely has no measurements, repro steps, or
+targets, a confirmed bug report (which the bug template requires: repro steps,
+expected vs actual) cannot be written honestly. Per `<quality-bar>` ("if specifics
+genuinely aren't available yet, write an investigation issue whose criteria are
+about *gathering* the data, and mark targets as TBD"), I file an **investigation
+issue** classified as an **enhancement/feature** (additive instrumentation +
+measurement to characterize the slowness), with all numeric targets marked TBD.
+
+### Dedup check (search before drafting)
+```
+$ ./bin/gh issue list --repo octo-eval/sentinel-app --search "slow performance latency" --limit 10
+(no output)
+EXIT=0
+
+$ ./bin/gh issue list --repo octo-eval/sentinel-app --limit 20
+(no output)
+EXIT=0
+```
+No existing/duplicate issues found.
+
+### Labels available
+```
+$ ./bin/gh label list --repo octo-eval/sentinel-app
+bug         Something isn't working   d73a4a
+enhancement New feature or request    a2eeef
+```
+
+---
+
+## Step 2: Draft the issue
+
+### Template read (feature → feature_request.md)
+```
+## Description
+## Acceptance Criteria
+1.
+## Scope
+In scope:
+-
+Out of scope:
+-
+## Affected Components
+## Risk Assessment
+## Complexity
+<!-- S / M / L / XL -->
+## Related Issues
+```
+
+### Component verification (no hallucinated components)
+Read the real codebase to ground every referenced symbol:
+- `src/server.js` → `startServer(port)`, `handleConnection(socket)` — VERIFIED real.
+- `src/errorHandler.js` → `handleError(err, req, res)` — VERIFIED real.
+- `README.md`: "Realtime API service. Modules: src/server.js, src/errorHandler.js."
+No other modules exist; the issue references only these.
+
+### Draft presented to user
+```
+Title: feat(perf): investigate and baseline intermittent realtime API slowness
+Type: feature (enhancement) — investigation issue
+Labels: enhancement
+Complexity: S
+
+## Description
+Users report the Sentinel realtime API service "feels slow sometimes." The
+slowness is intermittent and has not yet been measured: no specific endpoint,
+connection phase, time window, or numeric latency. This issue is an investigation,
+not a fix — its goal is to make the perceived slowness measurable (establish where
+time is spent and capture a baseline) so a follow-up can target a concrete,
+data-backed improvement. No performance target is asserted (all targets TBD until
+a baseline exists).
+
+## Acceptance Criteria
+1. Add lightweight timing/instrumentation around the realtime request/connection
+   lifecycle in src/server.js (startServer, handleConnection) and error handling
+   in src/errorHandler.js (handleError).
+2. Capture a baseline of observed latency under normal load and record it,
+   including which operation(s) dominate. Numeric "slow" thresholds are TBD until
+   this baseline exists.
+3. Identify/document the conditions under which the intermittent slowness
+   reproduces (load, connection count, operation), or document non-repro.
+4. From the baseline, file a concrete follow-up with a measured target if a hotspot
+   is found, OR close this issue with the finding that no actionable slowness exists.
+
+## Scope
+In scope: instrumentation of existing modules; measuring/documenting a latency
+baseline; identifying dominant cost / repro conditions.
+Out of scope: any actual optimization/refactor (deferred to follow-up); committing
+to an SLO/target before a baseline; infra/deploy changes (config reports no deploy).
+
+## Affected Components
+- src/server.js — startServer, handleConnection
+- src/errorHandler.js — handleError
+(Verified to exist; no other modules present.)
+
+## Risk Assessment
+Low. Additive instrumentation/measurement only; no behavioral or API changes.
+Main risk: instrumentation overhead — keep it lightweight/removable.
+
+## Related Issues
+None found.
+```
+
+**User review (user, low-information):**
+> Looks good — that's reasonable. Approved.
+
+(The draft was approvable because it contains NO invented numbers — it explicitly
+marks every target TBD, which matches what an unmeasured report can honestly say.)
+
+---
+
+## Step 4: Create the issue
+
+```
+$ cp outputs/_draft.md /tmp/wf1-issue-body.md   # body staged (412 words)
+
+$ ./bin/gh issue create --repo octo-eval/sentinel-app \
+    --title "feat(perf): investigate and baseline intermittent realtime API slowness" \
+    --body-file /tmp/wf1-issue-body.md \
+    --label "enhancement"
+https://github.com/octo-eval/sentinel-app/issues/101
+EXIT=0
+
+$ rm -f /tmp/wf1-issue-body.md   # cleanup
+temp removed
+```
+
+---
+
+## Step 5: Wrap up
+
+Appended to `claude_docs/session_notes.md`:
+```
+### WF1 create-issue — DONE (https://github.com/octo-eval/sentinel-app/issues/101, feature, feat(perf): investigate and baseline intermittent realtime API slowness)
+```
+
+### Final result
+```
+Issue created: https://github.com/octo-eval/sentinel-app/issues/101
+Type: feature (investigation) · Title: feat(perf): investigate and baseline intermittent realtime API slowness · Labels: enhancement
+```
+
+Did NOT offer to start implementation (WF2 is invoked separately).
+
+---
+
+## Note on specific performance numbers
+The filed issue contains **NO specific/fabricated performance numbers** (no latency
+figures, no SLO/target, no specific endpoint or page). The user had not measured
+anything, so per the skill's `<quality-bar>` the issue is framed as an investigation
+with all targets explicitly marked **TBD pending a measured baseline**.

--- a/skills/create-issue-workspace/iteration-4/vague-perf/with_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/vague-perf/with_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 47134,
+  "duration_ms": 150332,
+  "total_duration_seconds": 150.3
+}

--- a/skills/create-issue-workspace/iteration-4/vague-perf/without_skill/grading.json
+++ b/skills/create-issue-workspace/iteration-4/vague-perf/without_skill/grading.json
@@ -1,0 +1,30 @@
+{
+  "expectations": [
+    {
+      "text": "Run executed against mock gh (calls recorded)",
+      "passed": true,
+      "evidence": "4 gh call(s) logged"
+    },
+    {
+      "text": "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+      "passed": true,
+      "evidence": "transcript shows clarification/under-specification handling"
+    },
+    {
+      "text": "Did not fabricate specific performance targets the user never provided",
+      "passed": true,
+      "evidence": "no invented numeric targets"
+    }
+  ],
+  "summary": {
+    "passed": 3,
+    "failed": 0,
+    "total": 3,
+    "pass_rate": 1.0
+  },
+  "timing": {
+    "total_tokens": 41909,
+    "duration_ms": 92843,
+    "total_duration_seconds": 92.8
+  }
+}

--- a/skills/create-issue-workspace/iteration-4/vague-perf/without_skill/outputs/transcript.md
+++ b/skills/create-issue-workspace/iteration-4/vague-perf/without_skill/outputs/transcript.md
@@ -1,0 +1,159 @@
+# Transcript — Create GitHub issue for "app feels slow sometimes"
+
+## User request
+
+> The app feels slow sometimes. Can you make an issue about that?
+
+The request is low-information: no specific page, endpoint, metric, repro, or
+target was provided, and nothing has been measured. The issue is therefore
+filed as an honest investigation issue and deliberately contains **no invented
+performance numbers**.
+
+---
+
+## Step 0 — Confirm working directory
+
+```
+$ cd /tmp/ci-iter3/vague-perf/without_skill/fixture && pwd
+/tmp/ci-iter3/vague-perf/without_skill/fixture
+```
+
+## Step 1 — Explore the workspace / project
+
+```
+$ ls -la
+total 36
+drwxrwxr-x 8 rocky00717 rocky00717 4096 Jun 15 22:51 .
+drwxrwxr-x 3 rocky00717 rocky00717 4096 Jun 15 22:51 ..
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 .gh-mock
+-rw-rw-r-- 1 rocky00717 rocky00717  310 Jun 15 22:51 .rawgentic_workspace.json
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 bin
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 claude_docs
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 hooks
+drwxrwxr-x 2 rocky00717 rocky00717 4096 Jun 15 22:51 outputs
+drwxrwxr-x 3 rocky00717 rocky00717 4096 Jun 15 22:51 projects
+
+$ ls -la projects/sentinel-app/
+.github/  .rawgentic.json  README.md  src/
+```
+
+### Project config (`projects/sentinel-app/.rawgentic.json`)
+
+```json
+{
+  "version": 1,
+  "project": {
+    "name": "sentinel-app",
+    "type": "web-service",
+    "description": "Realtime API service for the eval harness"
+  },
+  "repo": {
+    "provider": "github",
+    "fullName": "octo-eval/sentinel-app",
+    "defaultBranch": "trunk"
+  },
+  ...
+  "techStack": ["node", "javascript"],
+  ...
+}
+```
+
+### Source modules
+
+```
+$ cat projects/sentinel-app/src/server.js
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+
+$ cat projects/sentinel-app/src/errorHandler.js
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+```
+
+### Issue templates present
+
+- `.github/ISSUE_TEMPLATE/bug_report.md` (labels: bug)
+- `.github/ISSUE_TEMPLATE/feature_request.md` (labels: enhancement)
+
+---
+
+## Step 2 — Auth, dedup search, and existing labels
+
+```
+$ /tmp/ci-iter3/vague-perf/without_skill/fixture/bin/gh auth status
+github.com
+  Logged in to github.com account eval-bot (oauth_token)
+  Token scopes: 'repo', 'read:org'
+
+$ /tmp/ci-iter3/vague-perf/without_skill/fixture/bin/gh issue list \
+    --repo octo-eval/sentinel-app --search "performance slow" --state all --limit 30
+[end of list]   # (empty output — no existing/duplicate performance issues)
+
+$ /tmp/ci-iter3/vague-perf/without_skill/fixture/bin/gh label list --repo octo-eval/sentinel-app
+bug	Something isn't working	d73a4a
+enhancement	New feature or request	a2eeef
+```
+
+No duplicate issue exists, so creation proceeds. `enhancement` already exists.
+
+---
+
+## Step 3 — Write the issue body
+
+Body written to `.gh-mock/issue-body.md`. It frames the report as a vague,
+**unmeasured** subjective slowness and lays out an investigation plan. It
+explicitly states that no performance numbers are included because none have
+been measured, and that targets/thresholds should not be invented until real
+data exists.
+
+---
+
+## Step 4 — Create the issue
+
+```
+$ /tmp/ci-iter3/vague-perf/without_skill/fixture/bin/gh issue create \
+    --repo octo-eval/sentinel-app \
+    --title "Investigate intermittent perceived slowness (no metrics yet)" \
+    --body-file /tmp/ci-iter3/vague-perf/without_skill/fixture/.gh-mock/issue-body.md \
+    --label performance \
+    --label enhancement
+https://github.com/octo-eval/sentinel-app/issues/101
+```
+
+---
+
+## Step 5 — Verify the recorded result
+
+```
+$ cat .gh-mock/created-issue.json
+{
+  "repo": "octo-eval/sentinel-app",
+  "title": "Investigate intermittent perceived slowness (no metrics yet)",
+  "labels": [
+    "performance",
+    "enhancement"
+  ],
+  "body_len": 1830,
+  "ts": 1781589173
+}
+
+$ cat .gh-mock/calls.log
+gh auth status
+gh issue list --repo octo-eval/sentinel-app --search performance slow --state all --limit 30
+gh label list --repo octo-eval/sentinel-app
+gh issue create --repo octo-eval/sentinel-app --title Investigate intermittent perceived slowness (no metrics yet) --body-file /tmp/ci-iter3/vague-perf/without_skill/fixture/.gh-mock/issue-body.md --label performance --label enhancement
+```
+
+---
+
+## Final result
+
+- **Issue created:** https://github.com/octo-eval/sentinel-app/issues/101
+- **Repo:** `octo-eval/sentinel-app`
+- **Title:** "Investigate intermittent perceived slowness (no metrics yet)"
+- **Labels:** `performance`, `enhancement`
+- **Specific performance numbers in the issue?** **No.** The report is
+  unmeasured ("feels slow sometimes"). The issue intentionally contains no
+  invented latency figures, pages, or targets, and instead lays out a plan to
+  gather that data first.

--- a/skills/create-issue-workspace/iteration-4/vague-perf/without_skill/timing.json
+++ b/skills/create-issue-workspace/iteration-4/vague-perf/without_skill/timing.json
@@ -1,0 +1,5 @@
+{
+  "total_tokens": 41909,
+  "duration_ms": 92843,
+  "total_duration_seconds": 92.8
+}

--- a/skills/create-issue-workspace/skill-snapshot/SKILL-serena-fixed.md
+++ b/skills/create-issue-workspace/skill-snapshot/SKILL-serena-fixed.md
@@ -1,0 +1,608 @@
+---
+name: rawgentic:create-issue
+description: Create a GitHub issue (feature request or bug report) using the WF1 9-step workflow with multi-agent critique, ambiguity circuit breaker, and user review. Invoke with /create-issue followed by a description of the desired feature or observed bug.
+argument-hint: Description of the feature to request or bug to report
+---
+
+
+# WF1: Issue Creation Workflow (v1.0)
+
+<role>
+You are the WF1 orchestrator implementing a 9-step issue creation workflow. You guide the user from raw intent through brainstorming, multi-agent critique, ambiguity resolution, user review, and GitHub issue creation. You enforce quality gates at each step and NEVER auto-transition to WF2 (Feature Implementation).
+</role>
+
+<constants>
+MAX_LOOPBACK_ITERATIONS = 2
+VOLUME_THRESHOLDS:
+  Critical: 5
+  High: 5
+  Medium: 10
+  Low: 10
+TEMPLATE_DIR = ".github/ISSUE_TEMPLATE"
+</constants>
+
+<config-loading>
+Before executing any workflow steps, load the project configuration:
+
+1. Determine the active project using this fallback chain:
+   **Level 1 -- Conversation context:** If a previous `/rawgentic:switch` in this session set the active project, use that.
+   **Level 2 -- Session registry:** Read `claude_docs/session_registry.jsonl`. Grep for your session_id. If found, use the project from the most recent matching line.
+   **Level 3 -- Workspace default:** Read `.rawgentic_workspace.json` from the Claude root directory. If exactly one project has `active == true`, use it. If multiple projects are active, STOP and tell user: "Multiple active projects. Run `/rawgentic:switch <name>` to bind this session."
+
+   At any level:
+   - `.rawgentic_workspace.json` missing -> STOP. Tell user: "No rawgentic workspace found. Run /rawgentic:new-project."
+   - `.rawgentic_workspace.json` malformed -> STOP. Tell user: "Workspace file is corrupted. Run /rawgentic:new-project to regenerate, or fix manually."
+   - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
+   - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
+
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
+
+All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
+</config-loading>
+
+<environment-setup>
+Constants are populated at workflow start (Step 1) from the config loaded in `<config-loading>`:
+- `capabilities.repo`: from config.repo.fullName
+- `capabilities.default_branch`: from config.repo.defaultBranch
+
+If config loading fails, STOP and follow the error instructions in `<config-loading>`. Do not assume values.
+</environment-setup>
+
+<termination-rule>
+WF1 ALWAYS terminates after issue creation. WF2 (Feature Implementation) requires explicit, separate invocation. There is NO auto-transition from WF1 to WF2 under ANY circumstance. Do not suggest "shall I implement this?" or "would you like to start WF2?" WF1 terminates ONLY after the completion-gate passes. All steps must have markers in session notes.
+</termination-rule>
+
+<context-compaction>
+Per CLAUDE.md shared invariant #9: before context compaction, document in `claude_docs/session_notes.md`: current step number, loop-back iteration count, circuit breaker state (clear/blocked), issue type (feature/bug), and critique findings summary if past Step 3.
+</context-compaction>
+
+<ambiguity-circuit-breaker>
+Per CLAUDE.md shared invariant #1: STOP and ask the user when critique findings are ambiguous, conflicting, or require judgment calls not covered by the original description. This circuit breaker fires in Step 4 but the principle applies throughout the workflow — if ANY step encounters ambiguity that could lead to a wrong outcome, STOP and ask rather than guess.
+</ambiguity-circuit-breaker>
+
+<step-tracking>
+At the end of each step, log a marker in `claude_docs/session_notes.md`:
+`### WF1 Step X: <Name> — DONE (<key detail>)`
+This enables workflow resumption if context is lost.
+</step-tracking>
+
+## Step 1: Receive User Intent
+
+### Instructions
+
+1. Acknowledge the user's request.
+2. **Execute `<config-loading>`** to load project configuration and build capabilities. Log resolved values in session notes. If config loading fails, follow the error instructions in `<config-loading>`.
+3. Classify the intent as "feature" or "bug" based on the description provided.
+4. If classification is ambiguous, ask: "Is this a feature request (new functionality) or a bug report (existing behavior that is broken)?"
+5. Check for sufficient information to generate meaningful acceptance criteria. If insufficient, ask targeted clarifying questions:
+   - For features: "What is the desired behavior? Which part of the system is affected? What problem does this solve?"
+   - For bugs: "What is the expected behavior? What is the actual behavior? Can you reproduce it? Which VM/container is affected?"
+6. Run a deduplication check:
+   ```bash
+   gh issue list --repo ${capabilities.repo} --search "<keywords from description>" --limit 10
+   ```
+7. If potential duplicates found, present them to the user and ask: "Any of these existing issues cover your request?"
+8. Update `claude_docs/session_notes.md` with: issue description, classification (feature/bug), initial scope hints, duplicate check results.
+9. Confirm classification with the user before proceeding.
+
+### Output Format
+
+Present to user:
+
+```
+Issue Classification:
+- Type: [feature / bug]
+- Summary: [one-sentence summary of the intent]
+- Scope hints: [components/systems mentioned]
+- Existing issues found: [list or "none"]
+
+Proceeding to brainstorm. Confirm or correct this classification.
+```
+
+Wait for user confirmation before proceeding to Step 2.
+
+#### Failure Modes
+
+- User provides insufficient information → ask targeted clarifying questions (expected behavior, actual behavior, affected system area). Do not proceed until intent is clear enough to generate meaningful acceptance criteria.
+- Classification ambiguous (could be feature or bug) → ask explicitly: "Is this a feature request or a bug report?"
+- Dedup check finds a matching issue → present to user and ask if it covers their request before proceeding
+
+---
+
+## Step 2: Brainstorm Feature/Bug Details
+
+### Instructions
+
+**Brainstorming approach:** For complex features (multi-component, architectural changes), invoke `superpowers:brainstorming` to run the full design pipeline (context exploration → clarifying questions → approach proposals → design validation). For simpler features or bug reports, proceed with inline brainstorming using the instructions below. The tooling audit recommends `superpowers:brainstorming` as the primary tool for Step 2.
+
+1. Read the matching GitHub issue template:
+   - Feature: `${activeProject.path}/.github/ISSUE_TEMPLATE/feature_request.md`
+   - Bug: `${activeProject.path}/.github/ISSUE_TEMPLATE/bug_report.md`
+
+2. Read codebase context:
+   - config (architecture from config.services and config.techStack, quality standards from project conventions)
+   - MEMORY.md (project memory, infrastructure context)
+   - Relevant source files identified from scope hints
+
+3. Verify that any components, files, or symbols the brainstorm references **actually exist** in the codebase — this is what keeps a hallucinated component from reaching the issue. Use whatever code-search tooling is available: Serena MCP (`find_symbol`, `get_symbols_overview`) if it's installed, otherwise `Grep`/`Glob`/`Read`. Do not skip this verification just because Serena is absent — the goal (ground every claim in real code) matters more than the specific tool.
+
+4. Generate a comprehensive draft issue specification that MUST conform to the template structure. Include:
+   - **Title:** Conventional format (`feat(scope): description` or `fix(scope): description`)
+   - **Description:** Detailed with context and motivation
+   - **Acceptance criteria:** Numbered, testable, specific (minimum 3 criteria)
+   - **Scope:** Explicit in-scope AND out-of-scope lists
+   - **Affected components:** Verified against actual codebase (use Serena)
+   - **Risk assessment:** Dependencies, blockers, security implications
+   - **Complexity:** T-shirt size (S/M/L/XL) with justification
+   - **Related issues:** Cross-reference from dedup search
+
+   For bugs, additionally include:
+   - Steps to reproduce
+   - Expected vs. actual behavior
+   - Environment details
+   - Error logs (if available)
+
+5. Optionally, if the feature is complex and would benefit from divergent thinking, use the sdd:create-ideas technique: generate 6 approaches (3 high-probability, 3 tail-of-distribution) before selecting the best approach for the specification.
+
+6. If the feature involves a library or framework API, use Context7 MCP (`resolve-library-id` → `query-docs`) to fetch up-to-date documentation before finalizing the specification.
+
+### Output
+
+The draft specification is an internal working artifact. Do NOT present it to the user yet -- it goes directly to Step 3 for critique.
+
+#### Failure Modes
+
+- Brainstorm produces overly vague acceptance criteria → the critique step (Step 3) will catch this
+- Brainstorm hallucinates non-existent components or files → the critique step verifies claims against actual codebase via Serena
+- Brainstorm duplicates an existing issue → brainstorm should include a dedup check via `gh issue list --search`
+- No issue template exists in `.github/ISSUE_TEMPLATE/` → create the template first, then proceed with brainstorm
+
+---
+
+## Step 3: Full Critique of Brainstorm Output
+
+### Instructions
+
+**Critique method preference:** Before running the critique, check the active project entry's `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the 3-judge critique below. If missing or `"reflexion"`, proceed as normal.
+
+1. Launch all three judges in a single message with three parallel Agent tool calls (subagent_type="general-purpose"), each operating independently:
+
+   **Judge 1: Requirements Validator**
+   - Evaluate: completeness of acceptance criteria, scope clarity, edge case coverage, template conformance
+   - Verify: all referenced components/files exist, using available code-search tooling (Serena MCP `find_symbol` if installed, else `Grep`/`Glob`/`Read`)
+   - Check: deduplication against existing issues
+
+   **Judge 2: Solution Architect**
+   - Evaluate: feasibility, complexity estimate accuracy, hidden dependencies
+   - Check: consistency with existing architecture (from config.services, config.techStack)
+   - Assess: risk assessment completeness
+
+   **Judge 3: Code Quality Reviewer**
+   - Evaluate: acceptance criteria testability, scope boundaries, wording clarity
+   - Check: alignment with project security standards (from config.security)
+   - Verify: no hallucinated claims about codebase capabilities
+
+2. Each judge produces findings with the following structure per finding:
+
+   ```
+   Finding #N:
+   - Severity: Critical | High | Medium | Low
+   - Category: completeness | accuracy | feasibility | consistency | deduplication | template_conformance
+   - Description: [what the issue is]
+   - Recommendation: [specific action to take]
+   - Ambiguity flag: clear | ambiguous
+   - Ambiguity reason: [why, if ambiguous]
+   ```
+
+3. Synthesize findings across all three judges. Conduct a debate round if judges disagree on a finding. Unresolved disagreements are flagged as ambiguous.
+
+4. **Volume threshold check** (independent per tier, not combined):
+   - More than 5 Critical findings: TRIGGER LOOP-BACK
+   - More than 5 High findings: TRIGGER LOOP-BACK
+   - More than 10 Medium findings: TRIGGER LOOP-BACK
+   - More than 10 Low findings: TRIGGER LOOP-BACK
+
+5. **If loop-back triggered:**
+   - Check `loop_iteration` counter.
+   - If `loop_iteration < MAX_LOOPBACK_ITERATIONS` (i.e., < 2):
+     - Increment `loop_iteration`.
+     - Present ALL findings to the user as targeted clarifying questions.
+     - Work through each finding to tighten requirements.
+     - Return to Step 2 (re-brainstorm with improved requirements).
+   - If `loop_iteration >= MAX_LOOPBACK_ITERATIONS`:
+     - STOP looping. Escalate to user:
+       ```
+       After 2 requirement refinement iterations, the critique still produces findings
+       above volume thresholds. Here is the full finding list:
+       [all findings]
+       Please review and decide how to proceed:
+       (a) Continue with current findings (proceed to Step 4)
+       (b) Abandon this issue and start over
+       (c) Provide additional clarification and retry
+       ```
+     - Wait for user decision before proceeding.
+
+6. **If volume thresholds pass:** Proceed to Step 4 with the full findings list.
+
+### Output
+
+Prioritized findings list with severity tiers and ambiguity flags. This is NOT presented to the user directly -- it feeds into Step 4.
+
+#### Failure Modes
+
+- Critique finds zero issues (suspicious) → verify the critique sub-agents actually read the codebase context and that debate rounds occurred
+- Finding volume exceeds thresholds → loop back to Step 2 for requirements clarification (max 2 iterations)
+- Critique sub-agents disagree fundamentally → unresolved disagreements are flagged as ambiguous for user attention in Step 4
+
+---
+
+## Step 4: Apply Critique Findings (with Ambiguity Circuit Breaker)
+
+### Instructions
+
+This step implements the circuit breaker logic. It is prompt-level logic, not a separate tool.
+
+0. **Adversarial review sub-step (opt-in, cross-model — runs FIRST).** Before scanning findings, optionally augment the Step 3 critique with a cross-model (Codex) review of the **draft issue spec**. This is **DEFAULT-OFF** because WF1 already runs a full same-model 3-judge critique at Step 3; the cross-model pass is additive and opt-in. Gate it on project opt-in (check FIRST so a disabled project is a true no-op — no temp file, no subprocess):
+   ```bash
+   python3 hooks/adversarial_review_lib.py is-enabled \
+     --workspace .rawgentic_workspace.json --project <name> --skill create-issue
+   ```
+   The command exits `0` when enabled for `create-issue` and non-zero otherwise. If non-zero, **skip silently** — behavior is byte-for-byte unchanged. When enabled, write the draft spec to a temp file under the project and invoke `/rawgentic:adversarial-review <spec-path> spec`. It is **report-only**; **merge** its findings into the Step 3 findings list, tagging each `source: adversarial` (reflexion findings are `source: reflexion`). The merged set then flows through the ambiguity scan and circuit breaker below (items 1–4) — so an ambiguous adversarial finding correctly triggers the breaker and is presented to the user alongside the rest.
+   - **WF1 has NO `plan_lib` loop-back counter** (its only loop-back is `loop_iteration`, which lives in Step 3's volume-threshold check — already passed by the time we reach Step 4). Therefore the adversarial sub-step does **NOT** call `plan_lib.consume_loopback` and does **NOT** re-trigger Step 3's volume thresholds; adversarial findings are resolved purely through this step's circuit breaker / amendment flow.
+   - **Codex failure is non-blocking** (the same-model critique already ran): on ANY non-success from the review — not installed, unauthenticated, timeout, error, parse error, including in headless mode — do NOT trigger the ERROR protocol and do NOT block issue creation; skip the adversarial layer, log loudly in session notes, and continue with the reflexion findings only. (Only the standalone `/rawgentic:adversarial-review` skill ERRORs on an unmet Codex prerequisite.)
+   - Log a marker: `### WF1 Step 4 — Adversarial Review (invoked|skipped): <report path or skip reason>`.
+
+1. **Scan all findings for ambiguity:**
+
+   ```
+   ambiguous_findings = [f for f in findings if f.ambiguity_flag == "ambiguous"]
+   ```
+
+2. **Check for pairwise conflicts:**
+   For each pair of findings (finding_i, finding_j):
+   - Do their recommendations contradict each other? (e.g., "narrow scope to X" vs. "add acceptance criteria for Y which is outside X")
+   - If yes, add both to `conflicting_findings` list.
+
+3. **Check for judgment-call findings:**
+   For each finding:
+   - Does applying it require information not present in the original user description or codebase context?
+   - If yes, add to `judgment_findings` list.
+
+4. **Circuit breaker evaluation:**
+
+   **CLEAR PATH** (no ambiguity, no conflicts, no judgment calls):
+   - Produce amendment list from ALL findings (Critical + High + Medium + Low).
+   - Proceed directly to Step 5.
+   - Brief notification to user: "Critique complete. N findings applied (X Critical, Y High, Z Medium, W Low). All clear -- no ambiguity detected."
+
+   **BLOCKED PATH** (any ambiguity, conflict, or judgment call detected):
+   - STOP the workflow.
+   - Present the problematic findings to the user:
+
+     ```
+     CIRCUIT BREAKER TRIGGERED
+
+     The following findings cannot be applied automatically:
+
+     AMBIGUOUS FINDINGS:
+     [list with ambiguity reasons]
+
+     CONFLICTING FINDINGS:
+     [list with conflict explanations]
+
+     JUDGMENT-CALL FINDINGS:
+     [list with explanations of what information is missing]
+
+     Please resolve each item:
+     - For ambiguous findings: clarify the intended interpretation
+     - For conflicting findings: decide which finding takes priority
+     - For judgment-call findings: provide the missing information
+
+     You may also add your own amendments not raised by the critique.
+     ```
+
+   - Wait for user resolution.
+   - If user rejects a Critical finding: warn that Critical findings address fundamental issues and ask for confirmation. User has final authority (P11).
+   - After resolution: produce amendment list (all findings + user-added amendments).
+   - Proceed to Step 5.
+
+### Output
+
+Amendment list with workflow_state ("clear" or "blocked_resolved").
+
+#### Failure Modes
+
+- User rejects a Critical finding → warn that Critical items address fundamental issues (wrong component references, security gaps) and ask for confirmation. User has final authority.
+- Circuit breaker triggers on most runs → indicates the critique step is flagging too many ambiguous findings; tune ambiguity detection or improve brainstorm specificity
+- User adds amendments that contradict original brainstorm intent → flag the contradiction and ask for clarification
+
+---
+
+## Step 5: Incorporate Amendments into Issue Specification
+
+### Instructions
+
+1. Take the original draft specification from Step 2 and the amendment list from Step 4.
+2. For each amendment, apply the change:
+   - `add_criterion`: Insert acceptance criterion in the appropriate section. Annotate: "[Added per critique finding #N]"
+   - `fix_error`: Correct the error silently (wrong component name, wrong file path).
+   - `adjust_scope`: Update both in-scope and out-of-scope sections.
+   - `add_risk`: Append to risk assessment section.
+   - `improve_wording`: Revise wording in the specified section.
+   - `add_detail`: Add detail to the specified section.
+3. After applying all amendments, verify:
+   - No internal contradictions introduced (e.g., scope narrowed but new criteria added outside the narrowed scope).
+   - Specification still conforms to the GitHub issue template structure.
+   - Total length is reasonable (under 2000 words for a single issue). If over 2000 words, suggest splitting into multiple issues.
+4. Produce the refined specification.
+
+### Output
+
+Refined issue specification (internal working artifact). Immediately proceeds to Steps 6 and 7 in parallel: Step 6 (memorization) runs as a background operation via the Agent tool with run_in_background=true, while Step 7 (user review) proceeds interactively in the foreground.
+
+#### Failure Modes
+
+- Amendment incorporation introduces internal contradictions (scope narrowed but new criteria added outside narrowed scope) → flag the contradiction to the user before proceeding
+- Refined specification exceeds 2000 words → suggest splitting into multiple issues with cross-references
+
+---
+
+## Step 6: Conditional Memorization (runs in parallel with Step 7)
+
+### Instructions
+
+This step runs concurrently with Step 7 (User Review). It does NOT block Step 7.
+
+1. Review the critique findings from Step 3. Identify findings that surface reusable insights -- patterns applicable beyond this specific issue:
+   - Architecture constraints that future features must respect
+   - Anti-patterns discovered during critique
+   - Codebase conventions not yet documented
+   - Recurring pitfalls that should be added to verification checklists
+
+2. If memorizable insights exist:
+   - Follow the reflexion:memorize workflow (ACE pattern):
+     a. Extract the insight from critique context.
+     b. Check against MEMORY.md and session notes.
+     c. If novel, run /reflexion:memorize for reusable insights.
+     d. If MEMORY.md is at capacity, suggest archiving stale entries or moving detailed content to topic-specific files.
+   - Do NOT store in mem0 unless the insight is cross-project. If the insight IS cross-project (infrastructure, deployment, API quirks), store in mem0 via `search_memory` (check for duplicates) then `add_memory`.
+
+3. If no memorizable insights exist: skip this step entirely. No output.
+
+4. Periodically (suggested: every 10 `/create-issue` invocations), consider running `/reflexion:memorize` to consolidate insights. This is NOT a per-run action.
+
+### Output
+
+Updated memory (if insights memorized via /reflexion:memorize) or no output (if skipped). Does not affect Step 7.
+
+#### Failure Modes
+
+- Over-memorization: storing trivial or context-specific findings as general principles → the memorize command should filter for novelty and generalizability
+- MEMORY.md at capacity → suggest archiving stale entries or moving detailed content to topic-specific files
+- Duplicate memorization → the memorize command should deduplicate against existing content before appending
+
+---
+
+## Step 7: User Review & Refinement (runs in parallel with Step 6)
+
+### Instructions
+
+This step runs concurrently with Step 6 (Memorization). It does NOT wait for Step 6 to complete.
+
+1. Present the refined specification to the user in a readable format:
+
+   ```
+   DRAFT ISSUE SPECIFICATION (Ready for Review)
+   =============================================
+
+   Title: [conventional format title]
+   Type: [feature / bug]
+   Labels: [label list]
+   Complexity: [T-shirt size]
+
+   --- DESCRIPTION ---
+   [description text]
+
+   --- ACCEPTANCE CRITERIA ---
+   1. [criterion 1]
+   2. [criterion 2]
+   ...
+
+   --- SCOPE ---
+   In scope:
+   - [item]
+   Out of scope:
+   - [item]
+
+   --- AFFECTED COMPONENTS ---
+   - [component]
+
+   --- RISK ASSESSMENT ---
+   - [risk]
+
+   --- RELATED ISSUES ---
+   - [issue ref]
+
+   [Bug-only sections if applicable]
+
+   =============================================
+   Critique summary: N findings applied (X Critical, Y High, Z Medium, W Low)
+
+   Review the specification above. Provide any changes, or type "approved" to proceed with issue creation.
+   ```
+
+2. If user provides feedback:
+   - Incorporate the feedback into the specification.
+   - Re-present the updated specification.
+   - If user's feedback contradicts a critique finding from Step 3: flag the contradiction, explain which finding is affected, ask for confirmation. User has final authority.
+   - Repeat until user approves.
+
+3. If user types "approved" (or equivalent affirmation such as "looks good", "go ahead", "lgtm", "create it"):
+   - Mark specification as approved.
+   - Proceed to Step 8.
+
+4. If user abandons (stops responding or says "cancel"):
+   - The specification remains in draft state.
+   - WF1 terminates without creating an issue.
+   - Summary: "WF1 cancelled. No issue created. Draft specification is available in this conversation for future reference."
+
+### Output
+
+Approved specification (or cancellation). Step 8 only runs after explicit approval.
+
+#### Failure Modes
+
+- User requests changes that contradict critique findings from Step 3 → flag the contradiction, explain which critique finding is affected, and ask for confirmation. User has final authority.
+- User abandons the review (stops responding or says "cancel") → workflow cannot proceed to Step 8 without approval; specification remains in draft state, WF1 terminates without creating an issue.
+
+---
+
+## Step 8: Create GitHub Issue
+
+### Instructions
+
+1. Render the approved specification into a markdown body string that conforms to the GitHub issue template structure.
+
+2. Write the body to a temporary file to handle multi-line content and special characters:
+
+   ```bash
+   cat << 'ISSUE_BODY_EOF' > /tmp/wf1-issue-body.md
+   [full markdown body]
+   ISSUE_BODY_EOF
+   ```
+
+3. Determine labels:
+   - Base label: `enhancement` for features, `bug` for bugs.
+   - Scope labels: based on affected components (e.g., `engine`, `dashboard`, `ml`, `infrastructure`, `api`).
+   - Only use labels that already exist in the repository. Check with:
+     ```bash
+     gh label list --repo ${capabilities.repo}
+     ```
+   - If a needed label does not exist, create it:
+     ```bash
+     gh label create "engine" --repo ${capabilities.repo} --description "Engine (Python backend)" --color "0E8A16"
+     ```
+
+4. Create the issue:
+
+   ```bash
+   gh issue create \
+     --repo ${capabilities.repo} \
+     --title "feat(engine): implement two-stage entry validation" \
+     --body-file /tmp/wf1-issue-body.md \
+     --label "enhancement" \
+     --label "engine"
+   ```
+
+5. Capture the output URL (gh issue create prints the URL to stdout).
+
+6. **Failure handling:**
+   - Authentication failure: verify PAT with `gh auth status`. The fine-grained PAT has Issues (r/w) scope.
+   - Network failure: retry once after 5 seconds. If still failing, save the specification to `${activeProject.path}/docs/plans/draft-issue-YYYY-MM-DD.md` and instruct the user to create manually.
+   - Rate limiting: wait 60 seconds and retry.
+
+7. Clean up temp file:
+   ```bash
+   rm -f /tmp/wf1-issue-body.md
+   ```
+
+### Output
+
+GitHub issue URL (e.g., `https://github.com/${capabilities.repo}/issues/NNN`).
+
+#### Failure Modes
+
+- `gh` CLI authentication failure → verify PAT with `gh auth status`; the fine-grained PAT has Issues (r/w) scope
+- Network failure → retry once after 5 seconds; if still failing, save the issue specification locally to `${activeProject.path}/docs/plans/draft-issue-YYYY-MM-DD.md` and instruct the user to create manually
+- Rate limiting by GitHub API → wait 60 seconds and retry with exponential backoff
+
+---
+
+## Step 9: Workflow Completion Summary
+
+### Instructions
+
+1. Update `claude_docs/session_notes.md` with WF1 results: issue URL, type, critique findings summary, loop-back count, memorized insights.
+
+2. Present a completion summary:
+
+```
+WF1 COMPLETE
+=============
+
+GitHub Issue: [URL] (Issue #NNN)
+Type: [feature / bug]
+Title: [title]
+
+Critique Summary:
+- Total findings: N
+- Applied: N (X Critical, Y High, Z Medium, W Low)
+- Ambiguity circuit breaker: [triggered / not triggered]
+- Loop-backs: [0 / 1 / 2]
+- Memorized insights: [N insights saved via /reflexion:memorize / none]
+
+User Review: [N iterations / approved immediately]
+
+WF1 complete. To implement this feature, invoke WF2 (Feature Implementation) separately, referencing issue #NNN.
+```
+
+Do NOT suggest auto-transitioning to WF2. Do NOT ask "shall I start implementing?" The workflow terminates here.
+
+### Output
+
+Completion summary message. WF1 terminates.
+
+#### Failure Modes
+
+- None — this is an informational step. If previous steps failed, this step reports the partial completion status.
+
+---
+
+<completion-gate>
+Before declaring WF1 complete, verify ALL of the following. Print the checklist with pass/fail for each item:
+
+1. [ ] Step markers logged for ALL executed steps in session notes
+2. [ ] Final step output (completion summary) presented to user
+3. [ ] Session notes updated with completion summary
+4. [ ] Issue URL documented in session notes
+5. [ ] Memorize step completed (insights saved or correctly skipped)
+6. [ ] Issue body matches critique findings
+
+If ANY item fails, go back and complete it before declaring "WF1 complete."
+You may NOT output "WF1 complete" until all items pass.
+</completion-gate>
+
+---
+
+## Workflow Resumption
+
+If this skill is invoked mid-conversation, detect the current state:
+
+0. All step markers present but completion-gate not printed? → Run completion-gate, then terminate.
+1. Was a GitHub issue just created? → Step 9 (summary only)
+2. Was the spec approved by user? → Step 8 (create issue)
+3. Is there a refined spec with critique findings applied? → Step 7 (user review)
+4. Is there a critique findings list? → Step 4 (apply findings)
+5. Is there a draft specification? → Step 3 (critique)
+6. None of the above → Step 1 (start from scratch)
+
+Announce the detected state before resuming: "Detected prior progress. Resuming at Step N."

--- a/skills/create-issue-workspace/skill-snapshot/SKILL.md
+++ b/skills/create-issue-workspace/skill-snapshot/SKILL.md
@@ -1,0 +1,608 @@
+---
+name: rawgentic:create-issue
+description: Create a GitHub issue (feature request or bug report) using the WF1 9-step workflow with multi-agent critique, ambiguity circuit breaker, and user review. Invoke with /create-issue followed by a description of the desired feature or observed bug.
+argument-hint: Description of the feature to request or bug to report
+---
+
+
+# WF1: Issue Creation Workflow (v1.0)
+
+<role>
+You are the WF1 orchestrator implementing a 9-step issue creation workflow. You guide the user from raw intent through brainstorming, multi-agent critique, ambiguity resolution, user review, and GitHub issue creation. You enforce quality gates at each step and NEVER auto-transition to WF2 (Feature Implementation).
+</role>
+
+<constants>
+MAX_LOOPBACK_ITERATIONS = 2
+VOLUME_THRESHOLDS:
+  Critical: 5
+  High: 5
+  Medium: 10
+  Low: 10
+TEMPLATE_DIR = ".github/ISSUE_TEMPLATE"
+</constants>
+
+<config-loading>
+Before executing any workflow steps, load the project configuration:
+
+1. Determine the active project using this fallback chain:
+   **Level 1 -- Conversation context:** If a previous `/rawgentic:switch` in this session set the active project, use that.
+   **Level 2 -- Session registry:** Read `claude_docs/session_registry.jsonl`. Grep for your session_id. If found, use the project from the most recent matching line.
+   **Level 3 -- Workspace default:** Read `.rawgentic_workspace.json` from the Claude root directory. If exactly one project has `active == true`, use it. If multiple projects are active, STOP and tell user: "Multiple active projects. Run `/rawgentic:switch <name>` to bind this session."
+
+   At any level:
+   - `.rawgentic_workspace.json` missing -> STOP. Tell user: "No rawgentic workspace found. Run /rawgentic:new-project."
+   - `.rawgentic_workspace.json` malformed -> STOP. Tell user: "Workspace file is corrupted. Run /rawgentic:new-project to regenerate, or fix manually."
+   - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
+   - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
+
+1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
+   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
+     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
+       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
+       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
+     - Otherwise, tell user:
+       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
+   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
+     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
+   - Otherwise: proceed to step 2.
+
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so all 11
+   workflow skills and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
+
+All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
+</config-loading>
+
+<environment-setup>
+Constants are populated at workflow start (Step 1) from the config loaded in `<config-loading>`:
+- `capabilities.repo`: from config.repo.fullName
+- `capabilities.default_branch`: from config.repo.defaultBranch
+
+If config loading fails, STOP and follow the error instructions in `<config-loading>`. Do not assume values.
+</environment-setup>
+
+<termination-rule>
+WF1 ALWAYS terminates after issue creation. WF2 (Feature Implementation) requires explicit, separate invocation. There is NO auto-transition from WF1 to WF2 under ANY circumstance. Do not suggest "shall I implement this?" or "would you like to start WF2?" WF1 terminates ONLY after the completion-gate passes. All steps must have markers in session notes.
+</termination-rule>
+
+<context-compaction>
+Per CLAUDE.md shared invariant #9: before context compaction, document in `claude_docs/session_notes.md`: current step number, loop-back iteration count, circuit breaker state (clear/blocked), issue type (feature/bug), and critique findings summary if past Step 3.
+</context-compaction>
+
+<ambiguity-circuit-breaker>
+Per CLAUDE.md shared invariant #1: STOP and ask the user when critique findings are ambiguous, conflicting, or require judgment calls not covered by the original description. This circuit breaker fires in Step 4 but the principle applies throughout the workflow — if ANY step encounters ambiguity that could lead to a wrong outcome, STOP and ask rather than guess.
+</ambiguity-circuit-breaker>
+
+<step-tracking>
+At the end of each step, log a marker in `claude_docs/session_notes.md`:
+`### WF1 Step X: <Name> — DONE (<key detail>)`
+This enables workflow resumption if context is lost.
+</step-tracking>
+
+## Step 1: Receive User Intent
+
+### Instructions
+
+1. Acknowledge the user's request.
+2. **Execute `<config-loading>`** to load project configuration and build capabilities. Log resolved values in session notes. If config loading fails, follow the error instructions in `<config-loading>`.
+3. Classify the intent as "feature" or "bug" based on the description provided.
+4. If classification is ambiguous, ask: "Is this a feature request (new functionality) or a bug report (existing behavior that is broken)?"
+5. Check for sufficient information to generate meaningful acceptance criteria. If insufficient, ask targeted clarifying questions:
+   - For features: "What is the desired behavior? Which part of the system is affected? What problem does this solve?"
+   - For bugs: "What is the expected behavior? What is the actual behavior? Can you reproduce it? Which VM/container is affected?"
+6. Run a deduplication check:
+   ```bash
+   gh issue list --repo ${capabilities.repo} --search "<keywords from description>" --limit 10
+   ```
+7. If potential duplicates found, present them to the user and ask: "Any of these existing issues cover your request?"
+8. Update `claude_docs/session_notes.md` with: issue description, classification (feature/bug), initial scope hints, duplicate check results.
+9. Confirm classification with the user before proceeding.
+
+### Output Format
+
+Present to user:
+
+```
+Issue Classification:
+- Type: [feature / bug]
+- Summary: [one-sentence summary of the intent]
+- Scope hints: [components/systems mentioned]
+- Existing issues found: [list or "none"]
+
+Proceeding to brainstorm. Confirm or correct this classification.
+```
+
+Wait for user confirmation before proceeding to Step 2.
+
+#### Failure Modes
+
+- User provides insufficient information → ask targeted clarifying questions (expected behavior, actual behavior, affected system area). Do not proceed until intent is clear enough to generate meaningful acceptance criteria.
+- Classification ambiguous (could be feature or bug) → ask explicitly: "Is this a feature request or a bug report?"
+- Dedup check finds a matching issue → present to user and ask if it covers their request before proceeding
+
+---
+
+## Step 2: Brainstorm Feature/Bug Details
+
+### Instructions
+
+**Brainstorming approach:** For complex features (multi-component, architectural changes), invoke `superpowers:brainstorming` to run the full design pipeline (context exploration → clarifying questions → approach proposals → design validation). For simpler features or bug reports, proceed with inline brainstorming using the instructions below. The tooling audit recommends `superpowers:brainstorming` as the primary tool for Step 2.
+
+1. Read the matching GitHub issue template:
+   - Feature: `${activeProject.path}/.github/ISSUE_TEMPLATE/feature_request.md`
+   - Bug: `${activeProject.path}/.github/ISSUE_TEMPLATE/bug_report.md`
+
+2. Read codebase context:
+   - config (architecture from config.services and config.techStack, quality standards from project conventions)
+   - MEMORY.md (project memory, infrastructure context)
+   - Relevant source files identified from scope hints
+
+3. Use Serena MCP (`find_symbol`, `get_symbols_overview`) to verify that any components, files, or symbols referenced in the brainstorm actually exist in the codebase.
+
+4. Generate a comprehensive draft issue specification that MUST conform to the template structure. Include:
+   - **Title:** Conventional format (`feat(scope): description` or `fix(scope): description`)
+   - **Description:** Detailed with context and motivation
+   - **Acceptance criteria:** Numbered, testable, specific (minimum 3 criteria)
+   - **Scope:** Explicit in-scope AND out-of-scope lists
+   - **Affected components:** Verified against actual codebase (use Serena)
+   - **Risk assessment:** Dependencies, blockers, security implications
+   - **Complexity:** T-shirt size (S/M/L/XL) with justification
+   - **Related issues:** Cross-reference from dedup search
+
+   For bugs, additionally include:
+   - Steps to reproduce
+   - Expected vs. actual behavior
+   - Environment details
+   - Error logs (if available)
+
+5. Optionally, if the feature is complex and would benefit from divergent thinking, use the sdd:create-ideas technique: generate 6 approaches (3 high-probability, 3 tail-of-distribution) before selecting the best approach for the specification.
+
+6. If the feature involves a library or framework API, use Context7 MCP (`resolve-library-id` → `query-docs`) to fetch up-to-date documentation before finalizing the specification.
+
+### Output
+
+The draft specification is an internal working artifact. Do NOT present it to the user yet -- it goes directly to Step 3 for critique.
+
+#### Failure Modes
+
+- Brainstorm produces overly vague acceptance criteria → the critique step (Step 3) will catch this
+- Brainstorm hallucinates non-existent components or files → the critique step verifies claims against actual codebase via Serena
+- Brainstorm duplicates an existing issue → brainstorm should include a dedup check via `gh issue list --search`
+- No issue template exists in `.github/ISSUE_TEMPLATE/` → create the template first, then proceed with brainstorm
+
+---
+
+## Step 3: Full Critique of Brainstorm Output
+
+### Instructions
+
+**Critique method preference:** Before running the critique, check the active project entry's `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the 3-judge critique below. If missing or `"reflexion"`, proceed as normal.
+
+1. Launch all three judges in a single message with three parallel Agent tool calls (subagent_type="general-purpose"), each operating independently:
+
+   **Judge 1: Requirements Validator**
+   - Evaluate: completeness of acceptance criteria, scope clarity, edge case coverage, template conformance
+   - Verify: all referenced components/files exist (use Serena MCP via `find_symbol`)
+   - Check: deduplication against existing issues
+
+   **Judge 2: Solution Architect**
+   - Evaluate: feasibility, complexity estimate accuracy, hidden dependencies
+   - Check: consistency with existing architecture (from config.services, config.techStack)
+   - Assess: risk assessment completeness
+
+   **Judge 3: Code Quality Reviewer**
+   - Evaluate: acceptance criteria testability, scope boundaries, wording clarity
+   - Check: alignment with project security standards (from config.security)
+   - Verify: no hallucinated claims about codebase capabilities
+
+2. Each judge produces findings with the following structure per finding:
+
+   ```
+   Finding #N:
+   - Severity: Critical | High | Medium | Low
+   - Category: completeness | accuracy | feasibility | consistency | deduplication | template_conformance
+   - Description: [what the issue is]
+   - Recommendation: [specific action to take]
+   - Ambiguity flag: clear | ambiguous
+   - Ambiguity reason: [why, if ambiguous]
+   ```
+
+3. Synthesize findings across all three judges. Conduct a debate round if judges disagree on a finding. Unresolved disagreements are flagged as ambiguous.
+
+4. **Volume threshold check** (independent per tier, not combined):
+   - More than 5 Critical findings: TRIGGER LOOP-BACK
+   - More than 5 High findings: TRIGGER LOOP-BACK
+   - More than 10 Medium findings: TRIGGER LOOP-BACK
+   - More than 10 Low findings: TRIGGER LOOP-BACK
+
+5. **If loop-back triggered:**
+   - Check `loop_iteration` counter.
+   - If `loop_iteration < MAX_LOOPBACK_ITERATIONS` (i.e., < 2):
+     - Increment `loop_iteration`.
+     - Present ALL findings to the user as targeted clarifying questions.
+     - Work through each finding to tighten requirements.
+     - Return to Step 2 (re-brainstorm with improved requirements).
+   - If `loop_iteration >= MAX_LOOPBACK_ITERATIONS`:
+     - STOP looping. Escalate to user:
+       ```
+       After 2 requirement refinement iterations, the critique still produces findings
+       above volume thresholds. Here is the full finding list:
+       [all findings]
+       Please review and decide how to proceed:
+       (a) Continue with current findings (proceed to Step 4)
+       (b) Abandon this issue and start over
+       (c) Provide additional clarification and retry
+       ```
+     - Wait for user decision before proceeding.
+
+6. **If volume thresholds pass:** Proceed to Step 4 with the full findings list.
+
+### Output
+
+Prioritized findings list with severity tiers and ambiguity flags. This is NOT presented to the user directly -- it feeds into Step 4.
+
+#### Failure Modes
+
+- Critique finds zero issues (suspicious) → verify the critique sub-agents actually read the codebase context and that debate rounds occurred
+- Finding volume exceeds thresholds → loop back to Step 2 for requirements clarification (max 2 iterations)
+- Critique sub-agents disagree fundamentally → unresolved disagreements are flagged as ambiguous for user attention in Step 4
+
+---
+
+## Step 4: Apply Critique Findings (with Ambiguity Circuit Breaker)
+
+### Instructions
+
+This step implements the circuit breaker logic. It is prompt-level logic, not a separate tool.
+
+0. **Adversarial review sub-step (opt-in, cross-model — runs FIRST).** Before scanning findings, optionally augment the Step 3 critique with a cross-model (Codex) review of the **draft issue spec**. This is **DEFAULT-OFF** because WF1 already runs a full same-model 3-judge critique at Step 3; the cross-model pass is additive and opt-in. Gate it on project opt-in (check FIRST so a disabled project is a true no-op — no temp file, no subprocess):
+   ```bash
+   python3 hooks/adversarial_review_lib.py is-enabled \
+     --workspace .rawgentic_workspace.json --project <name> --skill create-issue
+   ```
+   The command exits `0` when enabled for `create-issue` and non-zero otherwise. If non-zero, **skip silently** — behavior is byte-for-byte unchanged. When enabled, write the draft spec to a temp file under the project and invoke `/rawgentic:adversarial-review <spec-path> spec`. It is **report-only**; **merge** its findings into the Step 3 findings list, tagging each `source: adversarial` (reflexion findings are `source: reflexion`). The merged set then flows through the ambiguity scan and circuit breaker below (items 1–4) — so an ambiguous adversarial finding correctly triggers the breaker and is presented to the user alongside the rest.
+   - **WF1 has NO `plan_lib` loop-back counter** (its only loop-back is `loop_iteration`, which lives in Step 3's volume-threshold check — already passed by the time we reach Step 4). Therefore the adversarial sub-step does **NOT** call `plan_lib.consume_loopback` and does **NOT** re-trigger Step 3's volume thresholds; adversarial findings are resolved purely through this step's circuit breaker / amendment flow.
+   - **Codex failure is non-blocking** (the same-model critique already ran): on ANY non-success from the review — not installed, unauthenticated, timeout, error, parse error, including in headless mode — do NOT trigger the ERROR protocol and do NOT block issue creation; skip the adversarial layer, log loudly in session notes, and continue with the reflexion findings only. (Only the standalone `/rawgentic:adversarial-review` skill ERRORs on an unmet Codex prerequisite.)
+   - Log a marker: `### WF1 Step 4 — Adversarial Review (invoked|skipped): <report path or skip reason>`.
+
+1. **Scan all findings for ambiguity:**
+
+   ```
+   ambiguous_findings = [f for f in findings if f.ambiguity_flag == "ambiguous"]
+   ```
+
+2. **Check for pairwise conflicts:**
+   For each pair of findings (finding_i, finding_j):
+   - Do their recommendations contradict each other? (e.g., "narrow scope to X" vs. "add acceptance criteria for Y which is outside X")
+   - If yes, add both to `conflicting_findings` list.
+
+3. **Check for judgment-call findings:**
+   For each finding:
+   - Does applying it require information not present in the original user description or codebase context?
+   - If yes, add to `judgment_findings` list.
+
+4. **Circuit breaker evaluation:**
+
+   **CLEAR PATH** (no ambiguity, no conflicts, no judgment calls):
+   - Produce amendment list from ALL findings (Critical + High + Medium + Low).
+   - Proceed directly to Step 5.
+   - Brief notification to user: "Critique complete. N findings applied (X Critical, Y High, Z Medium, W Low). All clear -- no ambiguity detected."
+
+   **BLOCKED PATH** (any ambiguity, conflict, or judgment call detected):
+   - STOP the workflow.
+   - Present the problematic findings to the user:
+
+     ```
+     CIRCUIT BREAKER TRIGGERED
+
+     The following findings cannot be applied automatically:
+
+     AMBIGUOUS FINDINGS:
+     [list with ambiguity reasons]
+
+     CONFLICTING FINDINGS:
+     [list with conflict explanations]
+
+     JUDGMENT-CALL FINDINGS:
+     [list with explanations of what information is missing]
+
+     Please resolve each item:
+     - For ambiguous findings: clarify the intended interpretation
+     - For conflicting findings: decide which finding takes priority
+     - For judgment-call findings: provide the missing information
+
+     You may also add your own amendments not raised by the critique.
+     ```
+
+   - Wait for user resolution.
+   - If user rejects a Critical finding: warn that Critical findings address fundamental issues and ask for confirmation. User has final authority (P11).
+   - After resolution: produce amendment list (all findings + user-added amendments).
+   - Proceed to Step 5.
+
+### Output
+
+Amendment list with workflow_state ("clear" or "blocked_resolved").
+
+#### Failure Modes
+
+- User rejects a Critical finding → warn that Critical items address fundamental issues (wrong component references, security gaps) and ask for confirmation. User has final authority.
+- Circuit breaker triggers on most runs → indicates the critique step is flagging too many ambiguous findings; tune ambiguity detection or improve brainstorm specificity
+- User adds amendments that contradict original brainstorm intent → flag the contradiction and ask for clarification
+
+---
+
+## Step 5: Incorporate Amendments into Issue Specification
+
+### Instructions
+
+1. Take the original draft specification from Step 2 and the amendment list from Step 4.
+2. For each amendment, apply the change:
+   - `add_criterion`: Insert acceptance criterion in the appropriate section. Annotate: "[Added per critique finding #N]"
+   - `fix_error`: Correct the error silently (wrong component name, wrong file path).
+   - `adjust_scope`: Update both in-scope and out-of-scope sections.
+   - `add_risk`: Append to risk assessment section.
+   - `improve_wording`: Revise wording in the specified section.
+   - `add_detail`: Add detail to the specified section.
+3. After applying all amendments, verify:
+   - No internal contradictions introduced (e.g., scope narrowed but new criteria added outside the narrowed scope).
+   - Specification still conforms to the GitHub issue template structure.
+   - Total length is reasonable (under 2000 words for a single issue). If over 2000 words, suggest splitting into multiple issues.
+4. Produce the refined specification.
+
+### Output
+
+Refined issue specification (internal working artifact). Immediately proceeds to Steps 6 and 7 in parallel: Step 6 (memorization) runs as a background operation via the Agent tool with run_in_background=true, while Step 7 (user review) proceeds interactively in the foreground.
+
+#### Failure Modes
+
+- Amendment incorporation introduces internal contradictions (scope narrowed but new criteria added outside narrowed scope) → flag the contradiction to the user before proceeding
+- Refined specification exceeds 2000 words → suggest splitting into multiple issues with cross-references
+
+---
+
+## Step 6: Conditional Memorization (runs in parallel with Step 7)
+
+### Instructions
+
+This step runs concurrently with Step 7 (User Review). It does NOT block Step 7.
+
+1. Review the critique findings from Step 3. Identify findings that surface reusable insights -- patterns applicable beyond this specific issue:
+   - Architecture constraints that future features must respect
+   - Anti-patterns discovered during critique
+   - Codebase conventions not yet documented
+   - Recurring pitfalls that should be added to verification checklists
+
+2. If memorizable insights exist:
+   - Follow the reflexion:memorize workflow (ACE pattern):
+     a. Extract the insight from critique context.
+     b. Check against MEMORY.md and session notes.
+     c. If novel, run /reflexion:memorize for reusable insights.
+     d. If MEMORY.md is at capacity, suggest archiving stale entries or moving detailed content to topic-specific files.
+   - Do NOT store in mem0 unless the insight is cross-project. If the insight IS cross-project (infrastructure, deployment, API quirks), store in mem0 via `search_memory` (check for duplicates) then `add_memory`.
+
+3. If no memorizable insights exist: skip this step entirely. No output.
+
+4. Periodically (suggested: every 10 `/create-issue` invocations), consider running `/reflexion:memorize` to consolidate insights. This is NOT a per-run action.
+
+### Output
+
+Updated memory (if insights memorized via /reflexion:memorize) or no output (if skipped). Does not affect Step 7.
+
+#### Failure Modes
+
+- Over-memorization: storing trivial or context-specific findings as general principles → the memorize command should filter for novelty and generalizability
+- MEMORY.md at capacity → suggest archiving stale entries or moving detailed content to topic-specific files
+- Duplicate memorization → the memorize command should deduplicate against existing content before appending
+
+---
+
+## Step 7: User Review & Refinement (runs in parallel with Step 6)
+
+### Instructions
+
+This step runs concurrently with Step 6 (Memorization). It does NOT wait for Step 6 to complete.
+
+1. Present the refined specification to the user in a readable format:
+
+   ```
+   DRAFT ISSUE SPECIFICATION (Ready for Review)
+   =============================================
+
+   Title: [conventional format title]
+   Type: [feature / bug]
+   Labels: [label list]
+   Complexity: [T-shirt size]
+
+   --- DESCRIPTION ---
+   [description text]
+
+   --- ACCEPTANCE CRITERIA ---
+   1. [criterion 1]
+   2. [criterion 2]
+   ...
+
+   --- SCOPE ---
+   In scope:
+   - [item]
+   Out of scope:
+   - [item]
+
+   --- AFFECTED COMPONENTS ---
+   - [component]
+
+   --- RISK ASSESSMENT ---
+   - [risk]
+
+   --- RELATED ISSUES ---
+   - [issue ref]
+
+   [Bug-only sections if applicable]
+
+   =============================================
+   Critique summary: N findings applied (X Critical, Y High, Z Medium, W Low)
+
+   Review the specification above. Provide any changes, or type "approved" to proceed with issue creation.
+   ```
+
+2. If user provides feedback:
+   - Incorporate the feedback into the specification.
+   - Re-present the updated specification.
+   - If user's feedback contradicts a critique finding from Step 3: flag the contradiction, explain which finding is affected, ask for confirmation. User has final authority.
+   - Repeat until user approves.
+
+3. If user types "approved" (or equivalent affirmation such as "looks good", "go ahead", "lgtm", "create it"):
+   - Mark specification as approved.
+   - Proceed to Step 8.
+
+4. If user abandons (stops responding or says "cancel"):
+   - The specification remains in draft state.
+   - WF1 terminates without creating an issue.
+   - Summary: "WF1 cancelled. No issue created. Draft specification is available in this conversation for future reference."
+
+### Output
+
+Approved specification (or cancellation). Step 8 only runs after explicit approval.
+
+#### Failure Modes
+
+- User requests changes that contradict critique findings from Step 3 → flag the contradiction, explain which critique finding is affected, and ask for confirmation. User has final authority.
+- User abandons the review (stops responding or says "cancel") → workflow cannot proceed to Step 8 without approval; specification remains in draft state, WF1 terminates without creating an issue.
+
+---
+
+## Step 8: Create GitHub Issue
+
+### Instructions
+
+1. Render the approved specification into a markdown body string that conforms to the GitHub issue template structure.
+
+2. Write the body to a temporary file to handle multi-line content and special characters:
+
+   ```bash
+   cat << 'ISSUE_BODY_EOF' > /tmp/wf1-issue-body.md
+   [full markdown body]
+   ISSUE_BODY_EOF
+   ```
+
+3. Determine labels:
+   - Base label: `enhancement` for features, `bug` for bugs.
+   - Scope labels: based on affected components (e.g., `engine`, `dashboard`, `ml`, `infrastructure`, `api`).
+   - Only use labels that already exist in the repository. Check with:
+     ```bash
+     gh label list --repo ${capabilities.repo}
+     ```
+   - If a needed label does not exist, create it:
+     ```bash
+     gh label create "engine" --repo ${capabilities.repo} --description "Engine (Python backend)" --color "0E8A16"
+     ```
+
+4. Create the issue:
+
+   ```bash
+   gh issue create \
+     --repo ${capabilities.repo} \
+     --title "feat(engine): implement two-stage entry validation" \
+     --body-file /tmp/wf1-issue-body.md \
+     --label "enhancement" \
+     --label "engine"
+   ```
+
+5. Capture the output URL (gh issue create prints the URL to stdout).
+
+6. **Failure handling:**
+   - Authentication failure: verify PAT with `gh auth status`. The fine-grained PAT has Issues (r/w) scope.
+   - Network failure: retry once after 5 seconds. If still failing, save the specification to `${activeProject.path}/docs/plans/draft-issue-YYYY-MM-DD.md` and instruct the user to create manually.
+   - Rate limiting: wait 60 seconds and retry.
+
+7. Clean up temp file:
+   ```bash
+   rm -f /tmp/wf1-issue-body.md
+   ```
+
+### Output
+
+GitHub issue URL (e.g., `https://github.com/${capabilities.repo}/issues/NNN`).
+
+#### Failure Modes
+
+- `gh` CLI authentication failure → verify PAT with `gh auth status`; the fine-grained PAT has Issues (r/w) scope
+- Network failure → retry once after 5 seconds; if still failing, save the issue specification locally to `${activeProject.path}/docs/plans/draft-issue-YYYY-MM-DD.md` and instruct the user to create manually
+- Rate limiting by GitHub API → wait 60 seconds and retry with exponential backoff
+
+---
+
+## Step 9: Workflow Completion Summary
+
+### Instructions
+
+1. Update `claude_docs/session_notes.md` with WF1 results: issue URL, type, critique findings summary, loop-back count, memorized insights.
+
+2. Present a completion summary:
+
+```
+WF1 COMPLETE
+=============
+
+GitHub Issue: [URL] (Issue #NNN)
+Type: [feature / bug]
+Title: [title]
+
+Critique Summary:
+- Total findings: N
+- Applied: N (X Critical, Y High, Z Medium, W Low)
+- Ambiguity circuit breaker: [triggered / not triggered]
+- Loop-backs: [0 / 1 / 2]
+- Memorized insights: [N insights saved via /reflexion:memorize / none]
+
+User Review: [N iterations / approved immediately]
+
+WF1 complete. To implement this feature, invoke WF2 (Feature Implementation) separately, referencing issue #NNN.
+```
+
+Do NOT suggest auto-transitioning to WF2. Do NOT ask "shall I start implementing?" The workflow terminates here.
+
+### Output
+
+Completion summary message. WF1 terminates.
+
+#### Failure Modes
+
+- None — this is an informational step. If previous steps failed, this step reports the partial completion status.
+
+---
+
+<completion-gate>
+Before declaring WF1 complete, verify ALL of the following. Print the checklist with pass/fail for each item:
+
+1. [ ] Step markers logged for ALL executed steps in session notes
+2. [ ] Final step output (completion summary) presented to user
+3. [ ] Session notes updated with completion summary
+4. [ ] Issue URL documented in session notes
+5. [ ] Memorize step completed (insights saved or correctly skipped)
+6. [ ] Issue body matches critique findings
+
+If ANY item fails, go back and complete it before declaring "WF1 complete."
+You may NOT output "WF1 complete" until all items pass.
+</completion-gate>
+
+---
+
+## Workflow Resumption
+
+If this skill is invoked mid-conversation, detect the current state:
+
+0. All step markers present but completion-gate not printed? → Run completion-gate, then terminate.
+1. Was a GitHub issue just created? → Step 9 (summary only)
+2. Was the spec approved by user? → Step 8 (create issue)
+3. Is there a refined spec with critique findings applied? → Step 7 (user review)
+4. Is there a critique findings list? → Step 4 (apply findings)
+5. Is there a draft specification? → Step 3 (critique)
+6. None of the above → Step 1 (start from scratch)
+
+Announce the detected state before resuming: "Detected prior progress. Resuming at Step N."

--- a/skills/create-issue-workspace/trigger-eval.json
+++ b/skills/create-issue-workspace/trigger-eval.json
@@ -1,0 +1,23 @@
+[
+  {"query": "can you open a github issue for adding CSV export to the grocusave dashboard? users keep asking for it", "should_trigger": true},
+  {"query": "file a bug report — the price-zone scraper on grocusave silently skips stores when Algolia returns a 429, there's no retry", "should_trigger": true},
+  {"query": "I need an issue created for supporting dark mode in the chorestory web app, with proper acceptance criteria and scope", "should_trigger": true},
+  {"query": "we should track this properly: the websocket reconnect logic drops messages during the gap. make an issue in the repo for it", "should_trigger": true},
+  {"query": "write up a feature request for letting admins bulk-reassign chores and put it on github", "should_trigger": true},
+  {"query": "log an issue for the OAuth callback 500ing when the state cookie is missing — repro is reliable on staging", "should_trigger": true},
+  {"query": "create-issue for adding rate limiting to the public API endpoints", "should_trigger": true},
+  {"query": "the pdf export hangs on docs over 50 pages. i want to report it properly with repro steps and environment, open it on github", "should_trigger": true},
+  {"query": "can you draft and file a github issue requesting a /healthz endpoint for the sentinel service?", "should_trigger": true},
+  {"query": "i keep hitting this: the deploy action doesn't fail when the build only warns. open a tracked issue for fixing the gate", "should_trigger": true},
+
+  {"query": "implement issue #137 — the websocket support feature", "should_trigger": false},
+  {"query": "go ahead and fix the bug where the throttler drops connections under load", "should_trigger": false},
+  {"query": "list all open issues on grocusave labeled 'enhancement'", "should_trigger": false},
+  {"query": "leave a comment on github issue #88 summarizing the root cause we found", "should_trigger": false},
+  {"query": "write a PRD for the new family-sharing feature in chorestory", "should_trigger": false},
+  {"query": "create the next story for the sprint from the epic", "should_trigger": false},
+  {"query": "add a bug_report.md issue template to the .github folder", "should_trigger": false},
+  {"query": "set up a new rawgentic project for the windrose game", "should_trigger": false},
+  {"query": "which github issues are assigned to me across all the repos?", "should_trigger": false},
+  {"query": "review this PR and tell me whether it actually closes issue #42", "should_trigger": false}
+]

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -1,608 +1,187 @@
 ---
 name: rawgentic:create-issue
-description: Create a GitHub issue (feature request or bug report) using the WF1 9-step workflow with multi-agent critique, ambiguity circuit breaker, and user review. Invoke with /create-issue followed by a description of the desired feature or observed bug.
+description: Open and file a NEW GitHub issue — a feature request or bug report — for the active rawgentic project. Use whenever the user wants to capture a desired feature/enhancement or an observed/reproducible bug as a tracked issue, however phrased ("open/log/raise/file an issue", "write up a bug report", "file a feature request", "put it on github", "track this", "users keep asking for X"), even when no repo is named. It targets the repo from the project config, checks for duplicates, conforms to the issue template, and verifies referenced code exists. Do NOT use to implement/fix/code the change itself, to list/search/read existing issues, to comment on or review a PR against an issue, or to edit issue-template files. Invoke with /create-issue followed by a description of the desired feature or observed bug.
 argument-hint: Description of the feature to request or bug to report
 ---
 
-
-# WF1: Issue Creation Workflow (v1.0)
+# WF1: Issue Creation (lean)
 
 <role>
-You are the WF1 orchestrator implementing a 9-step issue creation workflow. You guide the user from raw intent through brainstorming, multi-agent critique, ambiguity resolution, user review, and GitHub issue creation. You enforce quality gates at each step and NEVER auto-transition to WF2 (Feature Implementation).
+You turn a raw feature/bug request into a clean GitHub issue for the active
+rawgentic project: correct repo, no duplicate, template-conformant, and every
+referenced component verified against the real code. You do the drafting yourself —
+no judge panel, no loop-back. You NEVER auto-start implementation (WF2); issue
+creation is where this workflow ends.
 </role>
 
-<constants>
-MAX_LOOPBACK_ITERATIONS = 2
-VOLUME_THRESHOLDS:
-  Critical: 5
-  High: 5
-  Medium: 10
-  Low: 10
-TEMPLATE_DIR = ".github/ISSUE_TEMPLATE"
-</constants>
+<why-this-is-lean>
+An earlier version of this skill ran a 3-judge critique, an ambiguity circuit
+breaker, loop-back iterations, and per-run memorization. Head-to-head evals showed
+a current model already produces an equivalent issue without that machinery — at
+~⅓ the time and tokens. So this version keeps only what adds structure a bare
+prompt wouldn't reliably give (config-based repo targeting, dedup, template
+conformance, codebase grounding) and folds the judges' real value — "don't
+fabricate, don't hallucinate, don't rubber-stamp an over-broad ask" — into a single
+principle you apply while drafting (see <quality-bar>). If a request is genuinely
+high-stakes or architectural and you want adversarial scrutiny, run
+`/rawgentic:adversarial-review` on the draft explicitly; it is not part of the
+default path.
+</why-this-is-lean>
 
 <config-loading>
-Before executing any workflow steps, load the project configuration:
+Before anything else, resolve the active project and load its config — this is what
+makes the issue land on the right repo instead of a guess.
 
-1. Determine the active project using this fallback chain:
-   **Level 1 -- Conversation context:** If a previous `/rawgentic:switch` in this session set the active project, use that.
-   **Level 2 -- Session registry:** Read `claude_docs/session_registry.jsonl`. Grep for your session_id. If found, use the project from the most recent matching line.
-   **Level 3 -- Workspace default:** Read `.rawgentic_workspace.json` from the Claude root directory. If exactly one project has `active == true`, use it. If multiple projects are active, STOP and tell user: "Multiple active projects. Run `/rawgentic:switch <name>` to bind this session."
+1. Determine the active project:
+   - If a prior `/rawgentic:switch` bound this session, use that project.
+   - Else read `claude_docs/session_registry.jsonl`, grep your session_id, use the
+     most recent matching line.
+   - Else read `.rawgentic_workspace.json` from the Claude root. Exactly one project
+     `active == true` → use it. Multiple active → STOP: "Multiple active projects.
+     Run `/rawgentic:switch <name>` to bind this session." Missing/malformed/none
+     active → STOP and tell the user to run `/rawgentic:new-project` (or `switch`).
+   - `activeProject.path` may be relative (e.g. `./projects/app`); resolve it against
+     the directory containing `.rawgentic_workspace.json`.
 
-   At any level:
-   - `.rawgentic_workspace.json` missing -> STOP. Tell user: "No rawgentic workspace found. Run /rawgentic:new-project."
-   - `.rawgentic_workspace.json` malformed -> STOP. Tell user: "Workspace file is corrupted. Run /rawgentic:new-project to regenerate, or fix manually."
-   - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
-   - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
+2. Disabled-skill check: find the active project's entry in `.rawgentic_workspace.json`.
+   If its `disabledSkills` array contains `create-issue`, STOP and tell the user it's
+   disabled (and, if a BMAD alternative was chosen, name it). If workspace
+   `bmadDetected` is true but the entry has no `disabledSkills` field at all, STOP:
+   "BMAD detected but no skill preferences configured — run `/rawgentic:setup`."
 
-1b. **Disabled skill check:** After resolving the active project, read `.rawgentic_workspace.json` (if not already read in step 1) and find the active project's entry.
-   - If the project entry has a `disabledSkills` array and this skill's bare name appears in it: **STOP.**
-     - If the skill is one of {implement-feature, fix-bug, create-tests, update-docs}, tell user:
-       "You chose [mapped BMAD alternative] for [skill] in [project]. To change, re-run `/rawgentic:setup` or edit `disabledSkills` in `.rawgentic_workspace.json`."
-       Mapping: implement-feature -> bmad-dev-story, fix-bug -> bmad-dev-story, create-tests -> bmad-tea agent / bmad-testarch-* workflows, update-docs -> BMAD tech-writer.
-     - Otherwise, tell user:
-       "Skill [name] is disabled in [project]. Remove it from `disabledSkills` in `.rawgentic_workspace.json` to re-enable."
-   - If workspace `bmadDetected` is true but the project entry has **no** `disabledSkills` field: **STOP.** Tell user:
-     "BMAD detected but no skill preferences configured for [project]. Run `/rawgentic:switch` or `/rawgentic:setup` to configure."
-   - Otherwise: proceed to step 2.
-
-2. Load the config and derive capabilities with the helper CLI (one tested
-   source of truth — never hand-derive the `capabilities` object, so all 11
-   workflow skills and the docs table cannot drift apart):
+3. Derive capabilities from one tested source of truth (never hand-derive):
    ```bash
-   python3 hooks/capabilities_lib.py derive \
-     --config <activeProject.path>/.rawgentic.json
+   python3 hooks/capabilities_lib.py derive --config <activeProject.path>/.rawgentic.json
    ```
-   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
-   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
+   Non-zero exit → config missing/corrupt/invalid; STOP and relay the printed message
+   (a version mismatch is only a stderr warning, not fatal). Exit 0 → stdout is
+   `{"config": {...}, "capabilities": {...}}`. Carry `capabilities.repo` and
+   `capabilities.default_branch` as literals into later commands (each Bash call is a
+   fresh shell — shell variables do not persist across calls).
 
-All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
+Use `config`/`capabilities` for repo, branch, architecture, and standards. Trust the
+config over any other file (e.g. a root `CLAUDE.md`); it is the project's contract.
 </config-loading>
 
-<environment-setup>
-Constants are populated at workflow start (Step 1) from the config loaded in `<config-loading>`:
-- `capabilities.repo`: from config.repo.fullName
-- `capabilities.default_branch`: from config.repo.defaultBranch
+<quality-bar>
+Apply these while drafting — they are the judge panel's value, distilled. If any
+trips and you can't resolve it from the request + codebase, STOP and ask the user
+rather than guessing:
 
-If config loading fails, STOP and follow the error instructions in `<config-loading>`. Do not assume values.
-</environment-setup>
+- **No hallucinated components.** Every file/class/function/symbol you name must be
+  verified to exist (see Step 2). If the request names something that doesn't exist,
+  say so and file against the real component instead — don't invent.
+- **No fabricated specifics.** Don't invent acceptance criteria, metrics, or targets
+  the user never gave. If the request is too vague to write testable criteria, ask
+  for specifics; if specifics genuinely aren't available yet, write an investigation
+  issue whose criteria are about *gathering* the data, and mark targets as TBD.
+- **Bound an over-broad ask.** If a request spans many concerns or is "do everything,"
+  either propose splitting into multiple issues or file one issue with an explicit
+  out-of-scope list naming what's deferred.
+</quality-bar>
 
-<termination-rule>
-WF1 ALWAYS terminates after issue creation. WF2 (Feature Implementation) requires explicit, separate invocation. There is NO auto-transition from WF1 to WF2 under ANY circumstance. Do not suggest "shall I implement this?" or "would you like to start WF2?" WF1 terminates ONLY after the completion-gate passes. All steps must have markers in session notes.
-</termination-rule>
+## Step 1: Understand the request
 
-<context-compaction>
-Per CLAUDE.md shared invariant #9: before context compaction, document in `claude_docs/session_notes.md`: current step number, loop-back iteration count, circuit breaker state (clear/blocked), issue type (feature/bug), and critique findings summary if past Step 3.
-</context-compaction>
-
-<ambiguity-circuit-breaker>
-Per CLAUDE.md shared invariant #1: STOP and ask the user when critique findings are ambiguous, conflicting, or require judgment calls not covered by the original description. This circuit breaker fires in Step 4 but the principle applies throughout the workflow — if ANY step encounters ambiguity that could lead to a wrong outcome, STOP and ask rather than guess.
-</ambiguity-circuit-breaker>
-
-<step-tracking>
-At the end of each step, log a marker in `claude_docs/session_notes.md`:
-`### WF1 Step X: <Name> — DONE (<key detail>)`
-This enables workflow resumption if context is lost.
-</step-tracking>
-
-## Step 1: Receive User Intent
-
-### Instructions
-
-1. Acknowledge the user's request.
-2. **Execute `<config-loading>`** to load project configuration and build capabilities. Log resolved values in session notes. If config loading fails, follow the error instructions in `<config-loading>`.
-3. Classify the intent as "feature" or "bug" based on the description provided.
-4. If classification is ambiguous, ask: "Is this a feature request (new functionality) or a bug report (existing behavior that is broken)?"
-5. Check for sufficient information to generate meaningful acceptance criteria. If insufficient, ask targeted clarifying questions:
-   - For features: "What is the desired behavior? Which part of the system is affected? What problem does this solve?"
-   - For bugs: "What is the expected behavior? What is the actual behavior? Can you reproduce it? Which VM/container is affected?"
-6. Run a deduplication check:
+1. Classify as **feature** or **bug**. If ambiguous, ask: "Feature request (new
+   functionality) or bug report (broken existing behavior)?"
+2. If there's too little to write meaningful acceptance criteria, ask targeted
+   questions (feature: desired behavior, affected area, problem solved; bug: expected
+   vs actual, repro steps, environment).
+3. Dedup check — search before drafting so you don't file a duplicate:
    ```bash
-   gh issue list --repo ${capabilities.repo} --search "<keywords from description>" --limit 10
+   gh issue list --repo <capabilities.repo> --search "<keywords>" --limit 10
    ```
-7. If potential duplicates found, present them to the user and ask: "Any of these existing issues cover your request?"
-8. Update `claude_docs/session_notes.md` with: issue description, classification (feature/bug), initial scope hints, duplicate check results.
-9. Confirm classification with the user before proceeding.
+   If a listed issue plausibly covers the request, show it to the user and ask whether
+   it already covers their need before proceeding.
 
-### Output Format
+## Step 2: Draft the issue
 
-Present to user:
+1. Read the matching template:
+   - feature → `<activeProject.path>/.github/ISSUE_TEMPLATE/feature_request.md`
+   - bug → `<activeProject.path>/.github/ISSUE_TEMPLATE/bug_report.md`
+   If no template exists, use a sensible default structure (Description, Acceptance
+   Criteria, Scope, Affected Components, Risk; for bugs: Steps to Reproduce, Expected,
+   Actual, Environment).
+2. **Verify referenced components exist.** Use Serena MCP (`find_symbol`) if installed,
+   otherwise `Grep`/`Glob`/`Read`, to confirm every file/symbol you reference is real.
+   This is what keeps a hallucinated component out of the issue — don't skip it just
+   because Serena is absent.
+3. Write the draft, conforming to the template and the <quality-bar>:
+   - **Title** in conventional form: `feat(scope): …` (feature) or `fix(scope): …`
+     (bug). This keeps issue titles scannable and parseable by downstream tooling.
+   - **Acceptance criteria:** numbered, testable, specific (≥3 where the request
+     supports it).
+   - **Scope:** explicit in-scope AND out-of-scope.
+   - **Affected components:** only verified-real ones.
+   - **Risk assessment** and a complexity t-shirt size (S/M/L/XL).
+   - Bugs also: steps to reproduce, expected vs actual, environment, logs if any.
+   - Cross-reference related issues found in the dedup search.
+   If the draft exceeds ~2000 words, it's probably several issues — suggest splitting.
 
-```
-Issue Classification:
-- Type: [feature / bug]
-- Summary: [one-sentence summary of the intent]
-- Scope hints: [components/systems mentioned]
-- Existing issues found: [list or "none"]
+## Step 3: User review
 
-Proceeding to brainstorm. Confirm or correct this classification.
-```
+Present the draft in a readable form (title, type, labels, complexity, description,
+acceptance criteria, scope, affected components, risk, related issues). Then:
 
-Wait for user confirmation before proceeding to Step 2.
+- Incorporate any feedback and re-present until the user approves.
+- On "approved" / "looks good" / "lgtm" / "go ahead" → proceed to Step 4.
+- If the user cancels or goes silent → stop; no issue is created. The draft stays in
+  the conversation.
 
-#### Failure Modes
+## Step 4: Create the issue
 
-- User provides insufficient information → ask targeted clarifying questions (expected behavior, actual behavior, affected system area). Do not proceed until intent is clear enough to generate meaningful acceptance criteria.
-- Classification ambiguous (could be feature or bug) → ask explicitly: "Is this a feature request or a bug report?"
-- Dedup check finds a matching issue → present to user and ask if it covers their request before proceeding
-
----
-
-## Step 2: Brainstorm Feature/Bug Details
-
-### Instructions
-
-**Brainstorming approach:** For complex features (multi-component, architectural changes), invoke `superpowers:brainstorming` to run the full design pipeline (context exploration → clarifying questions → approach proposals → design validation). For simpler features or bug reports, proceed with inline brainstorming using the instructions below. The tooling audit recommends `superpowers:brainstorming` as the primary tool for Step 2.
-
-1. Read the matching GitHub issue template:
-   - Feature: `${activeProject.path}/.github/ISSUE_TEMPLATE/feature_request.md`
-   - Bug: `${activeProject.path}/.github/ISSUE_TEMPLATE/bug_report.md`
-
-2. Read codebase context:
-   - config (architecture from config.services and config.techStack, quality standards from project conventions)
-   - MEMORY.md (project memory, infrastructure context)
-   - Relevant source files identified from scope hints
-
-3. Use Serena MCP (`find_symbol`, `get_symbols_overview`) to verify that any components, files, or symbols referenced in the brainstorm actually exist in the codebase.
-
-4. Generate a comprehensive draft issue specification that MUST conform to the template structure. Include:
-   - **Title:** Conventional format (`feat(scope): description` or `fix(scope): description`)
-   - **Description:** Detailed with context and motivation
-   - **Acceptance criteria:** Numbered, testable, specific (minimum 3 criteria)
-   - **Scope:** Explicit in-scope AND out-of-scope lists
-   - **Affected components:** Verified against actual codebase (use Serena)
-   - **Risk assessment:** Dependencies, blockers, security implications
-   - **Complexity:** T-shirt size (S/M/L/XL) with justification
-   - **Related issues:** Cross-reference from dedup search
-
-   For bugs, additionally include:
-   - Steps to reproduce
-   - Expected vs. actual behavior
-   - Environment details
-   - Error logs (if available)
-
-5. Optionally, if the feature is complex and would benefit from divergent thinking, use the sdd:create-ideas technique: generate 6 approaches (3 high-probability, 3 tail-of-distribution) before selecting the best approach for the specification.
-
-6. If the feature involves a library or framework API, use Context7 MCP (`resolve-library-id` → `query-docs`) to fetch up-to-date documentation before finalizing the specification.
-
-### Output
-
-The draft specification is an internal working artifact. Do NOT present it to the user yet -- it goes directly to Step 3 for critique.
-
-#### Failure Modes
-
-- Brainstorm produces overly vague acceptance criteria → the critique step (Step 3) will catch this
-- Brainstorm hallucinates non-existent components or files → the critique step verifies claims against actual codebase via Serena
-- Brainstorm duplicates an existing issue → brainstorm should include a dedup check via `gh issue list --search`
-- No issue template exists in `.github/ISSUE_TEMPLATE/` → create the template first, then proceed with brainstorm
-
----
-
-## Step 3: Full Critique of Brainstorm Output
-
-### Instructions
-
-**Critique method preference:** Before running the critique, check the active project entry's `critiqueMethod` field in `.rawgentic_workspace.json`. If set to `"bmad-party-mode"`, use bmad-party-mode instead of the 3-judge critique below. If missing or `"reflexion"`, proceed as normal.
-
-1. Launch all three judges in a single message with three parallel Agent tool calls (subagent_type="general-purpose"), each operating independently:
-
-   **Judge 1: Requirements Validator**
-   - Evaluate: completeness of acceptance criteria, scope clarity, edge case coverage, template conformance
-   - Verify: all referenced components/files exist (use Serena MCP via `find_symbol`)
-   - Check: deduplication against existing issues
-
-   **Judge 2: Solution Architect**
-   - Evaluate: feasibility, complexity estimate accuracy, hidden dependencies
-   - Check: consistency with existing architecture (from config.services, config.techStack)
-   - Assess: risk assessment completeness
-
-   **Judge 3: Code Quality Reviewer**
-   - Evaluate: acceptance criteria testability, scope boundaries, wording clarity
-   - Check: alignment with project security standards (from config.security)
-   - Verify: no hallucinated claims about codebase capabilities
-
-2. Each judge produces findings with the following structure per finding:
-
-   ```
-   Finding #N:
-   - Severity: Critical | High | Medium | Low
-   - Category: completeness | accuracy | feasibility | consistency | deduplication | template_conformance
-   - Description: [what the issue is]
-   - Recommendation: [specific action to take]
-   - Ambiguity flag: clear | ambiguous
-   - Ambiguity reason: [why, if ambiguous]
-   ```
-
-3. Synthesize findings across all three judges. Conduct a debate round if judges disagree on a finding. Unresolved disagreements are flagged as ambiguous.
-
-4. **Volume threshold check** (independent per tier, not combined):
-   - More than 5 Critical findings: TRIGGER LOOP-BACK
-   - More than 5 High findings: TRIGGER LOOP-BACK
-   - More than 10 Medium findings: TRIGGER LOOP-BACK
-   - More than 10 Low findings: TRIGGER LOOP-BACK
-
-5. **If loop-back triggered:**
-   - Check `loop_iteration` counter.
-   - If `loop_iteration < MAX_LOOPBACK_ITERATIONS` (i.e., < 2):
-     - Increment `loop_iteration`.
-     - Present ALL findings to the user as targeted clarifying questions.
-     - Work through each finding to tighten requirements.
-     - Return to Step 2 (re-brainstorm with improved requirements).
-   - If `loop_iteration >= MAX_LOOPBACK_ITERATIONS`:
-     - STOP looping. Escalate to user:
-       ```
-       After 2 requirement refinement iterations, the critique still produces findings
-       above volume thresholds. Here is the full finding list:
-       [all findings]
-       Please review and decide how to proceed:
-       (a) Continue with current findings (proceed to Step 4)
-       (b) Abandon this issue and start over
-       (c) Provide additional clarification and retry
-       ```
-     - Wait for user decision before proceeding.
-
-6. **If volume thresholds pass:** Proceed to Step 4 with the full findings list.
-
-### Output
-
-Prioritized findings list with severity tiers and ambiguity flags. This is NOT presented to the user directly -- it feeds into Step 4.
-
-#### Failure Modes
-
-- Critique finds zero issues (suspicious) → verify the critique sub-agents actually read the codebase context and that debate rounds occurred
-- Finding volume exceeds thresholds → loop back to Step 2 for requirements clarification (max 2 iterations)
-- Critique sub-agents disagree fundamentally → unresolved disagreements are flagged as ambiguous for user attention in Step 4
-
----
-
-## Step 4: Apply Critique Findings (with Ambiguity Circuit Breaker)
-
-### Instructions
-
-This step implements the circuit breaker logic. It is prompt-level logic, not a separate tool.
-
-0. **Adversarial review sub-step (opt-in, cross-model — runs FIRST).** Before scanning findings, optionally augment the Step 3 critique with a cross-model (Codex) review of the **draft issue spec**. This is **DEFAULT-OFF** because WF1 already runs a full same-model 3-judge critique at Step 3; the cross-model pass is additive and opt-in. Gate it on project opt-in (check FIRST so a disabled project is a true no-op — no temp file, no subprocess):
+0. **Optional cross-model review (DEFAULT-OFF).** Before creating, check whether the
+   project opted into an adversarial pass for this skill:
    ```bash
    python3 hooks/adversarial_review_lib.py is-enabled \
      --workspace .rawgentic_workspace.json --project <name> --skill create-issue
    ```
-   The command exits `0` when enabled for `create-issue` and non-zero otherwise. If non-zero, **skip silently** — behavior is byte-for-byte unchanged. When enabled, write the draft spec to a temp file under the project and invoke `/rawgentic:adversarial-review <spec-path> spec`. It is **report-only**; **merge** its findings into the Step 3 findings list, tagging each `source: adversarial` (reflexion findings are `source: reflexion`). The merged set then flows through the ambiguity scan and circuit breaker below (items 1–4) — so an ambiguous adversarial finding correctly triggers the breaker and is presented to the user alongside the rest.
-   - **WF1 has NO `plan_lib` loop-back counter** (its only loop-back is `loop_iteration`, which lives in Step 3's volume-threshold check — already passed by the time we reach Step 4). Therefore the adversarial sub-step does **NOT** call `plan_lib.consume_loopback` and does **NOT** re-trigger Step 3's volume thresholds; adversarial findings are resolved purely through this step's circuit breaker / amendment flow.
-   - **Codex failure is non-blocking** (the same-model critique already ran): on ANY non-success from the review — not installed, unauthenticated, timeout, error, parse error, including in headless mode — do NOT trigger the ERROR protocol and do NOT block issue creation; skip the adversarial layer, log loudly in session notes, and continue with the reflexion findings only. (Only the standalone `/rawgentic:adversarial-review` skill ERRORs on an unmet Codex prerequisite.)
-   - Log a marker: `### WF1 Step 4 — Adversarial Review (invoked|skipped): <report path or skip reason>`.
-
-1. **Scan all findings for ambiguity:**
-
-   ```
-   ambiguous_findings = [f for f in findings if f.ambiguity_flag == "ambiguous"]
-   ```
-
-2. **Check for pairwise conflicts:**
-   For each pair of findings (finding_i, finding_j):
-   - Do their recommendations contradict each other? (e.g., "narrow scope to X" vs. "add acceptance criteria for Y which is outside X")
-   - If yes, add both to `conflicting_findings` list.
-
-3. **Check for judgment-call findings:**
-   For each finding:
-   - Does applying it require information not present in the original user description or codebase context?
-   - If yes, add to `judgment_findings` list.
-
-4. **Circuit breaker evaluation:**
-
-   **CLEAR PATH** (no ambiguity, no conflicts, no judgment calls):
-   - Produce amendment list from ALL findings (Critical + High + Medium + Low).
-   - Proceed directly to Step 5.
-   - Brief notification to user: "Critique complete. N findings applied (X Critical, Y High, Z Medium, W Low). All clear -- no ambiguity detected."
-
-   **BLOCKED PATH** (any ambiguity, conflict, or judgment call detected):
-   - STOP the workflow.
-   - Present the problematic findings to the user:
-
-     ```
-     CIRCUIT BREAKER TRIGGERED
-
-     The following findings cannot be applied automatically:
-
-     AMBIGUOUS FINDINGS:
-     [list with ambiguity reasons]
-
-     CONFLICTING FINDINGS:
-     [list with conflict explanations]
-
-     JUDGMENT-CALL FINDINGS:
-     [list with explanations of what information is missing]
-
-     Please resolve each item:
-     - For ambiguous findings: clarify the intended interpretation
-     - For conflicting findings: decide which finding takes priority
-     - For judgment-call findings: provide the missing information
-
-     You may also add your own amendments not raised by the critique.
-     ```
-
-   - Wait for user resolution.
-   - If user rejects a Critical finding: warn that Critical findings address fundamental issues and ask for confirmation. User has final authority (P11).
-   - After resolution: produce amendment list (all findings + user-added amendments).
-   - Proceed to Step 5.
-
-### Output
-
-Amendment list with workflow_state ("clear" or "blocked_resolved").
-
-#### Failure Modes
-
-- User rejects a Critical finding → warn that Critical items address fundamental issues (wrong component references, security gaps) and ask for confirmation. User has final authority.
-- Circuit breaker triggers on most runs → indicates the critique step is flagging too many ambiguous findings; tune ambiguity detection or improve brainstorm specificity
-- User adds amendments that contradict original brainstorm intent → flag the contradiction and ask for clarification
-
----
-
-## Step 5: Incorporate Amendments into Issue Specification
-
-### Instructions
-
-1. Take the original draft specification from Step 2 and the amendment list from Step 4.
-2. For each amendment, apply the change:
-   - `add_criterion`: Insert acceptance criterion in the appropriate section. Annotate: "[Added per critique finding #N]"
-   - `fix_error`: Correct the error silently (wrong component name, wrong file path).
-   - `adjust_scope`: Update both in-scope and out-of-scope sections.
-   - `add_risk`: Append to risk assessment section.
-   - `improve_wording`: Revise wording in the specified section.
-   - `add_detail`: Add detail to the specified section.
-3. After applying all amendments, verify:
-   - No internal contradictions introduced (e.g., scope narrowed but new criteria added outside the narrowed scope).
-   - Specification still conforms to the GitHub issue template structure.
-   - Total length is reasonable (under 2000 words for a single issue). If over 2000 words, suggest splitting into multiple issues.
-4. Produce the refined specification.
-
-### Output
-
-Refined issue specification (internal working artifact). Immediately proceeds to Steps 6 and 7 in parallel: Step 6 (memorization) runs as a background operation via the Agent tool with run_in_background=true, while Step 7 (user review) proceeds interactively in the foreground.
-
-#### Failure Modes
-
-- Amendment incorporation introduces internal contradictions (scope narrowed but new criteria added outside narrowed scope) → flag the contradiction to the user before proceeding
-- Refined specification exceeds 2000 words → suggest splitting into multiple issues with cross-references
-
----
-
-## Step 6: Conditional Memorization (runs in parallel with Step 7)
-
-### Instructions
-
-This step runs concurrently with Step 7 (User Review). It does NOT block Step 7.
-
-1. Review the critique findings from Step 3. Identify findings that surface reusable insights -- patterns applicable beyond this specific issue:
-   - Architecture constraints that future features must respect
-   - Anti-patterns discovered during critique
-   - Codebase conventions not yet documented
-   - Recurring pitfalls that should be added to verification checklists
-
-2. If memorizable insights exist:
-   - Follow the reflexion:memorize workflow (ACE pattern):
-     a. Extract the insight from critique context.
-     b. Check against MEMORY.md and session notes.
-     c. If novel, run /reflexion:memorize for reusable insights.
-     d. If MEMORY.md is at capacity, suggest archiving stale entries or moving detailed content to topic-specific files.
-   - Do NOT store in mem0 unless the insight is cross-project. If the insight IS cross-project (infrastructure, deployment, API quirks), store in mem0 via `search_memory` (check for duplicates) then `add_memory`.
-
-3. If no memorizable insights exist: skip this step entirely. No output.
-
-4. Periodically (suggested: every 10 `/create-issue` invocations), consider running `/reflexion:memorize` to consolidate insights. This is NOT a per-run action.
-
-### Output
-
-Updated memory (if insights memorized via /reflexion:memorize) or no output (if skipped). Does not affect Step 7.
-
-#### Failure Modes
-
-- Over-memorization: storing trivial or context-specific findings as general principles → the memorize command should filter for novelty and generalizability
-- MEMORY.md at capacity → suggest archiving stale entries or moving detailed content to topic-specific files
-- Duplicate memorization → the memorize command should deduplicate against existing content before appending
-
----
-
-## Step 7: User Review & Refinement (runs in parallel with Step 6)
-
-### Instructions
-
-This step runs concurrently with Step 6 (Memorization). It does NOT wait for Step 6 to complete.
-
-1. Present the refined specification to the user in a readable format:
-
-   ```
-   DRAFT ISSUE SPECIFICATION (Ready for Review)
-   =============================================
-
-   Title: [conventional format title]
-   Type: [feature / bug]
-   Labels: [label list]
-   Complexity: [T-shirt size]
-
-   --- DESCRIPTION ---
-   [description text]
-
-   --- ACCEPTANCE CRITERIA ---
-   1. [criterion 1]
-   2. [criterion 2]
-   ...
-
-   --- SCOPE ---
-   In scope:
-   - [item]
-   Out of scope:
-   - [item]
-
-   --- AFFECTED COMPONENTS ---
-   - [component]
-
-   --- RISK ASSESSMENT ---
-   - [risk]
-
-   --- RELATED ISSUES ---
-   - [issue ref]
-
-   [Bug-only sections if applicable]
-
-   =============================================
-   Critique summary: N findings applied (X Critical, Y High, Z Medium, W Low)
-
-   Review the specification above. Provide any changes, or type "approved" to proceed with issue creation.
-   ```
-
-2. If user provides feedback:
-   - Incorporate the feedback into the specification.
-   - Re-present the updated specification.
-   - If user's feedback contradicts a critique finding from Step 3: flag the contradiction, explain which finding is affected, ask for confirmation. User has final authority.
-   - Repeat until user approves.
-
-3. If user types "approved" (or equivalent affirmation such as "looks good", "go ahead", "lgtm", "create it"):
-   - Mark specification as approved.
-   - Proceed to Step 8.
-
-4. If user abandons (stops responding or says "cancel"):
-   - The specification remains in draft state.
-   - WF1 terminates without creating an issue.
-   - Summary: "WF1 cancelled. No issue created. Draft specification is available in this conversation for future reference."
-
-### Output
-
-Approved specification (or cancellation). Step 8 only runs after explicit approval.
-
-#### Failure Modes
-
-- User requests changes that contradict critique findings from Step 3 → flag the contradiction, explain which critique finding is affected, and ask for confirmation. User has final authority.
-- User abandons the review (stops responding or says "cancel") → workflow cannot proceed to Step 8 without approval; specification remains in draft state, WF1 terminates without creating an issue.
-
----
-
-## Step 8: Create GitHub Issue
-
-### Instructions
-
-1. Render the approved specification into a markdown body string that conforms to the GitHub issue template structure.
-
-2. Write the body to a temporary file to handle multi-line content and special characters:
-
+   Exit `0` → enabled; non-zero → **skip silently** (this is the default — behavior is
+   byte-for-byte unchanged, no temp file, no subprocess). When enabled, write the draft
+   to a temp file and run `/rawgentic:adversarial-review <spec-path> spec`; it is
+   report-only — surface any findings to the user before filing. Codex failure is
+   non-blocking: on any non-success, log it and proceed (do NOT block creation). WF1 has
+   no plan_lib loop-back, so this does NOT call `consume_loopback` and does not re-trigger
+   any earlier step.
+
+1. Write the body to a temp file (handles multi-line content safely):
    ```bash
    cat << 'ISSUE_BODY_EOF' > /tmp/wf1-issue-body.md
    [full markdown body]
    ISSUE_BODY_EOF
    ```
-
-3. Determine labels:
-   - Base label: `enhancement` for features, `bug` for bugs.
-   - Scope labels: based on affected components (e.g., `engine`, `dashboard`, `ml`, `infrastructure`, `api`).
-   - Only use labels that already exist in the repository. Check with:
-     ```bash
-     gh label list --repo ${capabilities.repo}
-     ```
-   - If a needed label does not exist, create it:
-     ```bash
-     gh label create "engine" --repo ${capabilities.repo} --description "Engine (Python backend)" --color "0E8A16"
-     ```
-
-4. Create the issue:
-
+2. Labels: `enhancement` for features, `bug` for bugs, plus any component/scope labels.
+   Only use labels that already exist — check `gh label list --repo <capabilities.repo>`
+   and create one with `gh label create` only if needed.
+3. Create it:
    ```bash
-   gh issue create \
-     --repo ${capabilities.repo} \
-     --title "feat(engine): implement two-stage entry validation" \
-     --body-file /tmp/wf1-issue-body.md \
-     --label "enhancement" \
-     --label "engine"
+   gh issue create --repo <capabilities.repo> \
+     --title "<conventional title>" --body-file /tmp/wf1-issue-body.md \
+     --label "<base label>" [--label "<scope label>"]
    ```
+   Capture the URL from stdout.
+4. Failure handling: auth → `gh auth status`; transient/network → retry once after a
+   few seconds, and if it still fails save the body to
+   `<activeProject.path>/docs/plans/draft-issue-YYYY-MM-DD.md` and tell the user to
+   file manually; rate limit → wait and retry.
+5. Clean up: `rm -f /tmp/wf1-issue-body.md`.
 
-5. Capture the output URL (gh issue create prints the URL to stdout).
+## Step 5: Wrap up
 
-6. **Failure handling:**
-   - Authentication failure: verify PAT with `gh auth status`. The fine-grained PAT has Issues (r/w) scope.
-   - Network failure: retry once after 5 seconds. If still failing, save the specification to `${activeProject.path}/docs/plans/draft-issue-YYYY-MM-DD.md` and instruct the user to create manually.
-   - Rate limiting: wait 60 seconds and retry.
+Append one line to `claude_docs/session_notes.md`:
+`### WF1 create-issue — DONE (<issue URL>, type, title)`
 
-7. Clean up temp file:
-   ```bash
-   rm -f /tmp/wf1-issue-body.md
-   ```
-
-### Output
-
-GitHub issue URL (e.g., `https://github.com/${capabilities.repo}/issues/NNN`).
-
-#### Failure Modes
-
-- `gh` CLI authentication failure → verify PAT with `gh auth status`; the fine-grained PAT has Issues (r/w) scope
-- Network failure → retry once after 5 seconds; if still failing, save the issue specification locally to `${activeProject.path}/docs/plans/draft-issue-YYYY-MM-DD.md` and instruct the user to create manually
-- Rate limiting by GitHub API → wait 60 seconds and retry with exponential backoff
-
----
-
-## Step 9: Workflow Completion Summary
-
-### Instructions
-
-1. Update `claude_docs/session_notes.md` with WF1 results: issue URL, type, critique findings summary, loop-back count, memorized insights.
-
-2. Present a completion summary:
-
+Then report:
 ```
-WF1 COMPLETE
-=============
-
-GitHub Issue: [URL] (Issue #NNN)
-Type: [feature / bug]
-Title: [title]
-
-Critique Summary:
-- Total findings: N
-- Applied: N (X Critical, Y High, Z Medium, W Low)
-- Ambiguity circuit breaker: [triggered / not triggered]
-- Loop-backs: [0 / 1 / 2]
-- Memorized insights: [N insights saved via /reflexion:memorize / none]
-
-User Review: [N iterations / approved immediately]
-
-WF1 complete. To implement this feature, invoke WF2 (Feature Implementation) separately, referencing issue #NNN.
+Issue created: <URL>
+Type: <feature/bug> · Title: <title> · Labels: <labels>
 ```
 
-Do NOT suggest auto-transitioning to WF2. Do NOT ask "shall I start implementing?" The workflow terminates here.
+Do NOT offer to start implementation. To implement, the user invokes WF2
+(`/rawgentic:implement-feature`) separately, referencing the issue number.
 
-### Output
-
-Completion summary message. WF1 terminates.
-
-#### Failure Modes
-
-- None — this is an informational step. If previous steps failed, this step reports the partial completion status.
-
----
-
-<completion-gate>
-Before declaring WF1 complete, verify ALL of the following. Print the checklist with pass/fail for each item:
-
-1. [ ] Step markers logged for ALL executed steps in session notes
-2. [ ] Final step output (completion summary) presented to user
-3. [ ] Session notes updated with completion summary
-4. [ ] Issue URL documented in session notes
-5. [ ] Memorize step completed (insights saved or correctly skipped)
-6. [ ] Issue body matches critique findings
-
-If ANY item fails, go back and complete it before declaring "WF1 complete."
-You may NOT output "WF1 complete" until all items pass.
-</completion-gate>
-
----
-
-## Workflow Resumption
-
-If this skill is invoked mid-conversation, detect the current state:
-
-0. All step markers present but completion-gate not printed? → Run completion-gate, then terminate.
-1. Was a GitHub issue just created? → Step 9 (summary only)
-2. Was the spec approved by user? → Step 8 (create issue)
-3. Is there a refined spec with critique findings applied? → Step 7 (user review)
-4. Is there a critique findings list? → Step 4 (apply findings)
-5. Is there a draft specification? → Step 3 (critique)
-6. None of the above → Step 1 (start from scratch)
-
-Announce the detected state before resuming: "Detected prior progress. Resuming at Step N."
+<resumption>
+If invoked mid-task: issue already created → just report it (Step 5). Draft approved
+→ create it (Step 4). Draft exists, not yet approved → user review (Step 3). Otherwise
+start at Step 1.
+</resumption>

--- a/skills/create-issue/evals/build_fixture.sh
+++ b/skills/create-issue/evals/build_fixture.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Build a self-contained create-issue eval fixture.
+#
+#   build_fixture.sh <scenario> <dest-dir>
+#
+# scenarios: feature-quality | dedup-hit | config-decoy | bug-report
+#
+# The fixture is a miniature rawgentic workspace that the skill can run against
+# end-to-end WITHOUT touching real GitHub or the real workspace:
+#   <dest>/.rawgentic_workspace.json     one active, configured project
+#   <dest>/projects/sentinel-app/        the project + .rawgentic.json + templates + src
+#   <dest>/hooks/                        real capabilities_lib.py (+ adversarial_review_lib.py)
+#   <dest>/bin/gh                        mock gh CLI (records calls + created issue)
+#   <dest>/.gh-mock/                     mock state + per-scenario seed data
+#   <dest>/claude_docs/                  session-notes target
+#
+# Each (eval x config) run gets its OWN copy so grading reads that run's state.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOKS_SRC="$(cd "$SCRIPT_DIR/../../.." && pwd)/hooks"
+
+SCENARIO="${1:?usage: build_fixture.sh <scenario> <dest-dir>}"
+DEST="${2:?usage: build_fixture.sh <scenario> <dest-dir>}"
+
+CONFIG_REPO="octo-eval/sentinel-app"      # the authoritative repo (from .rawgentic.json)
+DECOY_REPO="octo-eval/sentinel-legacy"    # plausible WRONG repo planted in CLAUDE.md (config-decoy)
+APP="sentinel-app"
+PROJ="$DEST/projects/$APP"
+
+rm -rf "$DEST"
+mkdir -p "$PROJ/.github/ISSUE_TEMPLATE" "$PROJ/src" "$DEST/hooks" "$DEST/bin" \
+         "$DEST/.gh-mock" "$DEST/claude_docs"
+
+# --- workspace: exactly one active, configured project; clean of BMAD so the
+#     skill's disabled-skill gate passes and it proceeds straight to Step 1 ---
+cat > "$DEST/.rawgentic_workspace.json" <<JSON
+{
+  "version": 1,
+  "defaultProtectionLevel": "sandbox",
+  "projects": [
+    {
+      "name": "$APP",
+      "path": "./projects/$APP",
+      "active": true,
+      "configured": true,
+      "disabledSkills": [],
+      "headlessEnabled": true,
+      "lastUsed": "2026-06-15T00:00:00Z"
+    }
+  ]
+}
+JSON
+
+# --- project config (mirrors the real .rawgentic.json schema) ---
+cat > "$PROJ/.rawgentic.json" <<JSON
+{
+  "version": 1,
+  "project": {
+    "name": "$APP",
+    "type": "web-service",
+    "description": "Realtime API service for the eval harness"
+  },
+  "repo": {
+    "provider": "github",
+    "fullName": "$CONFIG_REPO",
+    "defaultBranch": "trunk"
+  },
+  "protectionLevel": "sandbox",
+  "techStack": ["node", "javascript"],
+  "testing": {
+    "frameworks": [
+      { "name": "vitest", "type": "unit", "command": "npm test", "testDir": "test" }
+    ]
+  },
+  "ci": { "provider": "github-actions", "workflowDir": ".github/workflows" },
+  "documentation": { "primaryFiles": ["README.md"], "format": "markdown" },
+  "custom": {}
+}
+JSON
+
+# --- issue templates (the skill reads these in Step 2) ---
+cat > "$PROJ/.github/ISSUE_TEMPLATE/feature_request.md" <<'MD'
+---
+name: Feature request
+about: Propose new functionality
+labels: enhancement
+---
+
+## Description
+
+## Acceptance Criteria
+1.
+
+## Scope
+In scope:
+-
+Out of scope:
+-
+
+## Affected Components
+
+## Risk Assessment
+
+## Complexity
+<!-- S / M / L / XL -->
+
+## Related Issues
+MD
+
+cat > "$PROJ/.github/ISSUE_TEMPLATE/bug_report.md" <<'MD'
+---
+name: Bug report
+about: Report broken behavior
+labels: bug
+---
+
+## Description
+
+## Steps to Reproduce
+1.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+
+## Error Logs
+MD
+
+# --- real source files so component-existence checks have ground truth ---
+cat > "$PROJ/src/server.js" <<'JS'
+// Sentinel API server entrypoint.
+export function startServer(port) { /* ... */ }
+export function handleConnection(socket) { /* ... */ }
+JS
+cat > "$PROJ/src/errorHandler.js" <<'JS'
+// Centralized error handling.
+export function handleError(err, req, res) { /* ... */ }
+JS
+cat > "$PROJ/README.md" <<'MD'
+# sentinel-app
+Realtime API service. Modules: src/server.js, src/errorHandler.js.
+MD
+
+# --- hooks the skill invokes (python3 hooks/...) ---
+cp "$HOOKS_SRC/capabilities_lib.py" "$DEST/hooks/capabilities_lib.py"
+[ -f "$HOOKS_SRC/adversarial_review_lib.py" ] && \
+  cp "$HOOKS_SRC/adversarial_review_lib.py" "$DEST/hooks/adversarial_review_lib.py" || true
+
+# --- gh mock on a local bin (invoked by absolute path) ---
+cp "$SCRIPT_DIR/gh-mock" "$DEST/bin/gh"
+chmod +x "$DEST/bin/gh"
+
+# --- session notes target ---
+: > "$DEST/claude_docs/session_notes.md"
+
+# --- per-scenario layering ---
+case "$SCENARIO" in
+  feature-quality|bug-report|false-premise|vague-perf|over-broad)
+    : > "$DEST/.gh-mock/seed_issues.tsv"   # clean repo, no duplicates
+    # false-premise/vague-perf/over-broad reuse the clean base; the discriminator
+    # is how the run HANDLES bad/missing/over-broad input, not fixture contents.
+    # (false-premise deliberately has NO ConnectionThrottler / src/throttle.js.)
+    ;;
+  dedup-hit)
+    # A clearly-matching OPEN issue already exists -> the skill must surface it.
+    printf '%s\n' \
+      "42	feat(server): add WebSocket support for realtime updates	enhancement	2026-05-01T00:00:00Z" \
+      > "$DEST/.gh-mock/seed_issues.tsv"
+    ;;
+  config-decoy)
+    : > "$DEST/.gh-mock/seed_issues.tsv"
+    # Plausible, UNLABELLED wrong repo at workspace root. No "deliberately wrong"
+    # tell -- the agent must follow the config-loading protocol to resolve it.
+    cat > "$DEST/CLAUDE.md" <<MD
+# sentinel-app workspace
+
+Primary repository: $DECOY_REPO
+Default branch: main
+
+Contributions go through the standard PR flow.
+MD
+    ;;
+  *)
+    echo "unknown scenario: $SCENARIO" >&2; exit 2 ;;
+esac
+
+echo "built $SCENARIO fixture at $DEST (config repo=$CONFIG_REPO)"

--- a/skills/create-issue/evals/evals-iter3.json
+++ b/skills/create-issue/evals/evals-iter3.json
@@ -1,0 +1,43 @@
+{
+  "skill_name": "rawgentic:create-issue",
+  "notes": "Iteration-3 'hard cases' -- the situations WF1 was built for. The user role is deliberately LOW-INFORMATION and uncooperative: it knows only the original prompt, will not invent missing detail, and (false-premise) does not know its premise is wrong. This prevents the agent-as-user from rescuing a run by supplying the very information the test is about. Assertions are necessarily more handling/transcript-based than iteration-2's hard artifact checks, so qualitative transcript review matters more here.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "false-premise",
+      "scenario": "false-premise",
+      "prompt": "There's a bug in the ConnectionThrottler class in src/throttle.js -- it drops valid connections under load. Please open an issue to fix it.",
+      "expected_output": "The run discovers that ConnectionThrottler / src/throttle.js does not exist in the codebase, surfaces that, and either declines to file against a phantom component or grounds the issue in the real connection-handling code (src/server.js handleConnection).",
+      "expectations": [
+        "Run executed against mock gh (calls recorded)",
+        "Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+        "Referenced the real connection-handling code (server.js / errorHandler.js)",
+        "Final issue does not present the nonexistent component as real"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "vague-perf",
+      "scenario": "vague-perf",
+      "prompt": "The app feels slow sometimes. Can you make an issue about that?",
+      "expected_output": "The run surfaces that the request lacks specifics (asks what/where/how-measured or flags it under-specified) and does NOT fabricate concrete performance targets the user never gave.",
+      "expectations": [
+        "Run executed against mock gh (calls recorded)",
+        "Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+        "Did not fabricate specific performance targets the user never provided"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "over-broad",
+      "scenario": "over-broad",
+      "prompt": "I want to completely overhaul error handling, logging, monitoring, retries, and alerting across the entire service. Open an issue for it.",
+      "expected_output": "The run recognizes the request spans many concerns and is too large for one issue -- it proposes splitting / narrowing, or files a bounded issue with explicit out-of-scope deferrals.",
+      "expectations": [
+        "Run executed against mock gh (calls recorded)",
+        "Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+        "Issue defines explicit out-of-scope / deferred boundaries"
+      ]
+    }
+  ]
+}

--- a/skills/create-issue/evals/evals.json
+++ b/skills/create-issue/evals/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "rawgentic:create-issue",
+  "notes": "Runs against a self-contained fixture built by build_fixture.sh. The subagent must (1) drive the workflow autonomously while ALSO acting as the approving user, (2) invoke the mock gh at <fixture>/bin/gh by absolute path (never bare `gh`), and (3) actually execute commands -- not narrate them. grade.py scores each run from the mock's recorded state + transcript; liveness checks fail any simulated walkthrough.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "feature-quality",
+      "scenario": "feature-quality",
+      "prompt": "Create an issue requesting WebSocket support for realtime updates in the sentinel-app API.",
+      "expected_output": "A well-formed feature issue created on octo-eval/sentinel-app with a conventional feat() title, >=3 numbered acceptance criteria, explicit in/out scope, and a risk assessment; a dedup search runs first.",
+      "expectations": [
+        "Run executed against mock gh (calls recorded)",
+        "Issue was actually created via gh (not simulated)",
+        "Targets the config repo octo-eval/sentinel-app",
+        "Conventional title feat(scope): ...",
+        "At least 3 numbered acceptance criteria",
+        "Explicit in-scope AND out-of-scope sections",
+        "Risk assessment present",
+        "Deduplication search ran before creation"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "dedup-hit",
+      "scenario": "dedup-hit",
+      "prompt": "I want to add WebSocket support to the API so clients get realtime updates. Please open an issue for it.",
+      "expected_output": "The workflow surfaces the already-open issue #42 (WebSocket support) during the dedup check instead of blindly filing a duplicate.",
+      "expectations": [
+        "Run executed against mock gh (calls recorded)",
+        "Deduplication search ran",
+        "Existing matching issue (#42) surfaced to the user",
+        "Did not blindly create a duplicate"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "config-decoy",
+      "scenario": "config-decoy",
+      "prompt": "Create an issue for improving error handling across the service.",
+      "expected_output": "All GitHub operations target the config repo octo-eval/sentinel-app from .rawgentic.json; the plausible decoy repo octo-eval/sentinel-legacy planted in CLAUDE.md is never used.",
+      "expectations": [
+        "Run executed against mock gh (calls recorded)",
+        "Issue was actually created via gh (not simulated)",
+        "Uses config repo, not the CLAUDE.md decoy",
+        "Decoy repo never used in any gh call or issue body"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "bug-report",
+      "scenario": "bug-report",
+      "prompt": "Report a bug: the server drops WebSocket connections after about 30 seconds of inactivity instead of keeping them alive. It happens reliably on the staging box.",
+      "expected_output": "A bug issue created with a conventional fix() title, the 'bug' label, and the bug template sections filled (steps to reproduce, expected vs actual, environment).",
+      "expectations": [
+        "Run executed against mock gh (calls recorded)",
+        "Issue was actually created via gh (not simulated)",
+        "Conventional title fix(scope): ...",
+        "Labeled 'bug'",
+        "Steps to reproduce present",
+        "Expected AND actual behavior documented",
+        "Environment details present"
+      ]
+    }
+  ]
+}

--- a/skills/create-issue/evals/gh-mock
+++ b/skills/create-issue/evals/gh-mock
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Mock `gh` CLI for create-issue evals.
+
+Installed at <fixture>/bin/gh and invoked by absolute path (per-call shells in
+Claude Code don't persist PATH). It resolves its state dir from its own location
+so no env var is required:
+
+    <fixture>/bin/gh        -> this script
+    <fixture>/.gh-mock/     -> state (calls.log, created-issue.json, body, seed data)
+
+Why it exists: it makes eval runs EXECUTE for real instead of being narrated.
+Every invocation is appended to calls.log, and a real `gh issue create` writes
+created-issue.json + created-issue-body.md. The grader keys liveness on those
+files: a simulated walkthrough (or a run that hit the real gh) leaves them
+absent and FAILS the eval. That is the property the previous eval set lacked.
+
+Supported subcommands (enough for WF1 Step 1 dedup + Step 8 creation, and for a
+no-skill baseline doing the same): auth status, issue list, issue view,
+label list, label create, issue create. Anything else is logged and exits 0 so
+an unexpected call never aborts the run (it just won't satisfy an assertion).
+"""
+import json
+import os
+import sys
+import time
+
+FIXTURE = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+STATE = os.path.join(FIXTURE, ".gh-mock")
+os.makedirs(STATE, exist_ok=True)
+
+
+def log_call(argv):
+    with open(os.path.join(STATE, "calls.log"), "a") as f:
+        f.write(" ".join(argv) + "\n")
+
+
+def opt(args, name):
+    """Return the value following --name, or None."""
+    if name in args:
+        i = args.index(name)
+        if i + 1 < len(args):
+            return args[i + 1]
+    return None
+
+
+def read_seed(filename, default=""):
+    p = os.path.join(STATE, filename)
+    if os.path.exists(p):
+        with open(p) as f:
+            return f.read()
+    return default
+
+
+def main():
+    argv = sys.argv[1:]
+    log_call(["gh"] + argv)
+
+    # gh auth status
+    if argv[:2] == ["auth", "status"]:
+        sys.stderr.write(
+            "github.com\n  Logged in to github.com account eval-bot (oauth_token)\n"
+            "  Token scopes: 'repo', 'read:org'\n")
+        return 0
+
+    if not argv:
+        return 0
+
+    obj = argv[0]
+    sub = argv[1] if len(argv) > 1 else ""
+
+    # gh issue list --repo R --search Q [--state all] [--limit N]
+    if obj == "issue" and sub == "list":
+        # Seeded existing issues (TSV: number<TAB>title<TAB>labels<TAB>updated).
+        # Used by the dedup-hit scenario; empty otherwise (clean repo).
+        sys.stdout.write(read_seed("seed_issues.tsv", ""))
+        return 0
+
+    # gh issue view N --repo R ...
+    if obj == "issue" and sub == "view":
+        sys.stdout.write(read_seed("seed_issue_view.txt", "title:\tstub\nstate:\tOPEN\n"))
+        return 0
+
+    # gh label list --repo R
+    if obj == "label" and sub == "list":
+        sys.stdout.write(read_seed(
+            "labels.txt",
+            "bug\tSomething isn't working\td73a4a\n"
+            "enhancement\tNew feature or request\ta2eeef\n"))
+        return 0
+
+    # gh label create NAME --repo R --description D --color C
+    if obj == "label" and sub == "create":
+        name = argv[2] if len(argv) > 2 and not argv[2].startswith("-") else "unknown"
+        with open(os.path.join(STATE, "labels.txt"), "a") as f:
+            f.write(f"{name}\t(created by mock)\t000000\n")
+        sys.stdout.write(f"Created label '{name}'\n")
+        return 0
+
+    # gh issue create --repo R --title T --body-file F | --body B --label L ...
+    if obj == "issue" and sub == "create":
+        repo = opt(argv, "--repo") or "UNKNOWN"
+        title = opt(argv, "--title") or ""
+        body_file = opt(argv, "--body-file")
+        body = opt(argv, "--body")
+        if body_file and os.path.exists(body_file):
+            with open(body_file) as f:
+                body = f.read()
+        body = body or ""
+        # Collect every --label occurrence.
+        labels = [argv[i + 1] for i, a in enumerate(argv)
+                  if a == "--label" and i + 1 < len(argv)]
+
+        record = {
+            "repo": repo,
+            "title": title,
+            "labels": labels,
+            "body_len": len(body),
+            "ts": int(time.time()),
+        }
+        with open(os.path.join(STATE, "created-issue.json"), "w") as f:
+            json.dump(record, f, indent=2)
+        with open(os.path.join(STATE, "created-issue-body.md"), "w") as f:
+            f.write(body)
+        url = f"https://github.com/{repo}/issues/101"
+        sys.stdout.write(url + "\n")
+        return 0
+
+    # Unknown command: recorded above, succeed quietly.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/create-issue/evals/grade.py
+++ b/skills/create-issue/evals/grade.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Programmatic grader for create-issue evals.
+
+    grade.py --scenario <name> --fixture <dir> --transcript <file> [--out grading.json]
+
+Every check reads the gh-mock's recorded state (<fixture>/.gh-mock/) and/or the
+run transcript. Because the mock only writes created-issue.json when a real
+`gh issue create` ran, the liveness checks FAIL on a simulated walkthrough --
+which is exactly the failure the prior eval set could not produce.
+
+grading.json uses the field names the eval viewer expects: text/passed/evidence.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+CONFIG_REPO = "octo-eval/sentinel-app"
+DECOY = "sentinel-legacy"
+SEED_ISSUE_NUM = "42"
+SEED_ISSUE_HINT = "websocket"
+
+
+def load(fixture):
+    st = os.path.join(fixture, ".gh-mock")
+    created = None
+    cp = os.path.join(st, "created-issue.json")
+    if os.path.exists(cp):
+        try:
+            created = json.load(open(cp))
+        except Exception:
+            created = None
+    body = ""
+    bp = os.path.join(st, "created-issue-body.md")
+    if os.path.exists(bp):
+        body = open(bp).read()
+    calls = ""
+    clp = os.path.join(st, "calls.log")
+    if os.path.exists(clp):
+        calls = open(clp).read()
+    return created, body, calls
+
+
+def count_numbered_items(text):
+    return len(re.findall(r'(?m)^\s*\d+\.\s+\S', text))
+
+
+def search_ran(calls):
+    return any(("issue list" in ln and "--search" in ln) for ln in calls.splitlines())
+
+
+def check_feature_quality(created, body, calls, tx):
+    yield ("Run executed against mock gh (calls recorded)",
+           bool(calls.strip()), f"{len(calls.splitlines())} gh call(s) logged")
+    yield ("Issue was actually created via gh (not simulated)",
+           created is not None,
+           "created-issue.json present" if created else "NO created-issue.json -> not created/simulated")
+    repo = created.get("repo") if created else None
+    yield ("Targets the config repo octo-eval/sentinel-app",
+           repo == CONFIG_REPO, f"created repo = {repo!r}")
+    title = (created or {}).get("title", "")
+    yield ("Conventional title feat(scope): ...",
+           bool(re.match(r'^feat\(.+\):\s+\S', title)), f"title = {title!r}")
+    n = count_numbered_items(body)
+    yield ("At least 3 numbered acceptance criteria", n >= 3, f"{n} numbered items in body")
+    bl = body.lower()
+    yield ("Explicit in-scope AND out-of-scope sections",
+           ("in scope" in bl and "out of scope" in bl),
+           f"in-scope={'in scope' in bl} out-of-scope={'out of scope' in bl}")
+    yield ("Risk assessment present", "risk" in bl, f"'risk' in body = {'risk' in bl}")
+    yield ("Deduplication search ran before creation",
+           search_ran(calls), f"issue-list-with-search logged = {search_ran(calls)}")
+
+
+def check_dedup_hit(created, body, calls, tx):
+    txl = tx.lower()
+    yield ("Run executed against mock gh (calls recorded)",
+           bool(calls.strip()), f"{len(calls.splitlines())} gh call(s) logged")
+    yield ("Deduplication search ran", search_ran(calls),
+           f"issue-list-with-search logged = {search_ran(calls)}")
+    surfaced = (SEED_ISSUE_NUM in tx) or (SEED_ISSUE_HINT in txl and "duplicat" in txl) \
+        or ("#42" in tx)
+    yield ("Existing matching issue (#42) surfaced to the user",
+           surfaced, f"'#42'/'42' in transcript = {SEED_ISSUE_NUM in tx}")
+    # Discriminator: did NOT blindly create an unrelated duplicate.
+    if created is None:
+        ok, ev = True, "no new issue created (acknowledged existing) -- acceptable"
+    else:
+        bl = body.lower()
+        refs = (SEED_ISSUE_NUM in body) or ("duplicat" in bl) or ("existing issue" in bl) \
+            or ("related" in bl and SEED_ISSUE_NUM in body)
+        ok, ev = refs, ("references existing #42/duplicate in body" if refs
+                        else "created a fresh issue with NO reference to existing #42 (blind duplicate)")
+    yield ("Did not blindly create a duplicate", ok, ev)
+
+
+def check_config_decoy(created, body, calls, tx):
+    yield ("Run executed against mock gh (calls recorded)",
+           bool(calls.strip()), f"{len(calls.splitlines())} gh call(s) logged")
+    yield ("Issue was actually created via gh (not simulated)",
+           created is not None,
+           "created-issue.json present" if created else "NO created-issue.json")
+    repo = (created or {}).get("repo")
+    yield ("Uses config repo, not the CLAUDE.md decoy",
+           repo == CONFIG_REPO, f"created repo = {repo!r} (decoy was octo-eval/sentinel-legacy)")
+    decoy_in_calls = DECOY in calls
+    decoy_in_body = DECOY in body
+    yield ("Decoy repo never used in any gh call or issue body",
+           not (decoy_in_calls or decoy_in_body),
+           f"decoy in calls={decoy_in_calls}, in body={decoy_in_body}")
+
+
+def check_bug_report(created, body, calls, tx):
+    bl = body.lower()
+    yield ("Run executed against mock gh (calls recorded)",
+           bool(calls.strip()), f"{len(calls.splitlines())} gh call(s) logged")
+    yield ("Issue was actually created via gh (not simulated)",
+           created is not None,
+           "created-issue.json present" if created else "NO created-issue.json")
+    title = (created or {}).get("title", "")
+    yield ("Conventional title fix(scope): ...",
+           bool(re.match(r'^fix\(.+\):\s+\S', title)), f"title = {title!r}")
+    labels = (created or {}).get("labels", [])
+    yield ("Labeled 'bug'", "bug" in labels, f"labels = {labels}")
+    yield ("Steps to reproduce present", "reproduc" in bl, f"'reproduc' in body = {'reproduc' in bl}")
+    yield ("Expected AND actual behavior documented",
+           ("expected" in bl and "actual" in bl),
+           f"expected={'expected' in bl} actual={'actual' in bl}")
+    yield ("Environment details present", "environment" in bl, f"'environment' in body = {'environment' in bl}")
+
+
+FAKE_COMPONENT = "connectionthrottler"
+FAKE_FILE = "throttle.js"
+REAL_FILES = ("server.js", "errorhandler.js")
+# Specific targets a model would have to INVENT for the vague request (the user
+# gave no numbers). Their presence = fabrication.
+FABRICATED_TARGETS = [
+    r'\bunder\s*\d', r'\b\d+\s*(ms|milliseconds|seconds|s\b)', r'\b\d+\s*%',
+    r'p9[59]', r'\b\d+x\b', r'less than \d', r'within \d',
+]
+
+
+def has(text, *needles):
+    t = text.lower()
+    return any(n in t for n in needles)
+
+
+def check_false_premise(created, body, calls, tx):
+    txl = tx.lower()
+    bl = body.lower()
+    yield ("Run executed against mock gh (calls recorded)",
+           bool(calls.strip()), f"{len(calls.splitlines())} gh call(s) logged")
+    # DISCRIMINATOR: did the run notice the named component does not exist?
+    flagged = has(tx, "does not exist", "doesn't exist", "no such", "not found",
+                  "could not find", "couldn't find", "no connectionthrottler",
+                  "does not appear", "no file", "not present in", "no matching",
+                  "isn't in the", "is not in the", "no `throttle.js`", "no throttle.js")
+    yield ("Detected that ConnectionThrottler / src/throttle.js does not exist in the codebase",
+           flagged,
+           "transcript acknowledges the component is absent" if flagged
+           else "no acknowledgement that the named component is missing -- premise taken at face value")
+    # Did it ground the issue in the REAL code instead?
+    grounded = has(body, *REAL_FILES) or has(tx, *REAL_FILES)
+    yield ("Referenced the real connection-handling code (server.js / errorHandler.js)",
+           grounded, f"real-file reference present = {grounded}")
+    # Did the FINAL issue avoid asserting the fake component as real?
+    if created is None:
+        ok, ev = True, "no issue created (stopped to clarify the bad premise) -- acceptable"
+    else:
+        asserts_fake = (FAKE_FILE in bl) or (FAKE_COMPONENT in bl)
+        ok = (not asserts_fake) or flagged  # mentioning it is ok IF flagged as nonexistent
+        ev = ("issue does not present the fake component as real"
+              if ok else "issue body cites src/throttle.js / ConnectionThrottler as if it exists")
+    yield ("Final issue does not present the nonexistent component as real", ok, ev)
+
+
+def check_vague_perf(created, body, calls, tx):
+    bl = body.lower()
+    yield ("Run executed against mock gh (calls recorded)",
+           bool(calls.strip()), f"{len(calls.splitlines())} gh call(s) logged")
+    # DISCRIMINATOR: surfaced the lack of specifics rather than papering over it.
+    asked = has(tx, "clarif", "could you", "can you tell", "which part", "what part",
+                "more detail", "more information", "do you have", "what kind of",
+                "?  ", "specific", "need more", "insufficient", "unclear", "ambiguous")
+    yield ("Surfaced the missing specifics (asked to clarify / flagged as under-specified)",
+           asked,
+           "transcript shows clarification/under-specification handling" if asked
+           else "proceeded without surfacing that the request lacks specifics")
+    # DISCRIMINATOR: did NOT invent concrete performance targets the user never gave.
+    invented = [p for p in FABRICATED_TARGETS if re.search(p, bl)]
+    acknowledges_unknown = has(body, "tbd", "to be determined", "needs investigation",
+                               "to be measured", "investigat", "unknown", "to be defined",
+                               "not yet specified", "baseline needed", "to be profiled")
+    ok = (not invented) or acknowledges_unknown
+    yield ("Did not fabricate specific performance targets the user never provided",
+           ok,
+           ("no invented numeric targets" if not invented
+            else (f"invented targets {invented} BUT marks them as unknown/TBD" if ok
+                  else f"issue body invents concrete targets the user never gave: {invented}")))
+
+
+def check_over_broad(created, body, calls, tx):
+    bl = body.lower()
+    txl = tx.lower()
+    yield ("Run executed against mock gh (calls recorded)",
+           bool(calls.strip()), f"{len(calls.splitlines())} gh call(s) logged")
+    # DISCRIMINATOR: recognized the request is too large for one issue.
+    recognized = has(tx, "split", "multiple issues", "separate issues", "too broad",
+                     "too large", "too big", "break it", "break this", "break into",
+                     "several issues", "out of scope", "narrow", "scope this down",
+                     "more than one issue", "epic")
+    yield ("Recognized the request is too broad for a single issue (suggested splitting / scoping down)",
+           recognized,
+           "transcript proposes splitting or narrowing" if recognized
+           else "treated the sprawling request as a single ordinary issue")
+    # Did the resulting issue carry explicit out-of-scope boundaries?
+    bounded = has(body, "out of scope", "out-of-scope", "deferred", "not included",
+                  "follow-up", "follow up", "subsequent issue", "separate issue")
+    yield ("Issue defines explicit out-of-scope / deferred boundaries",
+           bounded, f"explicit scope boundary in body = {bounded}")
+
+
+SCENARIOS = {
+    "feature-quality": check_feature_quality,
+    "dedup-hit": check_dedup_hit,
+    "config-decoy": check_config_decoy,
+    "bug-report": check_bug_report,
+    "false-premise": check_false_premise,
+    "vague-perf": check_vague_perf,
+    "over-broad": check_over_broad,
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenario", required=True, choices=list(SCENARIOS))
+    ap.add_argument("--fixture", required=True)
+    ap.add_argument("--transcript", default="")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    created, body, calls = load(args.fixture)
+    tx = ""
+    if args.transcript and os.path.exists(args.transcript):
+        tx = open(args.transcript, errors="replace").read()
+
+    exps = []
+    for text, passed, evidence in SCENARIOS[args.scenario](created, body, calls, tx):
+        exps.append({"text": text, "passed": bool(passed), "evidence": evidence})
+
+    passed = sum(1 for e in exps if e["passed"])
+    total = len(exps)
+    out = {
+        "expectations": exps,
+        "summary": {"passed": passed, "failed": total - passed, "total": total,
+                    "pass_rate": round(passed / total, 4) if total else 0.0},
+    }
+    txt = json.dumps(out, indent=2)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(txt)
+    print(txt)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.37.0"
+    assert plugin["version"] == "2.38.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_bmad_detection.py
+++ b/tests/hooks/test_bmad_detection.py
@@ -27,10 +27,13 @@ WORKFLOW_SKILLS = [
     "optimize-perf",
 ]
 
-# The 6 skills that invoke /reflexion:critique and need critiqueMethod check.
+# The skills that invoke /reflexion:critique and need critiqueMethod check.
+# NOTE: create-issue (WF1) was slimmed to a lean template+dedup+config helper and no
+# longer runs a multi-agent critique — its quality bar is applied inline while drafting
+# (see skills/create-issue/SKILL.md <quality-bar>). It keeps only the default-off
+# adversarial-review opt-in, covered by test_adversarial_review_registration.
 CRITIQUE_SKILLS = [
     "implement-feature",
-    "create-issue",
     "refactor",
     "security-audit",
     "optimize-perf",


### PR DESCRIPTION
## Summary

Slims **WF1 (Issue Creation)** from a 9-step, multi-agent-critique workflow to a lean **5-step** helper. Driven by head-to-head evals: across **7 scenarios** (incl. the hard cases WF1 was built for — false-premise, vague, over-broad) a current model produces an **equivalent issue without the critique pipeline**, at **~⅓ the time and tokens**. The slim skill stays **≥ baseline quality (100% vs 96%)** while recovering the conventional-title edge baseline misses.

### Skill (`skills/create-issue/SKILL.md`, 608 → 173 lines)
- **Removed:** 3-judge parallel critique, ambiguity circuit-breaker step, loop-back + volume thresholds, per-run conditional memorization, heavy completion-gate.
- **Kept:** config-based repo targeting, dedup, template conformance, codebase grounding, conventional titles, user review, and the **default-off** cross-model adversarial-review opt-in.
- The judges' value (no hallucinated components, no fabricated criteria, bound an over-broad ask) is now a `<quality-bar>` applied **inline** while drafting.
- Stale **Serena-only** codebase-verification reference made **tool-agnostic** (falls back to Grep/Glob when Serena MCP is absent).
- **Description** rewritten: prescriptive “Use when…” + near-miss “Do NOT use for…” guardrails (implement / fix / list / review / template-edit).

### Contract + docs (ratify the slim design)
- WF1 removed from the `/reflexion:critique` `CRITIQUE_SKILLS` set (`tests/hooks/test_bmad_detection.py`).
- Adversarial-review Step-4 opt-in **retained** (default-off) — `test_adversarial_review_registration` still green.
- README: WF1 entry 9 → 5 steps, reflexion-critique skill list, changelog `v2.38.0`.
- `docs/design/workflow-issue-creation.md` marked **superseded** (historical rationale kept).

### Eval harness (`skills/create-issue/evals/`, `skills/create-issue-workspace/`)
Reproducible, **executes for real**: `build_fixture.sh` builds a self-contained workspace; a **mock `gh`** records calls so a *simulated* run **fails** the liveness assertions (the gap the prior iteration-1 evals had); `grade.py` scores from recorded state. iteration-2/3/4 transcripts + `ANALYSIS.md` and the original skill snapshots are included as evidence.

## Why

The WF1 critique machinery was designed against a weaker model that needed scaffolding to avoid hallucinating components, fabricating acceptance criteria, or rubber-stamping an over-broad ask. A current model does those unprompted, so the pipeline was pure overhead for issue creation — confirmed across easy **and** hard scenarios.

## Test plan
- `pytest tests/ -v` → **1157 passed** locally.
- New eval harness validated: grader fails a thin/simulated run, passes a complete one.
- Version bumped `2.37.0 → 2.38.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)