### PR TITLE
fix(headless): prevent WF2 from executing remote operations in headless mode (#47)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.40.1",
+  "version": "2.41.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/.rawgentic/review-state/fix-47-headless-remote-ops-guard.json
+++ b/.rawgentic/review-state/fix-47-headless-remote-ops-guard.json
@@ -1,0 +1,6 @@
+{
+  "branch": "fix/47-headless-remote-ops-guard",
+  "last_review_log_status": "applied",
+  "schema_version": 1,
+  "ts": "2026-06-16T21:37:00Z"
+}

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Rawgentic includes hooks that run automatically on Claude Code events:
 | `wal-stop` | Stop | Logs session end marker |
 | `wal-context` | UserPromptSubmit | Injects session context (project, recent WAL activity) |
 | `wal-bind-guard` | PreToolUse | Blocks tool use if session unbound with multiple active projects; blocks cross-project file writes |
-| `wal-guard` | PreToolUse | Blocks dangerous production commands with per-project protection levels (sandbox/standard/strict) |
+| `wal-guard` | PreToolUse | Blocks dangerous production commands with per-project protection levels (sandbox/standard/strict); in headless mode also blocks **all** `ssh`/`scp`/`rsync`/`sftp` (unless `headlessAllowSSH: true`) |
 | `session-start` | SessionStart | WAL recovery, **notes size handler**, project reconciliation, security pattern staleness check, **security scanner bootstrap** (once, background, opt-out), resume context |
 | `notes-size-handler` | (called by session-start) | Trims session notes exceeding 800 lines to keep last 200; optionally ingests to memorypalace before trimming |
 | `security-guard` | PreToolUse | Blocks writing dangerous patterns (credentials, secrets, eval) to files |
@@ -700,6 +700,9 @@ For major changes, please open an issue first to discuss the approach.
 
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
+
+### v2.41.0 (2026-06-16)
+- **Headless mode is PR-terminal — no merge, no deploy, no outbound SSH (#47).** Fixes the gap that let the first autonomous headless run SSH to a live dev VM and corrupt it (chorestory #309). Two defense layers: (1) **workflow layer** — WF2 Step 2's live-env probe skips SSH (local exploration only), and Steps 14 (merge+deploy) and 15 (post-deploy) are skipped entirely; `resume_lib detect-step --headless` resumes a ready-to-merge/merged PR at Step 16 (an `open` PR still resumes at Step 13 so the bot can push CI fixes — a local op). (2) **guard layer** — `wal-guard` blocks **every** `ssh`/`scp`/`rsync`/`sftp` invocation while `RAWGENTIC_HEADLESS=1`, from any step or skill, independent of `protectionLevel` (fires even under `sandbox`), via the tested `hooks/headless_ssh_guard.py` matcher (sees through env-prefixes, wrappers, `bash -c`, `$(...)`, absolute paths; never flags `git`/`gh`). Opt back in per project with the workspace-scoped, fail-closed `headlessAllowSSH: true`. (#47)
 
 ### v2.40.1 (2026-06-16)
 - **Headless protocol moved to per-skill `references/headless.md` (leaner injected body).** The `<headless-interaction>` / `<headless-checkpoint>` / `<headless-resume>` blocks (~208 lines in implement-feature, ~75 in fix-bug) only matter when `HEADLESS MODE active` — yet they sat in the SKILL.md body, paid for on *every* (mostly non-headless) invocation. They now live in `skills/<skill>/references/headless.md`, loaded on demand; the body keeps the per-step `[Headless: …]` annotations + a short `<headless-mode>` pointer, and `<resumption-protocol>` points at the reference for the resume sequence. implement-feature SKILL.md **1484 → 1281**, fix-bug **800 → 732**. The 2 skills' headless protocols genuinely differ, so each keeps its own reference (not synced). `test_bmad_detection` updated to assert the protocol in the reference + the body pointer; the `[Headless` annotation count (27/12) is unchanged. (#111)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -398,7 +398,8 @@ its workspace entry. Default is `false` (safe — must opt in).
   "projects": [
     {
       "name": "my-app",
-      "headlessEnabled": true
+      "headlessEnabled": true,
+      "headlessAllowSSH": false
     }
   ]
 }
@@ -408,6 +409,20 @@ Set during `/rawgentic:setup` (Step 2c) or manually in `.rawgentic_workspace.jso
 When `RAWGENTIC_HEADLESS=1` is set but the project has `headlessEnabled: false`
 (or missing), the session-start hook blocks headless execution and the agent
 is instructed to exit immediately.
+
+**`headlessAllowSSH`** (boolean, default `false`) — the SSH escape hatch for the
+headless remote-ops guard (issue #47). In headless mode the bot's job ends at PR
+creation: no merge, no deploy, no outbound SSH. `wal-guard` therefore **blocks any
+`ssh`/`scp`/`rsync`/`sftp` invocation** while `RAWGENTIC_HEADLESS=1`, regardless of
+which workflow step (or skill) issues it, and **independent of `protectionLevel`**
+— it fires even under `sandbox`. Set `headlessAllowSSH: true` on the project's
+workspace entry to opt back in (for a project that genuinely needs headless remote
+ops). Resolution is **fail-closed**: anything other than a literal `true` (absent,
+`false`, null, non-boolean, unresolved project) leaves SSH blocked. Like
+`headlessEnabled`, this flag is **workspace-scoped** (it lives on the
+`.rawgentic_workspace.json` project entry, not in the project's `.rawgentic.json`),
+so all headless access-control stays in one place. `git`/`gh` (which use their own
+transport, not the `ssh` program) are never blocked.
 
 ### Environment Variable
 
@@ -491,6 +506,7 @@ per project at a time — the orchestrator enforces this via `ai-in-progress`.
 | Step 1 | Confirm capabilities (WF1-created) | AUTO-RESOLVE |
 | Step 1 | Confirm capabilities (manual issue) | QUESTION |
 | Step 2 | Components don't exist | QUESTION |
+| Step 2 | Live environment SSH probe | AUTO-RESOLVE (skip SSH probes, local exploration only) |
 | Step 3 | Design approach trade-offs | QUESTION |
 | Step 3 | Scope larger than estimated | QUESTION |
 | Step 4 | Ambiguity circuit breaker | QUESTION |
@@ -503,7 +519,9 @@ per project at a time — the orchestrator enforces this via `ai-in-progress`.
 | Step 8 | Periodic checkpoint | Checkpoint to session notes |
 | Step 11 | Design flaw + budget exhausted | ERROR |
 | Step 13 | CI timeout | AUTO-RESOLVE (2x wait, then ERROR) |
-| Step 14 | Manual deploy confirmation | QUESTION |
+| Step 14 | Merge and deploy | AUTO-RESOLVE (skip entire step — PR creation is the terminal deliverable; no merge, no deploy) |
+| Step 14 | Manual deploy confirmation | n/a — Step 14 is skipped in headless, so this is interactive-only |
+| Step 15 | Post-deploy verification | AUTO-RESOLVE (skip — no deployment occurred) |
 
 ### Structured Comment Format
 
@@ -592,6 +610,13 @@ function exposed as a CLI:
 - `bypassPermissions` mode removes human oversight — WAL guards and security
   guards are the last line of defense in headless mode. Guard blocks are
   logged to the WAL as `GUARD_BLOCK` entries for audit visibility.
+- **Headless = no outbound remote ops.** Beyond the per-step workflow guards,
+  `wal-guard` blocks every `ssh`/`scp`/`rsync`/`sftp` invocation while
+  `RAWGENTIC_HEADLESS=1` (unless `headlessAllowSSH: true`), so an ad-hoc SSH from
+  *any* step or skill is denied even if the skill author forgot to annotate it.
+  This is a hook-level safety net for the chorestory #309 class of incident (a
+  headless run SSHing to a live host); container-level SSH removal (arc #1) is the
+  complementary outer layer.
 - The `suspended_at` timestamp uses UTC wall-clock time. The orchestrator host
   and Claude host must have synchronized clocks (NTP) for the 24h TTL-based
   stale file cleanup to work correctly. Clock skew may cause premature or

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -264,6 +264,8 @@ and defer to BMAD equivalents on a per-project basis.
 | `disabledSkills` | `string[]` | Bare skill names the user chose to replace with BMAD equivalents. |
 | `critiqueMethod` | `string` | `"reflexion"` (default) or `"bmad-party-mode"`. Controls which critique tool is used at quality gates. |
 | `adversarialReview` | `object` \| `bool` | Opt-in cross-model adversarial review (WF5) at workflow quality gates. Shape: `{ "enabled": bool, "workflows": ["implement-feature", "fix-bug"] }`. Default disabled. Bool shorthand `true` enables the standalone skill mindset but lists no workflows (embedded gates stay off). Fail-closed: missing/malformed → disabled. See [Adversarial Review Data Handling](#adversarial-review-data-handling). |
+| `headlessEnabled` | `bool` | Opt-in to headless (non-interactive) execution. Default `false`. See [Per-Project Access Control](#per-project-access-control). |
+| `headlessAllowSSH` | `bool` | Escape hatch for the headless SSH guard. Default `false` (SSH blocked in headless). Fail-closed. See [Per-Project Access Control](#per-project-access-control). |
 
 ### `disabledSkills` Semantics
 

--- a/docs/wal-guide.md
+++ b/docs/wal-guide.md
@@ -126,7 +126,9 @@ running.
 
 ### Blocked Patterns
 
-Wal-guard blocks **production deployment commands** only:
+Wal-guard blocks two categories:
+
+**1. Production deployment commands** (always, subject to `protectionLevel`):
 - `ssh`/`scp`/`rsync` targeting prod hosts
 - `docker compose` targeting prod with `up`/`restart`/`start`
 - `ansible` targeting prod inventories
@@ -136,6 +138,17 @@ Wal-guard blocks **production deployment commands** only:
 
 All patterns are case-insensitive and match anywhere in the command string.
 
+**2. Blanket SSH-family block in headless mode** (issue #47): when
+`RAWGENTIC_HEADLESS=1`, wal-guard denies **any** `ssh`/`scp`/`rsync`/`sftp`
+invocation — not just prod-targeting ones — because a headless run's job ends at
+PR creation (no merge, no deploy, no remote access). This fires **regardless of
+`protectionLevel`** (even under `sandbox`) and is detected via the tested
+`hooks/headless_ssh_guard.py` matcher (which sees through env-assignments,
+wrappers like `sudo`/`timeout`, `bash -c`, `$(...)`, and absolute paths, but never
+flags `git`/`gh`, which use their own transport). Set `headlessAllowSSH: true` on
+the project's `.rawgentic_workspace.json` entry to opt out (see
+`docs/config-reference.md`). This block does **not** apply in interactive mode.
+
 ### What Is NOT Blocked
 
 Destructive local commands (`rm -rf`, `git push --force`, `git reset --hard`,
@@ -143,11 +156,14 @@ Destructive local commands (`rm -rf`, `git push --force`, `git reset --hard`,
 behavior already prompts the user before running these operations, and
 hard-blocking via hooks would prevent the user from approving when they
 intentionally want to proceed (hooks have no warn-and-confirm mechanism).
+`git`/`gh` are never treated as SSH commands even in headless mode.
 
 ### Fail-Closed Behavior
 
 If `jq` is unavailable, wal-guard denies **all** commands. This prevents
-unguarded execution when the pattern-matching infrastructure is broken.
+unguarded execution when the pattern-matching infrastructure is broken. The
+headless SSH block is likewise fail-closed: an unresolvable `headlessAllowSSH`
+(or an unavailable matcher) leaves SSH-family commands blocked.
 
 ## Troubleshooting
 

--- a/hooks/headless_ssh_guard.py
+++ b/hooks/headless_ssh_guard.py
@@ -78,7 +78,11 @@ def _interpreter_inner(tokens: list[str], depth: int) -> str | None:
     if prog == "eval":
         return detect_blocked_program(" ".join(tokens[1:]), depth + 1)
     for j in range(1, len(tokens)):
-        if tokens[j] == "-c" and j + 1 < len(tokens):
+        tok = tokens[j]
+        # `-c`, or a combined short-flag cluster carrying c (`-lc`, `-ec`, `-cx`):
+        # the following token is the command string. Long flags (`--x`) excluded.
+        if (tok.startswith("-") and not tok.startswith("--")
+                and "c" in tok and j + 1 < len(tokens)):
             return detect_blocked_program(tokens[j + 1], depth + 1)
     return None
 
@@ -122,6 +126,12 @@ def _scan_wrapped(rest: list[str], depth: int) -> str | None:
 
 def _segment_program(segment: str, depth: int) -> str | None:
     """Return the blocked SSH-family program invoked by one shell segment, else None."""
+    # Blank command-substitutions/subshells (no surrounding space) so a `$(...)`
+    # value that contains a space cannot fragment a leading env-assignment — e.g.
+    # `TS=$(date +%s) ssh host` must not tokenize to `TS=$(date`, `+%s)`, `ssh`,
+    # which would hide the real `ssh`. Their contents are still inspected by the
+    # _SUBST recursion in detect_blocked_program, so blanking here loses nothing.
+    segment = _SUBST.sub("__SUBST__", segment)
     try:
         tokens = shlex.split(segment, comments=False, posix=True)
     except ValueError:

--- a/hooks/headless_ssh_guard.py
+++ b/hooks/headless_ssh_guard.py
@@ -14,16 +14,29 @@ wal-lib.sh, which already read the env and the resolved project config.
 
 Detection rules (deliberately conservative — this is a safety net, and the
 `headlessAllowSSH:true` escape hatch exists for projects that need remote ops):
-  * Split the command on shell control operators (`;`, `&&`, `||`, `|`, `&`, and
-    newlines) into segments — a blocked program anywhere in the pipeline counts.
-  * Per segment, skip leading `VAR=value` env-assignments, then look at the first
-    real token's basename. If it is ssh/scp/rsync/sftp -> blocked.
-  * If that first token is a known command *wrapper* (sudo/env/timeout/nohup/...),
-    a blocked program appearing anywhere later in the segment counts (the wrapper
-    is invoking it) — this catches `sudo -u x ssh h`, `timeout 5 ssh h`, etc.
+  * Recurse into command substitutions `$(...)`, backticks, subshells `(...)`,
+    and process substitutions `<(...)`/`>(...)` — ssh hidden there still counts.
+  * Recurse into shell interpreter command strings: `bash -c '...'`, `sh -c`,
+    `eval '...'`, and `find ... -exec <prog>`.
+  * Split the remaining command on shell control operators (`;`, `&&`, `||`,
+    `|`, `&`, newlines) into segments. Per segment, skip leading `VAR=value`
+    env-assignments, then look at the first real token's basename. ssh/scp/
+    rsync/sftp -> blocked.
+  * If that first token is a known command *wrapper* (sudo/env/timeout/nohup/...)
+    scan the rest of the segment for a blocked program (and recurse into any
+    interpreter/find found there). This is intentionally broad — it does NOT
+    parse each wrapper's option arity — so `timeout -s KILL 5 ssh` and
+    `sudo -u user ssh` are caught with no bypass; the cost is over-blocking the
+    rare case where ssh/scp/rsync is a mere ARGUMENT under a wrapper
+    (`timeout 5 grep rsync src/`). Fail-toward-blocking is the right default for
+    a safety net; the escape hatch covers projects that need otherwise.
   * Program detection is by **basename**, so `/usr/bin/ssh` matches but `git push`
-    (git's own ssh transport), `gh`, and `ssh` used as a mere argument
+    (git's own ssh transport), `gh`, and `ssh` as a mere argument
     (`grep ssh`, `cat /etc/ssh/sshd_config`) do NOT.
+
+Residual gaps (documented, accepted): ssh embedded in a NON-shell interpreter
+string (`python3 -c "...os.system('ssh')"`) is not detected — arbitrary-language
+eval is out of scope; WF2's own deploy path is closed by the Layer-A Step-14 skip.
 """
 import os
 import re
@@ -35,24 +48,79 @@ import sys
 BLOCKED_PROGRAMS = frozenset({"ssh", "scp", "rsync", "sftp"})
 
 # Command wrappers that run another program — a blocked program after one of
-# these is still an SSH invocation. We do NOT try to parse each wrapper's option
-# arity (a rabbit hole); instead, once the segment starts with a wrapper we scan
-# the rest of the segment for a blocked program (fail-toward-blocking).
+# these is still an SSH invocation.
 WRAPPERS = frozenset({
     "sudo", "doas", "env", "command", "builtin", "exec", "nohup",
     "time", "timeout", "stdbuf", "xargs", "ionice", "nice", "setsid",
 })
 
+# Shell interpreters whose `-c` string (or, for eval, whose args) is itself a
+# shell command we must look inside.
+INTERPRETERS = frozenset({"bash", "sh", "zsh", "dash", "ash", "ksh", "eval"})
+
 _ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 _SEGMENT_SPLIT = re.compile(r"&&|\|\||[;&|\n]")
+# Command substitution `$(...)`, backticks, and (process-)subshells `(...)`,
+# `<(...)`, `>(...)`. Non-nested capture is sufficient for the common forms; the
+# recursion depth guard bounds pathological input.
+_SUBST = re.compile(r"\$\(([^()]*)\)|`([^`]*)`|(?<![\w$])[<>]?\(([^()]*)\)")
+
+_MAX_DEPTH = 6
 
 
 def _basename(token: str) -> str:
-    """Basename of a program token (so /usr/bin/ssh -> ssh)."""
     return os.path.basename(token)
 
 
-def _segment_program(segment: str) -> str | None:
+def _interpreter_inner(tokens: list[str], depth: int) -> str | None:
+    """Recurse into a shell interpreter's command string (`bash -c '...'`, `eval ...`)."""
+    prog = _basename(tokens[0])
+    if prog == "eval":
+        return detect_blocked_program(" ".join(tokens[1:]), depth + 1)
+    for j in range(1, len(tokens)):
+        if tokens[j] == "-c" and j + 1 < len(tokens):
+            return detect_blocked_program(tokens[j + 1], depth + 1)
+    return None
+
+
+def _find_exec_inner(tokens: list[str], depth: int) -> str | None:
+    """Recurse into the command run by `find ... -exec <prog> ... ;`."""
+    for j in range(1, len(tokens)):
+        if tokens[j] in ("-exec", "-execdir") and j + 1 < len(tokens):
+            rest = []
+            for tok in tokens[j + 1:]:
+                if tok in (";", "+", "\\;"):
+                    break
+                rest.append(tok)
+            return detect_blocked_program(" ".join(rest), depth + 1)
+    return None
+
+
+def _scan_wrapped(rest: list[str], depth: int) -> str | None:
+    """Broad scan of a wrapped command's tokens for a blocked program.
+
+    Looks for a blocked basename anywhere (skipping env-assignments), and
+    recurses into any interpreter / find encountered. Intentionally does not
+    model option arity (see module docstring) — broad coverage, no bypass.
+    """
+    for k, tok in enumerate(rest):
+        if _ASSIGNMENT.match(tok):
+            continue
+        base = _basename(tok)
+        if base in BLOCKED_PROGRAMS:
+            return base
+        if base in INTERPRETERS:
+            hit = _interpreter_inner(rest[k:], depth)
+            if hit:
+                return hit
+        if base == "find":
+            hit = _find_exec_inner(rest[k:], depth)
+            if hit:
+                return hit
+    return None
+
+
+def _segment_program(segment: str, depth: int) -> str | None:
     """Return the blocked SSH-family program invoked by one shell segment, else None."""
     try:
         tokens = shlex.split(segment, comments=False, posix=True)
@@ -62,7 +130,6 @@ def _segment_program(segment: str) -> str | None:
     if not tokens:
         return None
 
-    # Skip leading env-assignments (FOO=bar ssh ...).
     idx = 0
     while idx < len(tokens) and _ASSIGNMENT.match(tokens[idx]):
         idx += 1
@@ -72,29 +139,35 @@ def _segment_program(segment: str) -> str | None:
     first = _basename(tokens[idx])
     if first in BLOCKED_PROGRAMS:
         return first
-
+    if first in INTERPRETERS:
+        return _interpreter_inner(tokens[idx:], depth)
+    if first == "find":
+        return _find_exec_inner(tokens[idx:], depth)
     if first in WRAPPERS:
-        # Wrapper invokes another program; a blocked program anywhere after it
-        # (skipping further env-assignments) counts.
-        for tok in tokens[idx + 1:]:
-            if _ASSIGNMENT.match(tok):
-                continue
-            base = _basename(tok)
-            if base in BLOCKED_PROGRAMS:
-                return base
+        return _scan_wrapped(tokens[idx + 1:], depth)
     return None
 
 
-def detect_blocked_program(command: str) -> str | None:
+def detect_blocked_program(command: str, depth: int = 0) -> str | None:
     """Return the SSH-family program the command invokes (ssh/scp/rsync/sftp), or None.
 
     Pure detection: caller decides whether to block based on headless mode and the
     project's `headlessAllowSSH` flag.
     """
-    if not command or not command.strip():
+    if not command or not command.strip() or depth > _MAX_DEPTH:
         return None
+
+    # 1. Recurse into command substitutions / subshells / process substitutions.
+    for match in _SUBST.finditer(command):
+        inner = match.group(1) or match.group(2) or match.group(3)
+        if inner:
+            hit = detect_blocked_program(inner, depth + 1)
+            if hit:
+                return hit
+
+    # 2. Segment scan on the outer command.
     for segment in _SEGMENT_SPLIT.split(command):
-        program = _segment_program(segment)
+        program = _segment_program(segment, depth)
         if program:
             return program
     return None

--- a/hooks/headless_ssh_guard.py
+++ b/hooks/headless_ssh_guard.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Headless blanket SSH-family matcher (issue #47, Layer B).
+
+In headless mode the bot's job ends at PR creation — no merge, no deploy, no
+outbound SSH to remote hosts (chorestory #309 incident: a headless WF2 run SSHed
+to a live dev VM and corrupted it). `wal-guard` enforces this by DENYING any
+command that *invokes* an SSH-family program (ssh/scp/rsync/sftp), unless the
+project opts back in via the workspace `headlessAllowSSH` flag.
+
+This module is ONLY the detection — the security-critical, bypass-prone part —
+so it is pure and fully unit-tested. The gating (am-I-headless via
+`RAWGENTIC_HEADLESS`, and `headlessAllowSSH` resolution) stays in wal-guard /
+wal-lib.sh, which already read the env and the resolved project config.
+
+Detection rules (deliberately conservative — this is a safety net, and the
+`headlessAllowSSH:true` escape hatch exists for projects that need remote ops):
+  * Split the command on shell control operators (`;`, `&&`, `||`, `|`, `&`, and
+    newlines) into segments — a blocked program anywhere in the pipeline counts.
+  * Per segment, skip leading `VAR=value` env-assignments, then look at the first
+    real token's basename. If it is ssh/scp/rsync/sftp -> blocked.
+  * If that first token is a known command *wrapper* (sudo/env/timeout/nohup/...),
+    a blocked program appearing anywhere later in the segment counts (the wrapper
+    is invoking it) — this catches `sudo -u x ssh h`, `timeout 5 ssh h`, etc.
+  * Program detection is by **basename**, so `/usr/bin/ssh` matches but `git push`
+    (git's own ssh transport), `gh`, and `ssh` used as a mere argument
+    (`grep ssh`, `cat /etc/ssh/sshd_config`) do NOT.
+"""
+import os
+import re
+import shlex
+import sys
+
+# SSH-family programs blocked in headless mode (the issue names ssh/scp/rsync;
+# sftp is the same remote-shell family and included for completeness).
+BLOCKED_PROGRAMS = frozenset({"ssh", "scp", "rsync", "sftp"})
+
+# Command wrappers that run another program — a blocked program after one of
+# these is still an SSH invocation. We do NOT try to parse each wrapper's option
+# arity (a rabbit hole); instead, once the segment starts with a wrapper we scan
+# the rest of the segment for a blocked program (fail-toward-blocking).
+WRAPPERS = frozenset({
+    "sudo", "doas", "env", "command", "builtin", "exec", "nohup",
+    "time", "timeout", "stdbuf", "xargs", "ionice", "nice", "setsid",
+})
+
+_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_SEGMENT_SPLIT = re.compile(r"&&|\|\||[;&|\n]")
+
+
+def _basename(token: str) -> str:
+    """Basename of a program token (so /usr/bin/ssh -> ssh)."""
+    return os.path.basename(token)
+
+
+def _segment_program(segment: str) -> str | None:
+    """Return the blocked SSH-family program invoked by one shell segment, else None."""
+    try:
+        tokens = shlex.split(segment, comments=False, posix=True)
+    except ValueError:
+        # Unbalanced quotes etc. — fall back to whitespace split (conservative).
+        tokens = segment.split()
+    if not tokens:
+        return None
+
+    # Skip leading env-assignments (FOO=bar ssh ...).
+    idx = 0
+    while idx < len(tokens) and _ASSIGNMENT.match(tokens[idx]):
+        idx += 1
+    if idx >= len(tokens):
+        return None
+
+    first = _basename(tokens[idx])
+    if first in BLOCKED_PROGRAMS:
+        return first
+
+    if first in WRAPPERS:
+        # Wrapper invokes another program; a blocked program anywhere after it
+        # (skipping further env-assignments) counts.
+        for tok in tokens[idx + 1:]:
+            if _ASSIGNMENT.match(tok):
+                continue
+            base = _basename(tok)
+            if base in BLOCKED_PROGRAMS:
+                return base
+    return None
+
+
+def detect_blocked_program(command: str) -> str | None:
+    """Return the SSH-family program the command invokes (ssh/scp/rsync/sftp), or None.
+
+    Pure detection: caller decides whether to block based on headless mode and the
+    project's `headlessAllowSSH` flag.
+    """
+    if not command or not command.strip():
+        return None
+    for segment in _SEGMENT_SPLIT.split(command):
+        program = _segment_program(segment)
+        if program:
+            return program
+    return None
+
+
+def main(argv: list[str]) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="headless_ssh_guard.py",
+        description="Detect SSH-family program invocations (headless safety net).",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser(
+        "detect",
+        help="Read a command from stdin; print the blocked program (exit 0) "
+             "if it invokes ssh/scp/rsync/sftp, else print nothing (exit 1).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.cmd == "detect":
+        command = sys.stdin.read()
+        program = detect_blocked_program(command)
+        if program:
+            print(program)
+            return 0
+        return 1
+    return 2  # unreachable (subparser required)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/hooks/resume_lib.py
+++ b/hooks/resume_lib.py
@@ -61,15 +61,23 @@ def detect_resume_step(
     *,
     markers_complete: bool = False,
     completion_gate_printed: bool = False,
+    headless: bool = False,
 ) -> int | str:
     """Return the WF2 step to resume at given the gathered facts.
 
-    Returns an int step (1, 2, 5, 8, 9, 11, 13, 14, 15) or the ``COMPLETION_GATE``
-    sentinel. The mapping is total over all valid inputs: there is no input that
-    falls through to an undefined result. An *unrecognized* state raises
-    ``ValueError`` rather than defaulting to Step 1 — silently restarting an
-    in-flight workflow because a fact was mistyped would be worse than failing
-    loudly.
+    Returns an int step (1, 2, 5, 8, 9, 11, 13, 14, 15, 16) or the
+    ``COMPLETION_GATE`` sentinel. The mapping is total over all valid inputs:
+    there is no input that falls through to an undefined result. An *unrecognized*
+    state raises ``ValueError`` rather than defaulting to Step 1 — silently
+    restarting an in-flight workflow because a fact was mistyped would be worse
+    than failing loudly.
+
+    ``headless`` (issue #47): in headless mode WF2 is PR-terminal — it never
+    merges or deploys. A ``ready-to-merge`` PR (which non-headless would merge at
+    Step 14) and a ``merged`` PR (whose post-deploy at Step 15 is meaningless when
+    the bot performed no deploy) both resume at Step 16 (completion). ``open`` is
+    deliberately NOT remapped: the bot may still fix CI by pushing to its own PR
+    branch (a local op, not remote access), so it stays at Step 13.
     """
     for name, value, valid in (
         ("pr_state", pr_state, PR_STATES),
@@ -87,10 +95,13 @@ def detect_resume_step(
         return COMPLETION_GATE
 
     # PR cascade (rules 1-3) — a PR outranks branch/notes state.
+    # Headless (issue #47) is PR-terminal: ready-to-merge and merged both collapse
+    # to Step 16 (no merge, no deploy, no post-deploy). `open` is unchanged so the
+    # bot can still push CI fixes (a local op) before completing.
     if pr_state == "merged":
-        return 15
+        return 16 if headless else 15
     if pr_state == "ready-to-merge":
-        return 14
+        return 16 if headless else 14
     if pr_state == "open":
         return 13
 
@@ -148,6 +159,10 @@ def main(argv=None) -> int:
     p.add_argument("--completion-gate-printed", choices=["true", "false"],
                    default="false", dest="completion_gate_printed",
                    help="whether the completion gate was already printed")
+    p.add_argument("--headless", choices=["true", "false"], default="false",
+                   dest="headless",
+                   help="whether running in headless mode (PR-terminal: "
+                        "ready-to-merge/merged resume at Step 16, no merge/deploy)")
 
     args = parser.parse_args(argv)
 
@@ -157,6 +172,7 @@ def main(argv=None) -> int:
                 args.pr_state, args.branch_state, args.notes_state,
                 markers_complete=(args.markers_complete == "true"),
                 completion_gate_printed=(args.completion_gate_printed == "true"),
+                headless=(args.headless == "true"),
             )
         except ValueError as exc:
             print(str(exc), file=sys.stderr)

--- a/hooks/wal-guard
+++ b/hooks/wal-guard
@@ -72,6 +72,33 @@ if wal_find_workspace; then
 fi
 # If resolution failed, WAL_ACTIVE_WAL_GUARDS defaults to "ALL" (strict)
 
+# --- Headless blanket SSH block (issue #47, Layer B) ---
+# In headless mode (RAWGENTIC_HEADLESS=1) the bot's job ends at PR creation:
+# no merge, no deploy, no outbound SSH to remote hosts (chorestory #309 incident).
+# Block any ssh/scp/rsync/sftp invocation — caught via the tested matcher in
+# headless_ssh_guard.py — unless the project opts in via headlessAllowSSH:true.
+# This is INDEPENDENT of protectionLevel (headless safety is orthogonal — it
+# fires even under sandbox) and so runs before, and outside, _check_patterns.
+_check_headless_ssh() {
+  [ "${RAWGENTIC_HEADLESS:-}" = "1" ] || return 0
+  wal_resolve_headless_allow_ssh
+  [ "${WAL_HEADLESS_ALLOW_SSH:-false}" = "true" ] && return 0
+
+  local prog rc
+  # set -e safe: capture both stdout and the matcher's exit code.
+  #   rc 0 = blocked program found ($prog); rc 1 = clean; rc>=2 = matcher failed.
+  prog=$(printf '%s' "$COMMAND" | python3 "$SCRIPT_DIR/headless_ssh_guard.py" detect 2>/dev/null) && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ] && [ -n "$prog" ]; then
+    deny "BLOCKED: SSH ($prog) is disabled in headless mode — headless runs end at PR creation, with no outbound remote access. Set \"headlessAllowSSH\": true on this project's entry in .rawgentic_workspace.json to override." "$COMMAND"
+  elif [ "$rc" -ge 2 ]; then
+    # Matcher unavailable (e.g. python missing) — fail closed with a coarse check.
+    if printf '%s' "$COMMAND" | grep -qiE '(^|[;&|]|[[:space:]])(ssh|scp|rsync|sftp)([[:space:]]|$)'; then
+      deny "BLOCKED: headless SSH check could not run (matcher unavailable); SSH-like command blocked (fail-closed). Set \"headlessAllowSSH\": true to override." "$COMMAND"
+    fi
+  fi
+}
+_check_headless_ssh
+
 # --- Data-driven blocked patterns ---
 # Each entry: regex -> human-readable reason -> grep flags
 # Patterns match anywhere in the command string (no word boundaries).

--- a/hooks/wal-lib.sh
+++ b/hooks/wal-lib.sh
@@ -291,3 +291,30 @@ wal_resolve_protection_level() {
       ;;
   esac
 }
+
+# --- Headless SSH allow-flag resolution (issue #47) ---
+# In headless mode, outbound ssh/scp/rsync/sftp is blocked (the bot's job ends at
+# PR creation — no merge, no deploy, no remote access) UNLESS the project opts in.
+# The opt-in is WORKSPACE-scoped: a `headlessAllowSSH` boolean on the project's
+# .rawgentic_workspace.json entry, a sibling of headlessEnabled (all headless
+# access-control lives in the workspace file, not the committed project config).
+# FAIL-CLOSED: anything other than a literal boolean true (absent, false, null,
+# non-bool, unreadable workspace, unresolved project, jq error) → "false" (block).
+# Sets: WAL_HEADLESS_ALLOW_SSH ("true" | "false")
+# Requires: WAL_PROJECT and WAL_WORKSPACE_FILE (call after wal_resolve_project).
+wal_resolve_headless_allow_ssh() {
+  WAL_HEADLESS_ALLOW_SSH="false"
+  local ws_config="${WAL_WORKSPACE_FILE:-}"
+  [ -n "$ws_config" ] && [ -f "$ws_config" ] || return 0
+  [ -n "${WAL_PROJECT:-}" ] || return 0
+  local val
+  val=$("$WAL_JQ" -r --arg name "$WAL_PROJECT" '
+    (.projects // [])
+    | map(select(.name == $name))
+    | (.[0].headlessAllowSSH)
+    | if . == true then "true" else "false" end
+  ' "$ws_config" 2>/dev/null || true)
+  if [ "$val" = "true" ]; then
+    WAL_HEADLESS_ALLOW_SSH="true"
+  fi
+}

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -118,8 +118,8 @@ Conditional steps (skip ONLY when their condition is not met):
 - **Step 8a (Per-task Review, P15):** mandatory when ANY task has `riskLevel: high`. Dispatched as a sub-step of Step 8 after each high-risk task's commit. Marker: `### WF2 Step 8a [task <id>, sha <abc>]: DONE (<N findings>)` in session notes.
 - Step 10 (Memorize): background, never blocks
 - Step 13 (CI): skip only if has_ci == false
-- Step 14 (Merge/Deploy): skip only if user does not request merge
-- Step 15 (Post-Deploy): skip only if no deployment performed
+- Step 14 (Merge/Deploy): skip only if user does not request merge — **always skipped in headless mode** (`additionalContext` has "HEADLESS MODE active"): PR creation is the terminal deliverable, so a headless run never merges or deploys (`references/headless.md`).
+- Step 15 (Post-Deploy): skip only if no deployment performed — also skipped in headless mode (no deployment occurred).
 
 **Why these hold even under pressure:** the tempting reasons to skip — a long session, a
 running-low context window, a change that "looks mechanical," or "WF1 already critiqued
@@ -188,6 +188,15 @@ user: the QUESTION (post→label→suspend→exit), ERROR, rich-checkpoint, and 
 resume protocols live in `references/headless.md`. **Read that file in full before acting on
 any of the per-step headless annotations below.** When NOT in headless mode, ignore them and behave
 normally (STOP and wait for terminal input at each interaction point).
+
+**Headless is PR-terminal — no remote ops.** A headless run's job ends at PR
+creation: no merge, no deploy, no outbound SSH to remote hosts. Step 14 (merge +
+deploy) and Step 15 (post-deploy) are skipped entirely; Step 2's live-environment
+probe does no SSH (local exploration only); CI handles deployment when a human
+merges the PR. This is also enforced at the hook layer — `wal-guard` blocks any
+`ssh`/`scp`/`rsync`/`sftp` invocation in headless mode regardless of step (set
+`headlessAllowSSH: true` on the project's `.rawgentic_workspace.json` entry to
+override), so even an ad-hoc SSH that a step forgot to annotate is denied.
 </headless-mode>
 
 <termination-rule>
@@ -244,13 +253,18 @@ set -euo pipefail
 #     none            = neither                                       [-> Step 1]
 # MARKERS_COMPLETE = true|false  (true iff ALL step markers are present in notes)
 # GATE_PRINTED     = true|false  (true iff the completion gate was already printed)
+# HEADLESS = true|false  (true iff additionalContext has "HEADLESS MODE active").
+#   In headless mode WF2 is PR-terminal: a ready-to-merge PR resumes at Step 16
+#   (no merge/deploy) and a merged PR resumes at Step 16 (no post-deploy); `open`
+#   still resumes at Step 13 so the bot can push CI fixes (a local op).
 STEP=$(python3 hooks/resume_lib.py detect-step \
   --pr-state PR_STATE --branch-state BRANCH_STATE --notes-state NOTES_STATE \
-  --markers-complete MARKERS_COMPLETE --completion-gate-printed GATE_PRINTED)
+  --markers-complete MARKERS_COMPLETE --completion-gate-printed GATE_PRINTED \
+  --headless HEADLESS)
 echo "Resuming at: $STEP"
 ```
 
-Pass the marker booleans on every call (don't leave the completion-gate rule to prose) — `detect-step` prints either a step number (1, 2, 5, 8, 9, 11, 13, 14, 15) or `completion-gate` (all markers present but the gate was never printed — run the completion gate, then terminate). Resume at the printed step. An unrecognized `--*-state` or non-`true`/`false` marker value exits non-zero rather than defaulting to Step 1, so a mistyped fact fails loudly instead of restarting in-flight work.
+Pass the marker booleans (and `--headless`) on every call (don't leave the completion-gate or headless rules to prose) — `detect-step` prints either a step number (1, 2, 5, 8, 9, 11, 13, 14, 15, 16) or `completion-gate` (all markers present but the gate was never printed — run the completion gate, then terminate). Resume at the printed step. An unrecognized `--*-state` or non-`true`/`false` flag value exits non-zero rather than defaulting to Step 1, so a mistyped fact fails loudly instead of restarting in-flight work.
 
 Before context compacts, document in session notes:
 - Current step number and sub-step
@@ -402,7 +416,7 @@ This enables workflow resumption if context is lost.
    - `docs`: identify cross-references, linked pages, publishing scripts
    - `research`: primarily analysis notebooks, data pipelines, or literature review — testing means validation of results and reproducibility
 
-3. **Live environment probe (infrastructure projects only):** When `capabilities.project_type == "infrastructure"` and target hosts are known (from `config.infrastructure.hosts[]`), SSH to each target host to discover current state. This catches discrepancies between issue specs (which may be outdated) and reality.
+3. **Live environment probe (infrastructure projects only):** When `capabilities.project_type == "infrastructure"` and target hosts are known (from `config.infrastructure.hosts[]`), SSH to each target host to discover current state. This catches discrepancies between issue specs (which may be outdated) and reality. **[Headless: AUTO-RESOLVE — skip the SSH probes entirely; do local exploration only (file reads, grep, git). A headless run makes no outbound SSH, and `wal-guard` will block it regardless.]**
 
    Probe for:
    - **Server capacity:** `nproc` (CPU count), `free -g` (RAM), `df -h` (disk) — compare against issue requirements
@@ -1133,6 +1147,8 @@ CI status or skip confirmation.
 
 ### Instructions
 
+**[Headless: AUTO-RESOLVE — SKIP THIS ENTIRE STEP. In headless mode the PR is the terminal deliverable: do NOT merge, do NOT deploy, do NOT SSH anywhere. Proceed directly to Step 16. CI handles deployment when a human merges the PR. (The `ssh`/`script`/`compose` deploy paths below would otherwise run unconditionally — this is the gap that caused the chorestory #309 dev-VM incident.) `wal-guard` also blocks any SSH at the hook layer as a backstop. Append the skip marker per Step 16 item 1b.]**
+
 **P15 pre-merge gate:** re-read via `plan_lib.read_review_state(repo_root, branch)`. If None or `last_review_log_status != "applied"`, refuse to merge. Cleanup of `claude_docs/.wf2-state/<issue>/` AND the branch's `.rawgentic/review-state/<branch-sanitized>.json` happens on merge success.
 
 1. **Merge PR (squash merge):**
@@ -1169,7 +1185,7 @@ CI status or skip confirmation.
 
    Please deploy and confirm when complete.
    ```
-   Wait for user confirmation before proceeding to Step 15. **[Headless: QUESTION — post comment with deployment instructions and ask for confirmation, suspend.]**
+   Wait for user confirmation before proceeding to Step 15. **[Headless: not reachable — the whole step is skipped in headless mode (see the Step 14 header), so this manual-deploy confirmation only ever runs interactively.]**
 
 ### Output
 Deployed (or manual deployment instructions provided and confirmed).
@@ -1184,6 +1200,8 @@ Deployed (or manual deployment instructions provided and confirmed).
 ## Step 15: Quality Gate — Post-Deploy Verification (Conditional)
 
 ### Instructions
+
+**[Headless: SKIP — no deployment occurred (Step 14 was skipped), so there is nothing to verify. Proceed to Step 16.]**
 
 **If `capabilities.has_deploy == false` AND no deployment was performed:** Skip with note "No deployment target — verification deferred to manual testing."
 
@@ -1220,6 +1238,14 @@ the store is the Tier-2 measurement telemetry substrate (per
 measurable signal — not just a sentence the user reads once.
 
 1. Update session notes with WF2 results.
+
+1b. **Headless mode:** if `additionalContext` has "HEADLESS MODE active", Steps 14
+   and 15 were skipped — the PR is the terminal deliverable. Record this for
+   auditability by appending a session-notes marker:
+   `### WF2 Step 14/15: SKIPPED (headless — PR #N is terminal; merge/deploy deferred to human + CI)`
+   and set the run-record `outcome.deploy` to `"not_applicable"` with a
+   `follow_ups` note `"headless: merge/deploy deferred to human + CI"`. The
+   rendered summary then reflects deploy: not_applicable for the headless run.
 
 2. **Assemble the run-record** from the workflow so far and write it to
    `/tmp/wf2-run-record.json` (use the Write tool, or a `cat > … <<'JSON'`
@@ -1271,7 +1297,7 @@ Before declaring WF2 complete, verify the following. Items marked (conditional) 
 4. [ ] PR URL documented
 5. [ ] All commits pushed
 6. [ ] (conditional: has_ci) CI passed
-7. [ ] (conditional: has_deploy) Deployment verified or manual deploy confirmed
+7. [ ] (conditional: has_deploy, NOT headless) Deployment verified or manual deploy confirmed — auto-satisfied in headless mode, where Steps 14/15 are skipped (PR is the terminal deliverable)
 8. [ ] (conditional: architecture changed) CLAUDE.md updated
 9. [ ] All Critical/High code review findings resolved
 10. [ ] Security scan (Step 11.5) ran; all blocking findings resolved (or, if no scanners were installed, the skips are recorded in session notes + PR body)

--- a/skills/implement-feature/references/headless.md
+++ b/skills/implement-feature/references/headless.md
@@ -13,6 +13,7 @@ as normal (STOP and wait for terminal input). If in headless mode, follow this p
 AUTO-RESOLVE interactions (no user input needed in headless mode):
 - Step 1: Accept auto-generated ACs for WF1-created issues
 - Step 1: Accept capabilities for WF1-created issues
+- Step 2: Live environment probe — skip SSH probes entirely; local exploration only (file reads, grep, git). A headless run makes no outbound SSH.
 - Step 5: Remove excess tasks on scope creep (document in session notes)
 - Step 5: Risk ratio `warn` band — log to session notes, continue
 - Step 2: Trivial-work suggestion — continue the full workflow (no interactive user for a "do it directly" hand-off)
@@ -20,6 +21,7 @@ AUTO-RESOLVE interactions (no user input needed in headless mode):
 - Step 7: Always resume existing branch
 - Step 8: Rewrite failing RED test (up to 2 attempts)
 - Step 13: Wait up to 2x CI_MAX_WAIT before erroring
+- Step 14: Merge and deploy — skip the entire step; PR creation is the terminal deliverable (no merge, no deploy, no SSH). Proceed to Step 16. Step 15 (post-deploy) is likewise skipped.
 
 QUESTION interactions (post comment, suspend, exit):
 - Step 1: Confirm capabilities/ACs for manually-created issues
@@ -31,7 +33,8 @@ QUESTION interactions (post comment, suspend, exit):
 - Step 8a: Ambiguity circuit breaker on per-task review findings
 - Step 8a: Reviewer dispatch failure after retry (REVIEW_DISPATCH_FAILED)
 - Step 11: Unresolved deferred-High findings at exit gate
-- Step 14: Manual deploy confirmation
+  (Step 14's manual-deploy confirmation is NOT a headless QUESTION — Step 14 is
+  skipped entirely in headless mode; see the Step 14 AUTO-RESOLVE entry above.)
 
 ERROR interactions (post error comment, exit WITHOUT ai-waiting label):
 - Step 4: Design loop-back budget exhausted

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.40.1"
+    assert plugin["version"] == "2.41.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_bmad_detection.py
+++ b/tests/hooks/test_bmad_detection.py
@@ -151,7 +151,7 @@ class TestHeadlessInteractionBlock:
 
     # Expected [Headless annotation counts per skill
     EXPECTED_COUNTS = {
-        "implement-feature": 27,  # 17 base + 1 disabled-skill cleanup + 7 P15 (#73): Step 5 warn/halt/decompose + 8a ambiguity/dispatch-failure/design-flaw/headless-suspend + Step 11 deferred-High + 1 Step 11.5 security-scan block + 1 Step 2 trivial-work suggestion
+        "implement-feature": 30,  # 17 base + 1 disabled-skill cleanup + 7 P15 (#73): Step 5 warn/halt/decompose + 8a ambiguity/dispatch-failure/design-flaw/headless-suspend + Step 11 deferred-High + 1 Step 11.5 security-scan block + 1 Step 2 trivial-work suggestion + 3 headless remote-ops guards (#47): Step 2 SSH-probe skip, Step 14 merge/deploy skip, Step 15 post-deploy skip
         "fix-bug": 12,            # 10 interaction points + 1 disabled-skill cleanup + 1 Step 2 trivial-work suggestion
     }
 

--- a/tests/hooks/test_headless_ssh_guard.py
+++ b/tests/hooks/test_headless_ssh_guard.py
@@ -43,6 +43,15 @@ BLOCK_CASES = [
     ("eval", 'eval "ssh host"'),
     ("command substitution", "x=$(ssh host whoami)"),
     ("command subst inline", "echo $(ssh host hostname)"),
+    # env-assignment whose $(...) value has a SPACE must not fragment detection
+    # (Step 11 High): the real ssh after the assignment must still be caught.
+    ("env-assign subst-space ssh", "TS=$(date +%s) ssh deploy@dev-vm 'systemctl restart api'"),
+    ("env-assign subst-space rsync", "D=$(date +%F) rsync -av dist/ dev-vm:/var/www/"),
+    ("env-assign subst-space scp", "H=$(cat host.txt) scp f dev-vm:/p"),
+    # combined interpreter short-flags (Step 11 Low): -lc / -ec / -cx carry -c.
+    ("bash -lc", "bash -lc 'ssh host whoami'"),
+    ("sh -ec", "sh -ec 'scp f host:/p'"),
+    ("bash -cx", 'bash -cx "ssh host"'),
     ("backtick", "echo `ssh host id`"),
     ("subshell", "(ssh host)"),
     ("process substitution", "diff <(ssh host cat /etc/hosts) local"),

--- a/tests/hooks/test_headless_ssh_guard.py
+++ b/tests/hooks/test_headless_ssh_guard.py
@@ -36,6 +36,18 @@ BLOCK_CASES = [
     ("sudo with flag", "sudo -n ssh host"),
     ("sudo -u user", "sudo -u deploy ssh host"),
     ("timeout wrapper", "timeout 5 ssh host"),
+    # Bypass forms an agent plausibly emits (Step 8a High finding) — must block:
+    ("bash -c", "bash -c 'ssh host whoami'"),
+    ("sh -c", 'sh -c "ssh host reboot"'),
+    ("sudo bash -c", "sudo bash -c 'ssh host'"),
+    ("eval", 'eval "ssh host"'),
+    ("command substitution", "x=$(ssh host whoami)"),
+    ("command subst inline", "echo $(ssh host hostname)"),
+    ("backtick", "echo `ssh host id`"),
+    ("subshell", "(ssh host)"),
+    ("process substitution", "diff <(ssh host cat /etc/hosts) local"),
+    ("find -exec", "find . -name '*.log' -exec scp {} host:/logs/ ;"),
+    ("timeout signal opt then ssh", "timeout -s KILL 5 ssh host"),
     ("timeout duration suffix", "timeout 5s ssh host"),
     ("env wrapper", "env ssh host"),
     ("env wrapper with assign", "env FOO=bar ssh host"),
@@ -70,6 +82,39 @@ ALLOW_CASES = [
     ("empty", ""),
     ("whitespace", "   "),
 ]
+
+
+class TestConservativeOverBlock:
+    """The wrapper scan is deliberately broad (fail-toward-blocking): once a known
+    command-wrapper leads the segment, an ssh-family basename ANYWHERE after it is
+    blocked, without parsing each wrapper's option arity. This avoids bypasses
+    (`timeout -s KILL 5 ssh`, `sudo -u user ssh`) at the cost of over-blocking a
+    few benign commands where ssh/scp/rsync is merely an ARGUMENT under a wrapper.
+    These cases are pinned as INTENTIONAL — the cost is acceptable: it only bites
+    in headless mode, and `headlessAllowSSH:true` is the explicit escape hatch."""
+
+    @pytest.mark.parametrize("command", [
+        "timeout 5 grep -rn rsync src/",   # grep for "rsync" under timeout
+        "sudo cat ssh",                    # cat a file literally named ssh
+        "timeout 10 cat /usr/bin/ssh",     # inspect the ssh binary under timeout
+    ])
+    def test_wrapper_over_blocks_ssh_arg(self, command):
+        from headless_ssh_guard import detect_blocked_program
+        assert detect_blocked_program(command) is not None
+
+
+class TestKnownGaps:
+    """Documented residual gaps — the matcher is a conservative safety net, not a
+    sandbox; these forms are not blocked (and headlessAllowSSH:true is the explicit
+    escape hatch for projects that genuinely need remote ops)."""
+
+    def test_foreign_interpreter_eval_is_a_gap(self):
+        # ssh embedded in a NON-shell interpreter string (python/perl/node -e) is
+        # out of scope — only shell interpreters (bash/sh/...) and `eval` recurse.
+        # The argument below is INERT TEST DATA (a string literal asserting the
+        # matcher returns None) — it is never executed.
+        from headless_ssh_guard import detect_blocked_program
+        assert detect_blocked_program("python3 -c \"import os;os.system('ssh h')\"") is None
 
 
 class TestDetectBlockedProgram:

--- a/tests/hooks/test_headless_ssh_guard.py
+++ b/tests/hooks/test_headless_ssh_guard.py
@@ -1,0 +1,115 @@
+"""Tests for hooks/headless_ssh_guard.py — the headless blanket SSH-family matcher.
+
+Issue #47 Layer B: in headless mode the WAL guard must DENY any command that
+invokes an SSH-family program (ssh/scp/rsync/sftp), regardless of which WF2 step
+initiates it. The detection is the security-critical, bypass-prone part, so it
+lives in this pure, fully-unit-tested matcher; the env/config gating (is-headless,
+allowSSH) stays in wal-guard/wal-lib.
+
+The matcher detects the *program* — never a substring or an argument — so it must
+NOT fire on `git push`/`gh pr` (which use their own transport) nor on `ssh` used as
+a mere argument (`grep ssh`, `echo ssh`, `cat /etc/ssh/sshd_config`). It MUST fire
+through common wrappers/prefixes the judges flagged: env-assignments, sudo, env,
+timeout, nohup, command, xargs, and an absolute path to the binary.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+GUARD_CLI = HOOKS_DIR / "headless_ssh_guard.py"
+
+
+# (label, command) pairs that MUST be detected as SSH-family invocations.
+BLOCK_CASES = [
+    ("bare ssh", "ssh user@host"),
+    ("bare scp", "scp build.tar.gz host:/opt/app/"),
+    ("bare rsync", "rsync -av dist/ host:/var/www/"),
+    ("bare sftp", "sftp host"),
+    ("ssh to prod", "ssh deploy@prod-1.example.com 'systemctl restart api'"),
+    ("single env prefix", "FOO=bar ssh host"),
+    ("multi env prefix", "FOO=bar BAZ=qux ssh host"),
+    ("sudo wrapper", "sudo ssh host"),
+    ("sudo with flag", "sudo -n ssh host"),
+    ("sudo -u user", "sudo -u deploy ssh host"),
+    ("timeout wrapper", "timeout 5 ssh host"),
+    ("timeout duration suffix", "timeout 5s ssh host"),
+    ("env wrapper", "env ssh host"),
+    ("env wrapper with assign", "env FOO=bar ssh host"),
+    ("nohup wrapper", "nohup ssh host"),
+    ("command builtin", "command ssh host"),
+    ("nested wrappers", "sudo timeout 5 ssh host"),
+    ("absolute path", "/usr/bin/ssh host"),
+    ("xargs wrapper", "xargs ssh"),
+    ("after &&", "echo starting && ssh host"),
+    ("after ;", "echo starting; ssh host"),
+    ("after ||", "false || ssh host"),
+    ("piped into ssh", "tar czf - dir | ssh host 'tar xzf -'"),
+    ("after newline", "echo a\nssh host"),
+    ("scp via sudo", "sudo scp f host:/p"),
+]
+
+# (label, command) pairs that MUST NOT be detected — common legitimate commands.
+ALLOW_CASES = [
+    ("git push", "git push origin main"),
+    ("git push upstream", "git push -u origin fix/47-headless-remote-ops-guard"),
+    ("gh pr create", "gh pr create --title x --body y"),
+    ("git fetch", "git fetch origin"),
+    ("ssh as echo arg", "echo ssh is the transport"),
+    ("ssh as grep arg", "grep ssh /etc/services"),
+    ("cat sshd_config", "cat /etc/ssh/sshd_config"),
+    ("ls ssh dir", "ls -la /etc/ssh"),
+    ("pytest ssh testfile", "pytest tests/test_ssh_guard.py -v"),
+    ("ssh in quoted string", 'echo "remember to ssh later"'),
+    ("rsync substring word", "python3 rsyncutil.py"),
+    ("timeout non-ssh", "timeout 300 pytest tests/ -v"),
+    ("sudo non-ssh", "sudo apt-get update"),
+    ("empty", ""),
+    ("whitespace", "   "),
+]
+
+
+class TestDetectBlockedProgram:
+    @pytest.mark.parametrize("label,command", BLOCK_CASES, ids=[c[0] for c in BLOCK_CASES])
+    def test_blocked(self, label, command):
+        from headless_ssh_guard import detect_blocked_program
+        prog = detect_blocked_program(command)
+        assert prog in {"ssh", "scp", "rsync", "sftp"}, f"[{label}] expected block, got {prog!r}"
+
+    @pytest.mark.parametrize("label,command", ALLOW_CASES, ids=[c[0] for c in ALLOW_CASES])
+    def test_allowed(self, label, command):
+        from headless_ssh_guard import detect_blocked_program
+        prog = detect_blocked_program(command)
+        assert prog is None, f"[{label}] expected allow, got blocked-by {prog!r}"
+
+    def test_returns_specific_program(self):
+        from headless_ssh_guard import detect_blocked_program
+        assert detect_blocked_program("scp a host:/b") == "scp"
+        assert detect_blocked_program("rsync -av a host:/b") == "rsync"
+
+
+class TestCLI:
+    def _run(self, command, timeout=10):
+        import subprocess
+        return subprocess.run(
+            ["python3", str(GUARD_CLI), "detect"],
+            input=command, capture_output=True, text=True, timeout=timeout,
+        )
+
+    def test_cli_block_prints_program_exit0(self):
+        r = self._run("ssh user@host")
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == "ssh"
+
+    def test_cli_allow_empty_stdout_exit1(self):
+        r = self._run("git push origin main")
+        assert r.returncode == 1
+        assert r.stdout.strip() == ""
+
+    def test_cli_block_via_wrapper(self):
+        r = self._run("sudo -u deploy ssh host")
+        assert r.returncode == 0
+        assert r.stdout.strip() == "ssh"

--- a/tests/hooks/test_resume_lib.py
+++ b/tests/hooks/test_resume_lib.py
@@ -253,3 +253,85 @@ class TestResumeSkillWiring:
             "the prose cascade was re-introduced alongside detect-step; the CLI "
             "is the single source of truth for the resume ordering."
         )
+
+
+class TestDetectResumeStepHeadless:
+    """Issue #47 Layer A — headless mode is PR-terminal: it never merges or deploys.
+
+    User decision: headless `open` (CI not yet green) still resumes at Step 13 so
+    the bot can fix CI via a local push (not a remote op); `ready-to-merge` and
+    `merged` resume at Step 16 (merge/deploy/post-deploy are skipped). Non-headless
+    behavior is unchanged.
+    """
+
+    def test_headless_ready_to_merge_goes_to_completion(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("ready-to-merge", "none", "none", headless=True) == 16
+
+    def test_headless_merged_goes_to_completion(self):
+        from resume_lib import detect_resume_step
+        # PR was merged (by a human) — post-deploy verification is meaningless in
+        # headless since the bot performed no deploy. Go straight to completion.
+        assert detect_resume_step("merged", "none", "none", headless=True) == 16
+
+    def test_headless_open_still_monitors_ci(self):
+        from resume_lib import detect_resume_step
+        # CI not yet green: the bot may still push CI fixes (local op) → Step 13.
+        assert detect_resume_step("open", "none", "none", headless=True) == 13
+
+    def test_headless_no_pr_uses_normal_branch_cascade(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("none", "verified", "none", headless=True) == 11
+        assert detect_resume_step("none", "empty", "none", headless=True) == 8
+
+    def test_completion_gate_outranks_headless_remap(self):
+        from resume_lib import detect_resume_step
+        # A fully-marked run that never printed its gate → gate, regardless of headless.
+        assert detect_resume_step(
+            "ready-to-merge", "none", "none",
+            markers_complete=True, headless=True,
+        ) == "completion-gate"
+
+    def test_non_headless_unchanged(self):
+        from resume_lib import detect_resume_step
+        assert detect_resume_step("ready-to-merge", "none", "none", headless=False) == 14
+        assert detect_resume_step("merged", "none", "none", headless=False) == 15
+        assert detect_resume_step("open", "none", "none", headless=False) == 13
+
+    def test_headless_defaults_false(self):
+        from resume_lib import detect_resume_step
+        # Omitting headless keeps the original mapping.
+        assert detect_resume_step("ready-to-merge", "none", "none") == 14
+
+
+class TestHeadlessCLI:
+    def test_cli_headless_ready_to_merge_prints_16(self):
+        out, err, rc = _run_cli(
+            "detect-step", "--pr-state", "ready-to-merge",
+            "--branch-state", "none", "--notes-state", "none", "--headless", "true",
+        )
+        assert rc == 0, err
+        assert out.strip() == "16"
+
+    def test_cli_headless_open_prints_13(self):
+        out, err, rc = _run_cli(
+            "detect-step", "--pr-state", "open",
+            "--branch-state", "none", "--notes-state", "none", "--headless", "true",
+        )
+        assert rc == 0, err
+        assert out.strip() == "13"
+
+    def test_cli_headless_default_false(self):
+        out, _, rc = _run_cli(
+            "detect-step", "--pr-state", "ready-to-merge",
+            "--branch-state", "none", "--notes-state", "none",
+        )
+        assert rc == 0
+        assert out.strip() == "14"
+
+    def test_cli_headless_rejects_invalid_value(self):
+        _, _, rc = _run_cli(
+            "detect-step", "--pr-state", "open",
+            "--branch-state", "none", "--notes-state", "none", "--headless", "maybe",
+        )
+        assert rc != 0

--- a/tests/hooks/test_wal_guard.py
+++ b/tests/hooks/test_wal_guard.py
@@ -466,6 +466,9 @@ class TestHeadlessSSHBlock:
         ("sftp", "sftp host"),
         ("sudo ssh", "sudo ssh host"),
         ("piped ssh", "tar czf - d | ssh host 'tar xzf -'"),
+        # bypass forms must also block end-to-end through the hook (Step 8a):
+        ("bash -c ssh", "bash -c 'ssh deploy@host'"),
+        ("cmd subst ssh", "OUT=$(ssh deploy@host hostname)"),
     ]
 
     @pytest.mark.parametrize("label,command", SSH_CMDS, ids=[c[0] for c in SSH_CMDS])

--- a/tests/hooks/test_wal_guard.py
+++ b/tests/hooks/test_wal_guard.py
@@ -466,9 +466,10 @@ class TestHeadlessSSHBlock:
         ("sftp", "sftp host"),
         ("sudo ssh", "sudo ssh host"),
         ("piped ssh", "tar czf - d | ssh host 'tar xzf -'"),
-        # bypass forms must also block end-to-end through the hook (Step 8a):
+        # bypass forms must also block end-to-end through the hook (Step 8a/11):
         ("bash -c ssh", "bash -c 'ssh deploy@host'"),
         ("cmd subst ssh", "OUT=$(ssh deploy@host hostname)"),
+        ("env subst-space ssh", "TS=$(date +%s) ssh deploy@dev-vm uptime"),
     ]
 
     @pytest.mark.parametrize("label,command", SSH_CMDS, ids=[c[0] for c in SSH_CMDS])

--- a/tests/hooks/test_wal_guard.py
+++ b/tests/hooks/test_wal_guard.py
@@ -415,3 +415,102 @@ class TestAnsibleExcludePattern:
         command = "ansible-playbook -i prod-inventory site.yml"
         decision, _ = _run_guard_with_level(command, "strict", make_workspace)
         assert decision == "deny"
+
+
+# ── Issue #47: headless blanket SSH block ────────────────────────────────
+
+def _run_guard_headless(
+    command, make_workspace, *, allow_ssh=None, level="standard", headless=True,
+):
+    """Run wal-guard with a session bound to testproj, optionally headless.
+
+    `headlessAllowSSH` is WORKSPACE-scoped (sibling of headlessEnabled in the
+    project's .rawgentic_workspace.json entry), so it is set via the project
+    entry, NOT the per-project .rawgentic.json.
+    """
+    session_id = "headless-guard-sess"
+    entry = {
+        "name": "testproj", "path": "./projects/testproj",
+        "active": True, "configured": True,
+    }
+    if allow_ssh is not None:
+        entry["headlessAllowSSH"] = allow_ssh
+    ws = make_workspace(
+        projects=[entry],
+        registry_entries=[{
+            "session_id": session_id, "project": "testproj",
+            "project_path": "./projects/testproj",
+        }],
+        project_configs={"testproj": {"protectionLevel": level}},
+    )
+    payload = {
+        "tool_input": {"command": command}, "tool_name": "Bash",
+        "session_id": session_id, "tool_use_id": "tu-h", "cwd": str(ws.root),
+    }
+    env = {"RAWGENTIC_HEADLESS": "1"} if headless else None
+    stdout, _stderr, _rc = run_hook(HOOK, payload, cwd=ws.root, env_override=env)
+    parsed = parse_hook_output(stdout)
+    decision = "allow"
+    if parsed and parsed.get("hookSpecificOutput", {}).get("permissionDecision") == "deny":
+        decision = "deny"
+    return decision, parsed
+
+
+class TestHeadlessSSHBlock:
+    """Issue #47 Layer B — blanket ssh/scp/rsync/sftp block in headless mode."""
+
+    SSH_CMDS = [
+        ("ssh", "ssh deploy@host"),
+        ("scp", "scp build.tar.gz host:/opt/app/"),
+        ("rsync", "rsync -av dist/ host:/var/www/"),
+        ("sftp", "sftp host"),
+        ("sudo ssh", "sudo ssh host"),
+        ("piped ssh", "tar czf - d | ssh host 'tar xzf -'"),
+    ]
+
+    @pytest.mark.parametrize("label,command", SSH_CMDS, ids=[c[0] for c in SSH_CMDS])
+    def test_headless_blocks_ssh_family_default(self, label, command, make_workspace):
+        # allowSSH absent → fail-closed default → block
+        decision, _ = _run_guard_headless(command, make_workspace)
+        assert decision == "deny", f"[{label}] headless should block: {command}"
+
+    def test_headless_blocks_even_under_sandbox(self, make_workspace):
+        # Independent of protectionLevel: sandbox normally allows everything.
+        decision, _ = _run_guard_headless("ssh deploy@host", make_workspace, level="sandbox")
+        assert decision == "deny"
+
+    def test_headless_allow_ssh_true_permits(self, make_workspace):
+        decision, _ = _run_guard_headless("ssh deploy@host", make_workspace, allow_ssh=True)
+        assert decision == "allow"
+
+    def test_headless_allow_ssh_false_blocks(self, make_workspace):
+        decision, _ = _run_guard_headless("ssh deploy@host", make_workspace, allow_ssh=False)
+        assert decision == "deny"
+
+    @pytest.mark.parametrize("command", [
+        "git push origin main",
+        "git push -u origin fix/47-headless-remote-ops-guard",
+        "gh pr create --title x --body y",
+    ])
+    def test_headless_allows_git_gh(self, command, make_workspace):
+        # git/gh use their own transport — must NOT be blocked even in headless.
+        decision, _ = _run_guard_headless(command, make_workspace)
+        assert decision == "allow", f"headless must not block: {command}"
+
+    def test_non_headless_does_not_block_plain_ssh(self, make_workspace):
+        # No RAWGENTIC_HEADLESS → headless block inactive; plain `ssh host` (no
+        # "prod") under standard is allowed by the existing prod patterns.
+        decision, _ = _run_guard_headless(
+            "ssh deploy@host", make_workspace, headless=False, level="standard")
+        assert decision == "allow"
+
+    def test_non_headless_still_blocks_ssh_prod(self, make_workspace):
+        # Existing behavior unchanged: ssh-to-prod blocked under strict.
+        decision, _ = _run_guard_headless(
+            "ssh deploy@prod-1", make_workspace, headless=False, level="strict")
+        assert decision == "deny"
+
+    def test_block_message_mentions_allowssh_override(self, make_workspace):
+        _, parsed = _run_guard_headless("ssh deploy@host", make_workspace)
+        reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "headlessAllowSSH" in reason


### PR DESCRIPTION
## Summary

Fixes #47 — a headless WF2 run could autonomously merge a PR and SSH-deploy to a remote host (the chorestory #309 incident corrupted a live dev VM). Two independent defense layers:

**Layer A — workflow (prose):** In headless mode WF2 is PR-terminal. Step 2's live-environment probe skips SSH (local exploration only); Step 14 (merge + deploy) and Step 15 (post-deploy) are skipped entirely; `resume_lib detect-step --headless` resumes a `ready-to-merge`/`merged` PR at Step 16 (an `open` PR still resumes at Step 13 so the bot can push CI fixes — a local op). `references/headless.md`, `docs/config-reference.md`, and the completion gate/mandatory-steps are updated to match.

**Layer B — guard (hooks, TDD):** `wal-guard` blocks **every** `ssh`/`scp`/`rsync`/`sftp` invocation while `RAWGENTIC_HEADLESS=1`, from any step or skill, **independent of `protectionLevel`** (fires even under `sandbox`), via the new tested `hooks/headless_ssh_guard.py` matcher. The matcher sees through env-assignments (incl. spaced `$(...)` values), wrappers (`sudo`/`timeout`/`env`/...), `bash -c`/`eval`/subshells/`find -exec`, and absolute paths — but never flags `git`/`gh` (own transport). Opt back in per project with the workspace-scoped, fail-closed `headlessAllowSSH: true`.

Closes #47

## Design Decisions

- **`headlessAllowSSH` is workspace-scoped** (sibling of `headlessEnabled` on the `.rawgentic_workspace.json` entry), not in the project `.rawgentic.json` — keeps all headless access-control in one place (owner decision; diverges from the issue's literal AC12 wording, which is noted).
- **Headless resume** realizes AC8 ("PR not merged → Step 16") as `ready-to-merge`/`merged` → Step 16 while keeping `open` → Step 13, so a headless run can still fix CI via a local push (owner decision).
- **Guard placement:** `wal-guard` (the only fail-closed PreToolUse Bash hook) hosts the blanket block, outside `_check_patterns` so it is protectionLevel-independent. Detection is a pure, unit-tested Python matcher; the env/config gating stays in bash. Fail-closed throughout (anything but a literal `true`, or an unavailable matcher, → block).
- **Conservative wrapper scan:** the matcher does not parse each wrapper's option arity (a bypass risk); it scans broadly, accepting rare over-blocks (e.g. `timeout 5 grep rsync`) as documented intentional — `headlessAllowSSH:true` is the escape hatch. For a safety net, a missed `ssh` is worse than a blocked `grep`.

## Verification

- TDD per task (RED→GREEN), full suite **1280 passing** (was 1158 baseline).
- New tests assert new behavior: matcher 65 (incl. all bypass/false-positive/known-gap cases), wal-guard headless 18 (end-to-end through the hook), resume headless 8 + CLI.
- Non-headless behavior unchanged; the 84 pre-existing wal-guard tests untouched.

## Quality Gate Summary

- **Design critique (Step 4):** 3-judge; 6 High / 6 Med / 7 Low → 1 design loop-back; 2 ambiguous findings resolved by owner decision.
- **Plan drift (Step 6):** aligned — all 15 ACs map to a task.
- **Step 8a (per-task, hooks):** 2 reviewers; High bypass (subst/eval/interpreter) found and fixed.
- **Implementation drift (Step 9):** clean.
- **Code review (Step 11):** 3-agent; 1 High (env-subst bypass) + 1 Low (combined interpreter flags) fixed with TDD; 5 Agent-3 Lows triaged (1 intentional, 1 doc fix applied, rest below-threshold/advisory).
- **Security scan (Step 11.5):** PASS — 0 blocking, 0 advisory, 0 errors. Skipped: `iac` (n/a to a library project), `sca` (no dependency manifests/lockfiles to scan). Secrets + SAST clean on `origin/main..HEAD`.

## Follow-ups (out of #47 scope)

- `/rawgentic:setup` wizard does not yet prompt for `headlessAllowSSH` (the field is documented and manually settable). Worth a small follow-up to add the prompt alongside `headlessEnabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
