### PR TITLE
feat(work_summary): aggregate subcommand for run-record Tier-2 rollups (#94)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.41.0",
+  "version": "2.42.0",
   "description": "11 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -562,6 +562,14 @@ for workflow-specific lines (e.g. WF3's Root Cause / Fix). The store is
 summary renders best-effort (a schema nit never costs the user their completion
 output). See [run-records.md](docs/run-records.md).
 
+Once runs accumulate, `work_summary.py aggregate --store <path>` rolls the store
+up into Tier-2 metrics — per-gate effectiveness (hit rate, findings caught vs
+resolved), loop-back behavior, outcome rates (CI/merge/deploy/security), and
+effort means — with `--json`, `--group-by {workflow,version,type,complexity}`
+(version is the cross-skill A/B slice), and `--since <ISO date>`. The reader is
+fail-closed: a corrupt or schema-invalid store line is excluded with a visible
+count, never silently averaged in.
+
 ### Shared Invariants
 
 1. **Config-loading protocol** — All workflow skills read `.rawgentic.json` before executing

--- a/docs/run-records.md
+++ b/docs/run-records.md
@@ -100,6 +100,52 @@ Exit codes:
 | `1` | Record invalid: summary still rendered, errors on stderr, record **not** persisted. The skill records the telemetry gap. |
 | `2` | Usage error or unreadable/non-JSON record file. |
 
+## Aggregating the store (Tier-2 rollups)
+
+Once runs accumulate, `aggregate` turns the store into the measurements the
+substrate exists for — gate effectiveness becomes a query, not a guess:
+
+```bash
+python3 hooks/work_summary.py aggregate \
+  --store <path> \
+  [--json] [--group-by {workflow,version,type,complexity}] [--since <ISO-date>]
+```
+
+`--store` falls back to `$RAWGENTIC_RUN_RECORD_STORE`; unlike `summarize`,
+`aggregate` has **no implicit default store** (rolling up the wrong project's
+store silently would be worse than a clear usage error). Markdown by default;
+`--json` emits the metric object plus the `excluded`/`excluded_count`. Reported
+metrics:
+
+| Group | Metrics |
+|-------|---------|
+| Gate effectiveness | per gate: hit rate (% of present runs with findings>0), total findings, total resolved, resolution rate, mean findings/run, `runs_present` |
+| Loop-backs | mean used; `pct_hit_cap` (used==budget, over runs with budget>0) |
+| Outcomes | CI-pass (over ci∈{passed,failed}), merge (over non-null merged), deploy-success (over deploy≠not_applicable), security-blocked (over ran==true), scanner-skip frequency |
+| Effort | means of files_changed / insertions / deletions / commits / tests.added (null insertions/deletions excluded from their mean) |
+
+Every rate reports its denominator; a 0 denominator renders `n/a` (never a
+divide-by-zero). `--group-by` partitions every metric (a missing complexity
+buckets under `(none)`); **`--group-by version`** is the deterministic half of
+the cross-skill A/B.
+
+**Gate identity is keyed on `step`, not `step + name`.** Real stores carry the
+same gate under drifting names (e.g. `4: Design Critique` vs `4: design critique
+(3-judge + codex)`); keying on `step` (which the writer already enforces unique
+*within* a record) keeps one gate's effectiveness from fragmenting across name
+variants, and the distinct names ride along as a `names` label list. When a store
+mixes workflows that reuse a step number for different gates, use `--group-by
+workflow` for a clean read. (This is a deliberate refinement of issue #94's
+literal AC2.)
+
+**Fail-closed reader** (mirrors the fail-closed writer): a line that is unparseable
+JSON, not an object, schema-invalid, or missing/non-ISO `generated_at` is
+**excluded** with a `line N: <reason>` entry surfaced on stderr and counted in the
+output — never silently averaged in or dropped. A missing/unreadable store (or a
+NUL in the path) is a usage error (exit 2); an empty store renders a `0 records`
+report (exit 0). Exit codes follow the tool convention: `0` success (including
+corrupt-lines-excluded), `2` usage error.
+
 ## How the workflows wire it in
 
 Each completion step (WF2 Step 16 → `/tmp/wf2-run-record.json`; WF3 Step 14 →

--- a/hooks/work_summary.py
+++ b/hooks/work_summary.py
@@ -415,6 +415,293 @@ def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+# --- aggregate: fail-closed JSONL reader (#94) -----------------------------
+
+def _looks_iso(s) -> bool:
+    """Cheap shape check for an ISO-8601 date/timestamp that sorts lexically
+    (the writer stamps '%Y-%m-%dT%H:%M:%SZ'): a leading YYYY-MM-DD with digit
+    groups and '-' separators. Used to fail-close on a record whose
+    generated_at the aggregator dates/filters on but validate_record never
+    checks (it is writer-stamped, not workflow-supplied)."""
+    if not _is_str(s) or len(s) < 10:
+        return False
+    d = s[:10]
+    return (d[4] == "-" and d[7] == "-" and d[:4].isdigit()
+            and d[5:7].isdigit() and d[8:10].isdigit())
+
+
+def load_store(path) -> tuple:
+    """Read a JSONL run-record store -> (records, excluded).
+
+    Fail-closed reader (mirrors the fail-closed writer): each non-blank line is
+    JSON-parsed and run through validate_record; a parse-error, non-object,
+    schema-invalid, or missing/non-ISO `generated_at` line is EXCLUDED and
+    appended to `excluded` as a "line N: <reason>" string — never silently
+    averaged in nor silently dropped. Blank lines are ignored (not errors).
+
+    An unreadable/missing file (or a NUL in the path) raises WorkSummaryError
+    (usage error). An empty file returns ([], [])."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+    except (OSError, ValueError) as exc:   # ValueError: embedded NUL in path
+        raise WorkSummaryError(f"cannot read store {path}: {exc}")
+    records, excluded = [], []
+    for i, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError) as exc:
+            excluded.append(f"line {i}: not valid JSON ({exc})")
+            continue
+        errs = validate_record(obj)
+        if errs:
+            excluded.append(f"line {i}: schema-invalid ({errs[0]})")
+            continue
+        if not _looks_iso(obj.get("generated_at")):
+            excluded.append(f"line {i}: missing or non-ISO generated_at")
+            continue
+        records.append(obj)
+    return records, excluded
+
+
+def filter_since(records, since):
+    """Keep records whose `generated_at` >= `since` (lexical ISO compare —
+    correct for the writer's Zulu format vs a bare YYYY-MM-DD, where the full
+    timestamp sorts after the bare date). Records reaching here already carry a
+    valid generated_at (load_store fail-closes otherwise). `since` falsy -> all."""
+    if not since:
+        return list(records)
+    return [r for r in records if str(r.get("generated_at", "")) >= since]
+
+
+# --- aggregate: pure metrics (#94) -----------------------------------------
+
+def _mean(values):
+    """Mean of the non-None numbers, or None if there are none (0-denominator
+    -> null, consistent with _rate)."""
+    vals = [v for v in values if v is not None]
+    return sum(vals) / len(vals) if vals else None
+
+
+def _rate(numerator, denominator):
+    """numerator/denominator, or None when denominator is 0 (never divide by
+    zero; an empty denominator is 'not measurable', rendered as n/a)."""
+    return (numerator / denominator) if denominator else None
+
+
+def aggregate_records(records) -> dict:
+    """Roll a list of (already-validated) run-records up into the aggregate
+    metric object: gate effectiveness, loop-backs, outcome rates, effort means.
+
+    Gate identity is keyed on `step` (the stable id the writer already enforces
+    unique within a record), NOT step+name: real stores carry the same gate
+    under drifting names (e.g. '4: Design Critique' vs '4: design critique
+    (3-judge + codex)'), so keying on step+name would fragment the metric. The
+    distinct names are carried as a `names` label list. (Documented deviation
+    from issue #94 AC2; see docs/run-records.md.)"""
+    n = len(records)
+
+    # gate effectiveness, keyed on step
+    gate_acc = {}
+    for r in records:
+        for g in _as_list(r.get("gates")):
+            if not isinstance(g, dict):
+                continue
+            step = g.get("step")
+            if not _is_str(step):
+                continue
+            a = gate_acc.setdefault(step, {"names": [], "runs_present": 0,
+                                           "runs_with_findings": 0,
+                                           "total_findings": 0,
+                                           "total_resolved": 0})
+            name = g.get("name")
+            if _is_str(name) and name not in a["names"]:
+                a["names"].append(name)
+            a["runs_present"] += 1
+            fnd = g.get("findings") if _is_int(g.get("findings")) else 0
+            rsv = g.get("resolved") if _is_int(g.get("resolved")) else 0
+            a["total_findings"] += fnd
+            a["total_resolved"] += rsv
+            if fnd > 0:
+                a["runs_with_findings"] += 1
+    gates = {}
+    for step, a in gate_acc.items():
+        gates[step] = {
+            "names": a["names"],
+            "runs_present": a["runs_present"],
+            "hit_rate": _rate(a["runs_with_findings"], a["runs_present"]),
+            "total_findings": a["total_findings"],
+            "total_resolved": a["total_resolved"],
+            "resolution_rate": _rate(a["total_resolved"], a["total_findings"]),
+            "mean_findings_per_run": _rate(a["total_findings"], a["runs_present"]),
+        }
+
+    # loop-backs
+    used_vals, cap_denom, cap_hits = [], 0, 0
+    for r in records:
+        lb = r.get("loop_backs")
+        if not isinstance(lb, dict):
+            continue
+        if _is_int(lb.get("used")):
+            used_vals.append(lb["used"])
+        if _is_int(lb.get("budget")) and lb["budget"] > 0:
+            cap_denom += 1
+            if _is_int(lb.get("used")) and lb["used"] == lb["budget"]:
+                cap_hits += 1
+    loop_backs = {"mean_used": _mean(used_vals),
+                  "pct_hit_cap": _rate(cap_hits, cap_denom),
+                  "cap_runs_considered": cap_denom}
+
+    # outcomes
+    ci_denom = ci_pass = merge_denom = merge_yes = 0
+    dep_denom = dep_ok = sec_denom = sec_blocked = 0
+    skip_freq = {}
+    for r in records:
+        out = _as_dict(r.get("outcome"))
+        if out.get("ci") in ("passed", "failed"):
+            ci_denom += 1
+            if out["ci"] == "passed":
+                ci_pass += 1
+        if isinstance(out.get("merged"), bool):
+            merge_denom += 1
+            if out["merged"]:
+                merge_yes += 1
+        if out.get("deploy") in ("success", "manual", "failed"):
+            dep_denom += 1
+            if out["deploy"] == "success":
+                dep_ok += 1
+        sec = _as_dict(r.get("security_scan"))
+        if sec.get("ran") is True:
+            sec_denom += 1
+            if _is_int(sec.get("blocking_resolved")) and sec["blocking_resolved"] > 0:
+                sec_blocked += 1
+            for kind in _as_list(sec.get("skipped")):
+                if _is_str(kind):
+                    skip_freq[kind] = skip_freq.get(kind, 0) + 1
+    outcomes = {
+        "ci_pass_rate": _rate(ci_pass, ci_denom), "ci_runs_considered": ci_denom,
+        "merge_rate": _rate(merge_yes, merge_denom),
+        "merge_runs_considered": merge_denom,
+        "deploy_success_rate": _rate(dep_ok, dep_denom),
+        "deploy_runs_considered": dep_denom,
+        "security_blocked_rate": _rate(sec_blocked, sec_denom),
+        "security_runs_considered": sec_denom,
+        "scanner_skip_freq": skip_freq,
+    }
+
+    # effort proxies (means; null insertions/deletions excluded from their mean)
+    def _col(section, field):
+        return [r[section][field] for r in records
+                if isinstance(r.get(section), dict) and _is_int(r[section].get(field))]
+    effort = {
+        "mean_files_changed": _mean(_col("changes", "files_changed")),
+        "mean_insertions": _mean(_col("changes", "insertions")),
+        "mean_deletions": _mean(_col("changes", "deletions")),
+        "mean_commits": _mean(_col("changes", "commits")),
+        "mean_tests_added": _mean(_col("tests", "added")),
+    }
+    return {"n": n, "gates": gates, "loop_backs": loop_backs,
+            "outcomes": outcomes, "effort": effort}
+
+
+_GROUP_KEYS = {
+    "workflow": lambda r: r.get("workflow"),
+    "version": lambda r: r.get("workflow_version"),
+    "type": lambda r: _as_dict(r.get("issue")).get("type"),
+    "complexity": lambda r: _as_dict(r.get("issue")).get("complexity"),
+}
+
+
+def aggregate_grouped(records, group_by) -> dict:
+    """Partition records by `group_by` (one of _GROUP_KEYS) and aggregate each
+    partition. A missing/null group value buckets under '(none)'."""
+    keyfn = _GROUP_KEYS[group_by]
+    groups = {}
+    for r in records:
+        k = keyfn(r)
+        groups.setdefault(k if _is_str(k) else "(none)", []).append(r)
+    return {k: aggregate_records(v) for k, v in groups.items()}
+
+
+# --- aggregate: Markdown render (#94) --------------------------------------
+
+def _fmt_pct(x):
+    return "n/a" if x is None else f"{x * 100:.0f}%"
+
+
+def _fmt_num(x):
+    if x is None:
+        return "n/a"
+    return f"{x:.1f}" if isinstance(x, float) else str(x)
+
+
+def _render_one(a) -> list:
+    lines = [f"- Records: {a['n']}", "", "### Gate effectiveness (keyed on step)"]
+    if a["gates"]:
+        lines.append("| Step | Name(s) | Runs | Hit rate | Findings | Resolved | "
+                     "Resolution | Mean/run |")
+        lines.append("|------|---------|------|----------|----------|----------|"
+                     "------------|----------|")
+        for step in sorted(a["gates"], key=lambda s: (len(s), s)):
+            g = a["gates"][step]
+            names = ", ".join(g["names"]) or "?"
+            lines.append(
+                f"| {step} | {names} | {g['runs_present']} | "
+                f"{_fmt_pct(g['hit_rate'])} | {g['total_findings']} | "
+                f"{g['total_resolved']} | {_fmt_pct(g['resolution_rate'])} | "
+                f"{_fmt_num(g['mean_findings_per_run'])} |")
+    else:
+        lines.append("(no gates recorded)")
+    lb = a["loop_backs"]
+    lines += ["", "### Loop-backs",
+              f"- Mean used: {_fmt_num(lb['mean_used'])}",
+              f"- Hit cap: {_fmt_pct(lb['pct_hit_cap'])} "
+              f"(of {lb['cap_runs_considered']} runs with budget>0)"]
+    o = a["outcomes"]
+    skips = o["scanner_skip_freq"]
+    skipstr = ", ".join(f"{k}={v}" for k, v in sorted(skips.items())) if skips else "none"
+    lines += ["", "### Outcomes",
+              f"- CI pass rate: {_fmt_pct(o['ci_pass_rate'])} (of {o['ci_runs_considered']})",
+              f"- Merge rate: {_fmt_pct(o['merge_rate'])} (of {o['merge_runs_considered']})",
+              f"- Deploy success rate: {_fmt_pct(o['deploy_success_rate'])} "
+              f"(of {o['deploy_runs_considered']})",
+              f"- Security blocked-something rate: {_fmt_pct(o['security_blocked_rate'])} "
+              f"(of {o['security_runs_considered']})",
+              f"- Scanner skips: {skipstr}"]
+    e = a["effort"]
+    lines += ["", "### Effort (means)",
+              f"- Files changed: {_fmt_num(e['mean_files_changed'])}",
+              f"- Insertions: {_fmt_num(e['mean_insertions'])}",
+              f"- Deletions: {_fmt_num(e['mean_deletions'])}",
+              f"- Commits: {_fmt_num(e['mean_commits'])}",
+              f"- Tests added: {_fmt_num(e['mean_tests_added'])}"]
+    return lines
+
+
+def render_aggregate_markdown(agg, *, group_by=None, excluded=None, since=None) -> str:
+    """Render the aggregate metric object as a Markdown report. The excluded
+    count is ALWAYS shown so a fail-closed exclusion can never read as a clean run."""
+    excluded = excluded or []
+    lines = ["# Run-record aggregate", ""]
+    if since:
+        lines += [f"_Filtered to records on/after {since}._", ""]
+    if group_by:
+        lines += [f"Grouped by **{group_by}** — {len(agg)} group(s).", ""]
+        for key in sorted(agg):
+            lines += [f"## {group_by} = {key}", ""] + _render_one(agg[key]) + [""]
+    else:
+        lines += _render_one(agg)
+    lines.append("")
+    if excluded:
+        lines.append(f"## Excluded lines ({len(excluded)})")
+        lines += [f"- {e}" for e in excluded]
+    else:
+        lines.append("Excluded lines: 0")
+    return "\n".join(lines)
+
+
 # --- CLI -------------------------------------------------------------------
 
 def main(argv=None) -> int:
@@ -446,6 +733,19 @@ def main(argv=None) -> int:
                    help="emit the normalized record as JSON instead of human text")
     p.add_argument("--no-persist", action="store_true",
                    help="render only; do not append the record to the store")
+
+    pa = sub.add_parser(
+        "aggregate",
+        help="roll a JSONL run-record store up into aggregate Tier-2 metrics")
+    pa.add_argument("--store", default=None,
+                    help=f"run-record store path (falls back to ${STORE_ENV})")
+    pa.add_argument("--json", action="store_true",
+                    help="emit the metric object as JSON instead of Markdown")
+    pa.add_argument("--group-by", choices=sorted(_GROUP_KEYS), default=None,
+                    help="partition every metric by this dimension "
+                         "(version is the cross-skill A/B slice)")
+    pa.add_argument("--since", default=None,
+                    help="only records whose generated_at is on/after this ISO date")
     args = parser.parse_args(argv)
 
     if args.cmd == "summarize":
@@ -477,6 +777,36 @@ def main(argv=None) -> int:
                 print(f"failed to persist run-record to {store}: {exc}",
                       file=sys.stderr)
                 return 1
+        return 0
+
+    if args.cmd == "aggregate":
+        store = args.store or os.environ.get(STORE_ENV)
+        if not store:
+            print(f"aggregate requires --store or ${STORE_ENV}", file=sys.stderr)
+            return 2
+        try:
+            records, excluded = load_store(store)
+        except WorkSummaryError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        records = filter_since(records, args.since)
+        agg = (aggregate_grouped(records, args.group_by) if args.group_by
+               else aggregate_records(records))
+        if args.json:
+            print(json.dumps(
+                {"group_by": args.group_by, "since": args.since,
+                 "excluded": excluded, "excluded_count": len(excluded),
+                 "aggregate": agg}, separators=(",", ":")))
+        else:
+            print(render_aggregate_markdown(
+                agg, group_by=args.group_by, excluded=excluded, since=args.since))
+        # AC8: corrupt/excluded lines are ALSO surfaced on stderr with a count,
+        # so a fail-closed exclusion is never invisible.
+        if excluded:
+            print(f"{len(excluded)} line(s) excluded as corrupt/invalid:",
+                  file=sys.stderr)
+            for e in excluded:
+                print(f"  - {e}", file=sys.stderr)
         return 0
 
     return 2

--- a/hooks/work_summary.py
+++ b/hooks/work_summary.py
@@ -784,6 +784,10 @@ def main(argv=None) -> int:
         if not store:
             print(f"aggregate requires --store or ${STORE_ENV}", file=sys.stderr)
             return 2
+        if args.since is not None and not _looks_iso(args.since):
+            print(f"--since must be an ISO-8601 date (YYYY-MM-DD); got: {args.since}",
+                  file=sys.stderr)
+            return 2
         try:
             records, excluded = load_store(store)
         except WorkSummaryError as exc:

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -36,7 +36,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.41.0"
+    assert plugin["version"] == "2.42.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_work_summary.py
+++ b/tests/hooks/test_work_summary.py
@@ -702,7 +702,6 @@ class TestWorkSummarySkillWiring:
 # ===========================================================================
 # aggregate subcommand (#94) — Tier-2 run-record rollups
 # ===========================================================================
-import os as _os
 import subprocess as _subprocess
 
 
@@ -1044,8 +1043,16 @@ class TestAggregateCLI:
             main(["aggregate", "--store", store, "--group-by", "nonsense"])
         assert ei.value.code == 2
 
+    def test_malformed_since_is_usage_error(self, tmp_path):
+        from work_summary import main
+        store = _write_store(tmp_path / "s.jsonl", [_store_rec()])
+        # an unpadded date would silently filter everything via lexical compare;
+        # fail loud instead of returning a confusing empty result.
+        assert main(["aggregate", "--store", store, "--since", "2026-6-17"]) == 2
+
     def test_real_subprocess(self, tmp_path):
         store = _write_store(tmp_path / "s.jsonl", [_store_rec()])
         r = _subprocess.run([sys.executable, str(SUMMARY_CLI), "aggregate",
-                             "--store", store], capture_output=True, text=True)
+                             "--store", store], capture_output=True, text=True,
+                            timeout=30)
         assert r.returncode == 0 and "Run-record aggregate" in r.stdout

--- a/tests/hooks/test_work_summary.py
+++ b/tests/hooks/test_work_summary.py
@@ -697,3 +697,355 @@ class TestWorkSummarySkillWiring:
             f"{skill}/SKILL.md completion step must invoke "
             f"`work_summary.py summarize`; if you renamed it, update this guard."
         )
+
+
+# ===========================================================================
+# aggregate subcommand (#94) — Tier-2 run-record rollups
+# ===========================================================================
+import os as _os
+import subprocess as _subprocess
+
+
+def _store_rec(**ov):
+    """A stored (normalized) run-record: a schema-valid core plus the
+    generated_at/schema_version the writer stamps and the aggregate reader
+    requires. Override whole sections by keyword (gates=..., outcome=..., etc.)."""
+    r = _valid_record()
+    r["schema_version"] = 1
+    r["generated_at"] = "2026-06-15T18:00:00Z"
+    for k, v in ov.items():
+        r[k] = v
+    return r
+
+
+def _write_store(path, records):
+    path.write_text("".join(json.dumps(r) + "\n" for r in records))
+    return str(path)
+
+
+class TestLoadStore:
+    def test_reads_valid_lines(self, tmp_path):
+        from work_summary import load_store
+        p = _write_store(tmp_path / "s.jsonl", [_store_rec(), _store_rec()])
+        recs, excl = load_store(p)
+        assert len(recs) == 2 and excl == []
+
+    def test_blank_lines_skipped_not_excluded(self, tmp_path):
+        from work_summary import load_store
+        p = tmp_path / "s.jsonl"
+        p.write_text(json.dumps(_store_rec()) + "\n\n   \n" + json.dumps(_store_rec()) + "\n")
+        recs, excl = load_store(str(p))
+        assert len(recs) == 2 and excl == []
+
+    def test_corrupt_json_line_excluded_with_lineno(self, tmp_path):
+        from work_summary import load_store
+        p = tmp_path / "s.jsonl"
+        p.write_text(json.dumps(_store_rec()) + "\n{not json\n" + json.dumps(_store_rec()) + "\n")
+        recs, excl = load_store(str(p))
+        assert len(recs) == 2
+        assert len(excl) == 1 and "line 2" in excl[0]
+
+    @pytest.mark.parametrize("bad", ["42", "[]", '"x"', "null", "true"])
+    def test_non_dict_json_value_excluded(self, tmp_path, bad):
+        from work_summary import load_store
+        p = tmp_path / "s.jsonl"
+        p.write_text(bad + "\n" + json.dumps(_store_rec()) + "\n")
+        recs, excl = load_store(str(p))
+        assert len(recs) == 1 and len(excl) == 1 and "line 1" in excl[0]
+
+    def test_schema_invalid_line_excluded(self, tmp_path):
+        from work_summary import load_store
+        bad = _store_rec()
+        del bad["outcome"]
+        p = _write_store(tmp_path / "s.jsonl", [bad, _store_rec()])
+        recs, excl = load_store(p)
+        assert len(recs) == 1 and len(excl) == 1 and "line 1" in excl[0]
+
+    def test_missing_generated_at_excluded(self, tmp_path):
+        from work_summary import load_store
+        bad = _store_rec()
+        del bad["generated_at"]
+        p = _write_store(tmp_path / "s.jsonl", [bad])
+        recs, excl = load_store(p)
+        assert recs == [] and len(excl) == 1 and "generated_at" in excl[0]
+
+    def test_non_iso_generated_at_excluded(self, tmp_path):
+        from work_summary import load_store
+        p = _write_store(tmp_path / "s.jsonl", [_store_rec(generated_at="not-a-date")])
+        recs, excl = load_store(p)
+        assert recs == [] and len(excl) == 1
+
+    def test_empty_file_no_records_no_error(self, tmp_path):
+        from work_summary import load_store
+        p = tmp_path / "s.jsonl"
+        p.write_text("")
+        assert load_store(str(p)) == ([], [])
+
+    def test_missing_file_raises(self, tmp_path):
+        from work_summary import load_store, WorkSummaryError
+        with pytest.raises(WorkSummaryError):
+            load_store(str(tmp_path / "nope.jsonl"))
+
+    def test_nul_in_path_raises(self):
+        from work_summary import load_store, WorkSummaryError
+        with pytest.raises(WorkSummaryError):
+            load_store("/tmp/a\x00b.jsonl")
+
+
+class TestFilterSince:
+    def test_none_returns_all(self):
+        from work_summary import filter_since
+        recs = [_store_rec(generated_at="2026-01-01T00:00:00Z")]
+        assert filter_since(recs, None) == recs
+
+    def test_boundary_excludes_prior_day(self):
+        from work_summary import filter_since
+        a = _store_rec(generated_at="2026-06-16T23:59:59Z")
+        b = _store_rec(generated_at="2026-06-17T12:00:00Z")
+        assert filter_since([a, b], "2026-06-17") == [b]
+
+    def test_same_day_full_timestamp_kept(self):
+        from work_summary import filter_since
+        r = _store_rec(generated_at="2026-06-17T00:00:01Z")
+        assert filter_since([r], "2026-06-17") == [r]
+
+
+class TestAggregateGates:
+    def test_name_drift_merges_on_step(self):
+        from work_summary import aggregate_records
+        r1 = _store_rec(); r1["gates"] = [{"step": "4", "name": "Design Critique",
+                                           "findings": 2, "resolved": 2, "status": "pass"}]
+        r2 = _store_rec(); r2["gates"] = [{"step": "4", "name": "design critique (3-judge + codex)",
+                                           "findings": 0, "resolved": 0, "status": "pass"}]
+        g = aggregate_records([r1, r2])["gates"]
+        assert set(g) == {"4"}
+        assert g["4"]["runs_present"] == 2
+        assert sorted(g["4"]["names"]) == sorted(
+            ["Design Critique", "design critique (3-judge + codex)"])
+        assert g["4"]["hit_rate"] == 0.5
+        assert g["4"]["total_findings"] == 2 and g["4"]["total_resolved"] == 2
+        assert g["4"]["resolution_rate"] == 1.0
+        assert g["4"]["mean_findings_per_run"] == 1.0
+
+    def test_resolution_rate_div0_is_none(self):
+        from work_summary import aggregate_records
+        r = _store_rec(); r["gates"] = [{"step": "6", "name": "Plan Drift",
+                                         "findings": 0, "resolved": 0, "status": "pass"}]
+        g = aggregate_records([r])["gates"]["6"]
+        assert g["resolution_rate"] is None and g["hit_rate"] == 0.0
+
+    def test_absent_gate_is_not_a_miss(self):
+        from work_summary import aggregate_records
+        r1 = _store_rec(); r1["gates"] = [{"step": "11", "name": "Code Review",
+                                           "findings": 1, "resolved": 1, "status": "pass"}]
+        r2 = _store_rec(); r2["gates"] = []
+        g = aggregate_records([r1, r2])["gates"]["11"]
+        assert g["runs_present"] == 1 and g["hit_rate"] == 1.0
+
+
+class TestAggregateLoopBacks:
+    def test_mean_and_cap_rate(self):
+        from work_summary import aggregate_records
+        recs = [_store_rec(loop_backs={"used": 3, "budget": 3}),
+                _store_rec(loop_backs={"used": 1, "budget": 3})]
+        lb = aggregate_records(recs)["loop_backs"]
+        assert lb["mean_used"] == 2.0
+        assert lb["pct_hit_cap"] == 0.5 and lb["cap_runs_considered"] == 2
+
+    def test_budget_zero_excluded_from_cap(self):
+        from work_summary import aggregate_records
+        recs = [_store_rec(loop_backs={"used": 0, "budget": 0}),
+                _store_rec(loop_backs={"used": 2, "budget": 2})]
+        lb = aggregate_records(recs)["loop_backs"]
+        assert lb["cap_runs_considered"] == 1 and lb["pct_hit_cap"] == 1.0
+
+
+class TestAggregateOutcomes:
+    def _o(self, **kw):
+        r = _store_rec()
+        r["outcome"] = {**r["outcome"], **kw}
+        return r
+
+    def test_ci_pass_rate_excludes_non_configured(self):
+        from work_summary import aggregate_records
+        recs = [self._o(ci="passed"), self._o(ci="failed"),
+                self._o(ci="not_configured"), self._o(ci="skipped")]
+        out = aggregate_records(recs)["outcomes"]
+        assert out["ci_runs_considered"] == 2 and out["ci_pass_rate"] == 0.5
+
+    def test_merge_rate_excludes_null(self):
+        from work_summary import aggregate_records
+        recs = [self._o(merged=True), self._o(merged=False), self._o(merged=None)]
+        out = aggregate_records(recs)["outcomes"]
+        assert out["merge_runs_considered"] == 2 and out["merge_rate"] == 0.5
+
+    def test_deploy_excludes_not_applicable(self):
+        from work_summary import aggregate_records
+        recs = [self._o(deploy="success"), self._o(deploy="failed"),
+                self._o(deploy="not_applicable")]
+        out = aggregate_records(recs)["outcomes"]
+        assert out["deploy_runs_considered"] == 2 and out["deploy_success_rate"] == 0.5
+
+    def test_security_blocked_and_skips_over_ran_true(self):
+        from work_summary import aggregate_records
+        r1 = _store_rec(security_scan={"ran": True, "blocking_resolved": 1,
+                                       "advisory": 0, "skipped": ["iac"]})
+        r2 = _store_rec(security_scan={"ran": True, "blocking_resolved": 0,
+                                       "advisory": 0, "skipped": ["iac", "sca"]})
+        r3 = _store_rec(security_scan={"ran": False, "blocking_resolved": 0,
+                                       "advisory": 0, "skipped": []})
+        out = aggregate_records([r1, r2, r3])["outcomes"]
+        assert out["security_runs_considered"] == 2
+        assert out["security_blocked_rate"] == 0.5
+        assert out["scanner_skip_freq"] == {"iac": 2, "sca": 1}
+
+    def test_zero_denominator_rates_are_none(self):
+        from work_summary import aggregate_records
+        r = self._o(ci="not_configured", merged=None, deploy="not_applicable")
+        r["security_scan"] = {"ran": False, "blocking_resolved": 0,
+                              "advisory": 0, "skipped": []}
+        out = aggregate_records([r])["outcomes"]
+        assert out["ci_pass_rate"] is None and out["merge_rate"] is None
+        assert out["deploy_success_rate"] is None and out["security_blocked_rate"] is None
+
+
+class TestAggregateEffort:
+    def test_means_and_null_exclusion(self):
+        from work_summary import aggregate_records
+        r1 = _store_rec(changes={"files_changed": 4, "insertions": 100,
+                                 "deletions": 10, "commits": 2})
+        r2 = _store_rec(changes={"files_changed": 2, "insertions": None,
+                                 "deletions": None, "commits": 4})
+        e = aggregate_records([r1, r2])["effort"]
+        assert e["mean_files_changed"] == 3.0 and e["mean_commits"] == 3.0
+        assert e["mean_insertions"] == 100.0
+
+    def test_all_null_insertions_is_none(self):
+        from work_summary import aggregate_records
+        r = _store_rec(changes={"files_changed": 1, "insertions": None,
+                                "deletions": None, "commits": 1})
+        assert aggregate_records([r])["effort"]["mean_insertions"] is None
+
+
+class TestAggregateGrouped:
+    def test_group_by_version(self):
+        from work_summary import aggregate_grouped
+        a = _store_rec(workflow_version="2.40.0")
+        b = _store_rec(workflow_version="2.41.0")
+        c = _store_rec(workflow_version="2.41.0")
+        g = aggregate_grouped([a, b, c], "version")
+        assert set(g) == {"2.40.0", "2.41.0"}
+        assert g["2.41.0"]["n"] == 2 and g["2.40.0"]["n"] == 1
+
+    def test_group_by_complexity_none_bucket(self):
+        from work_summary import aggregate_grouped
+        a = _store_rec()
+        a["issue"] = {**a["issue"], "complexity": None}
+        g = aggregate_grouped([a], "complexity")
+        assert "(none)" in g
+
+    @pytest.mark.parametrize("dim", ["workflow", "version", "type", "complexity"])
+    def test_all_dims_supported(self, dim):
+        from work_summary import aggregate_grouped
+        assert aggregate_grouped([_store_rec()], dim)
+
+
+class TestAggregateEdge:
+    def test_empty_records_no_crash(self):
+        from work_summary import aggregate_records
+        a = aggregate_records([])
+        assert a["n"] == 0 and a["gates"] == {}
+        assert a["loop_backs"]["mean_used"] is None
+        assert a["outcomes"]["ci_pass_rate"] is None
+        assert a["effort"]["mean_files_changed"] is None
+
+    def test_unknown_fields_ignored(self):
+        from work_summary import aggregate_records
+        r = _store_rec(); r["future_field"] = "x"
+        assert aggregate_records([r])["n"] == 1
+
+    def test_render_has_no_pr_url_leak(self):
+        from work_summary import aggregate_records, render_aggregate_markdown
+        md = render_aggregate_markdown(aggregate_records([_store_rec()]))
+        assert "https://github.com" not in md and "pr_url" not in md
+
+    def test_render_always_shows_excluded(self):
+        from work_summary import aggregate_records, render_aggregate_markdown
+        md = render_aggregate_markdown(aggregate_records([_store_rec()]),
+                                       excluded=["line 2: bad"])
+        assert "Excluded" in md and "line 2" in md
+
+
+class TestAggregateCLI:
+    def test_markdown_smoke(self, tmp_path, capsys):
+        from work_summary import main
+        store = _write_store(tmp_path / "s.jsonl", [_store_rec(), _store_rec()])
+        rc = main(["aggregate", "--store", store])
+        out = capsys.readouterr().out
+        assert rc == 0 and "Gate effectiveness" in out and "Records: 2" in out
+
+    def test_json_keys(self, tmp_path, capsys):
+        from work_summary import main
+        store = _write_store(tmp_path / "s.jsonl", [_store_rec()])
+        rc = main(["aggregate", "--store", store, "--json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert {"group_by", "since", "excluded", "excluded_count", "aggregate"} <= set(payload)
+        assert {"n", "gates", "loop_backs", "outcomes", "effort"} <= set(payload["aggregate"])
+
+    def test_group_by_version_cli(self, tmp_path, capsys):
+        from work_summary import main
+        store = _write_store(tmp_path / "s.jsonl",
+                             [_store_rec(workflow_version="2.40.0"),
+                              _store_rec(workflow_version="2.41.0")])
+        rc = main(["aggregate", "--store", store, "--json", "--group-by", "version"])
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0 and {"2.40.0", "2.41.0"} <= set(payload["aggregate"])
+
+    def test_since_filter_cli(self, tmp_path, capsys):
+        from work_summary import main
+        store = _write_store(tmp_path / "s.jsonl",
+                             [_store_rec(generated_at="2026-06-10T00:00:00Z"),
+                              _store_rec(generated_at="2026-06-17T00:00:00Z")])
+        rc = main(["aggregate", "--store", store, "--json", "--since", "2026-06-17"])
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0 and payload["aggregate"]["n"] == 1
+
+    def test_corrupt_line_exit0_stderr(self, tmp_path, capsys):
+        from work_summary import main
+        p = tmp_path / "s.jsonl"
+        p.write_text(json.dumps(_store_rec()) + "\n{bad\n")
+        rc = main(["aggregate", "--store", str(p), "--json"])
+        cap = capsys.readouterr()
+        assert rc == 0
+        payload = json.loads(cap.out)
+        assert payload["excluded_count"] == 1
+        assert "exclud" in cap.err.lower()
+
+    def test_missing_store_and_no_env_exit2(self, capsys, monkeypatch):
+        from work_summary import main
+        monkeypatch.delenv("RAWGENTIC_RUN_RECORD_STORE", raising=False)
+        assert main(["aggregate"]) == 2
+
+    def test_missing_file_exit2(self, tmp_path):
+        from work_summary import main
+        assert main(["aggregate", "--store", str(tmp_path / "nope.jsonl")]) == 2
+
+    def test_env_store_fallback(self, tmp_path, monkeypatch):
+        from work_summary import main
+        store = _write_store(tmp_path / "s.jsonl", [_store_rec()])
+        monkeypatch.setenv("RAWGENTIC_RUN_RECORD_STORE", store)
+        assert main(["aggregate", "--json"]) == 0
+
+    def test_bad_group_by_is_usage_error(self, tmp_path):
+        from work_summary import main
+        store = _write_store(tmp_path / "s.jsonl", [_store_rec()])
+        with pytest.raises(SystemExit) as ei:
+            main(["aggregate", "--store", store, "--group-by", "nonsense"])
+        assert ei.value.code == 2
+
+    def test_real_subprocess(self, tmp_path):
+        store = _write_store(tmp_path / "s.jsonl", [_store_rec()])
+        r = _subprocess.run([sys.executable, str(SUMMARY_CLI), "aggregate",
+                             "--store", store], capture_output=True, text=True)
+        assert r.returncode == 0 and "Run-record aggregate" in r.stdout


### PR DESCRIPTION
## Summary

Adds an `aggregate` subcommand to `hooks/work_summary.py` that rolls the JSONL
run-record store up into Tier-2 metrics: per-gate effectiveness (hit rate,
findings caught vs resolved, resolution rate, mean/run), loop-back behavior,
outcome rates (CI / merge / deploy / security), and effort means. Flags:
`--json`, `--group-by {workflow,version,type,complexity}`, `--since <ISO>`.
Read-only over the store; no schema or writer changes.

Closes #94

## Design decisions

- **Gate identity keyed on `step`, not `step + name` (deliberate AC2 refinement).**
  Real stores carry the same gate under drifting names — `4: Design Critique` vs
  `4: design critique (3-judge + codex)` vs `4: Design Critique (3-panel + codex)`,
  all present in the studio store. Keying on step+name would fragment the headline
  gate-effectiveness metric; keying on `step` (which the writer already enforces
  unique *within* a record) keeps it whole, with the distinct names carried as a
  `names` label list. `--group-by workflow` separates any cross-workflow step-number
  reuse. Raised on the [readiness comment](https://github.com/3D-Stories/rawgentic/issues/94#issuecomment-4737507427)
  and surfaced here for sign-off.
- **Every rate reports its denominator; a 0 denominator → `null`** (never a
  divide-by-zero): CI-pass over ci∈{passed,failed}, merge over non-null merged,
  deploy over deploy≠not_applicable, security/skip over ran==true, `pct_hit_cap`
  over budget>0.
- **Fail-closed reader** (mirrors the fail-closed writer): an unparseable,
  non-object, schema-invalid, or missing/non-ISO-`generated_at` line is excluded
  with a `line N: <reason>` on stderr + a visible count in the output — never
  silently averaged in. `validate_record` doesn't check `generated_at` (it is
  writer-stamped), so the reader fail-closes on it explicitly so `filter_since`
  can't crash.
- `aggregate` has **no implicit default store** (unlike `summarize`) — silently
  rolling up the wrong project's store is worse than a clear usage error.

## Verification

- **TDD**, 50 new tests (RED→GREEN): fail-closed reader (corrupt / non-object /
  schema-invalid / missing-generated_at / NUL-path / empty / missing-file), every
  metric + denominator edge, gate name-drift merge, group-by each dimension,
  `--since` boundary (+ malformed-date guard), `--json` key set, exit-code matrix,
  a real-subprocess smoke, and a no-`pr_url`-leak assertion.
- **Full suite: 1280 → 1330 passed, 0 failed.**
- **Dogfooded against the real studio store (14 records):** step 4 correctly merged
  three drifting name variants into one gate; surfaced real signal (Design Critique
  71% hit / 9.0 findings per run; Code Review 100% hit / 93% resolution; drift gates
  0% as expected). Confirms the keyed-on-step decision in practice.

## Quality gate summary

- Design critique (Step 4): full 3-judge — 0 Critical / 0 High / ~7 Medium / ~9 Low,
  all folded into the design before coding (no loop-back).
- Plan drift (Step 6): clean.
- Implementation drift (Step 9): clean — all 9 ACs covered; full suite green.
- Code review (Step 11, 3-agent): 0 Critical/High; the bug reviewer could not
  construct a failing input. Fixes applied: `--since` guard, dead import, subprocess
  timeout.
- Security scan (Step 11.5): gitleaks/semgrep clean on the diff — 0 blocking, 0
  advisory, 0 errors. Skipped: `iac` (no Docker), `sca` (no dependency manifest).

## Data-readiness note (from the issue comment)

Build-ready, but the statistical payoff is still thin: the only non-trivial store
is the studio's 14 records (under the "few dozen" bar), `--group-by version` is
degenerate (12/14 on 2.41.0), and there are no WF3 records yet — treat emitted
rates as directional until more runs accumulate. Two follow-ups noted (out of
scope here): multi-`--store` / fleet view, and gate/scanner-skip **name
canonicalization at the writer** (the aggregator works around drift but can't fix
the source).
