### PR TITLE
chore: post-v2.46.0 cleanups (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ pytest tests/ -v
 pytest tests/hooks/test_wal_guard.py -v
 ```
 
-**~1,140 tests** across the hook + skill-helper modules. See [docs/testing.md](docs/testing.md) for full details.
+**1,400+ tests** across the hook + skill-helper modules. See [docs/testing.md](docs/testing.md) for full details.
 
 **CI:** GitHub Actions runs `pytest tests/ -v` on all PRs to `main` (`.github/workflows/ci.yml`). SDLC workflows also run tests automatically when `.rawgentic.json` has a `testing` section configured.
 

--- a/tests/hooks/test_plan_lib.py
+++ b/tests/hooks/test_plan_lib.py
@@ -773,9 +773,11 @@ class TestReviewState:
         # Manually corrupt: rename branch inside file
         path = mod.review_state_path(str(tmp_path), "feature/x")
         import json
-        data = json.loads(open(path).read())
+        with open(path) as f:
+            data = json.load(f)
         data["branch"] = "feature/y"
-        open(path, "w").write(json.dumps(data))
+        with open(path, "w") as f:
+            json.dump(data, f)
         result = mod.read_review_state(str(tmp_path), "feature/x")
         assert result is None
         captured = capsys.readouterr()
@@ -785,7 +787,8 @@ class TestReviewState:
         mod = _reload_plan_lib()
         path = mod.review_state_path(str(tmp_path), "feature/x")
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        open(path, "w").write("{not json")
+        with open(path, "w") as f:
+            f.write("{not json")
         assert mod.read_review_state(str(tmp_path), "feature/x") is None
         assert "unreadable" in capsys.readouterr().err.lower()
 

--- a/tests/test_shared_block_drift.py
+++ b/tests/test_shared_block_drift.py
@@ -6,6 +6,7 @@ is single-sourced by keeping the source in shared/blocks/ and generating each sk
 inline copy via scripts/sync_shared_blocks.py. This guard fails if any copy drifts from
 its source — the exact failure that let config-loading silently diverge (an em-dash) before.
 """
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -18,6 +19,15 @@ SHARED = REPO_ROOT / "shared" / "blocks"
 
 def _run(*args):
     return subprocess.run([sys.executable, str(SCRIPT), *args], capture_output=True, text=True)
+
+
+def _run_in(root: Path, *args):
+    """Run a COPY of the sync script rooted at `root` (it resolves paths from its
+    own __file__). Isolates any file-writing sync from the real working tree."""
+    return subprocess.run(
+        [sys.executable, str(root / "scripts" / "sync_shared_blocks.py"), *args],
+        capture_output=True, text=True,
+    )
 
 
 def _config_block(skill: str) -> str:
@@ -35,11 +45,21 @@ def test_no_shared_block_drift():
     assert r.returncode == 0, f"drift detected:\n{r.stderr}"
 
 
-def test_sync_is_idempotent():
-    """Running sync when already in sync changes nothing."""
-    r = _run()
+def test_sync_is_idempotent(tmp_path):
+    """Running sync when already in sync changes nothing.
+
+    Runs in a COPY of the repo, not the working tree: a bare `sync` WRITES files,
+    so on a tree with in-progress drift it would silently clobber the edit. The
+    sandbox keeps this guard from ever mutating a contributor's real checkout.
+    """
+    for d in ("scripts", "shared", "skills"):
+        shutil.copytree(REPO_ROOT / d, tmp_path / d)
+    r = _run_in(tmp_path)
     assert r.returncode == 0
     assert "nothing to sync" in r.stdout.lower(), r.stdout
+    # And it truly touched nothing: the copied skills equal the originals.
+    for skill in ("config-loading.md",):  # source block itself unchanged
+        assert (tmp_path / "shared" / "blocks" / skill).read_text() == (SHARED / skill).read_text()
 
 
 def test_create_issue_intentionally_not_synced():


### PR DESCRIPTION
## Summary

Post-v2.46.0 minor cleanups from #127. Low-blast, reversible; no behavior change to shipped code.

## Changes
- **`test_sync_is_idempotent` no longer mutates the working tree.** It ran the bare (file-**writing**) sync directly on the repo; if a contributor had an in-progress shared-block edit at test time, the sync silently reverted it (this actually bit us during the v2.46.0 build). Now it copies `scripts/`+`shared/`+`skills/` into a `tmp_path` and runs the sync there — same asserted property ("in-sync tree → nothing to sync"), zero real-tree risk.
- **`test_plan_lib.py`: three files opened without a context manager** (`open(...).read()` / `open(...).write(...)`) → closed via `with`. Removes the `ResourceWarning: unclosed file` noise seen under `-W default`.
- **README stale count:** "~1,140 tests" → "1,400+" (non-brittle; actual 1420).

## Not changed (with reasons)
- **#127 item "dangling `</output>` in adversarial-review/SKILL.md" — refuted.** No `<output>`/`</output>` tag exists in that file (`grep` empty); the original review finding was spurious. Nothing to fix.
- **The 5 suite warnings remain** — all are the same `os.fork()` DeprecationWarning from `test_concurrent_consume_does_not_overspend`, which deliberately forks 5 processes to test atomic loop-back accounting. Silencing them means changing that test's start method (`spawn`), out of scope for a cleanup.

## Verification
- Full suite: **1420 passed, 0 failed, 5 warnings** (unchanged count — the 5 are the intentional fork warnings; the ResourceWarnings that my fix removed only surfaced under `-W default`, confirmed gone there).
- Sandboxed idempotency test: 4 passed, verified it operates on the copy, not the real tree.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
