### PR TITLE
feat(model-routing,wf2): implementation model as per-task ceiling + never-Haiku (#132)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.47.0",
+  "version": "2.47.1",
   "description": "12 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, peer consultation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -713,6 +713,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v2.47.1 (2026-07-03)
+- **`modelRouting.implementation` is now a per-task ceiling, not a blanket assignment (#132).** WF2 Step 8 calls `model_routing_lib.select_impl_model(ceiling, riskLevel, complexity)` per task: high-risk or `complex_feature` tasks get the ceiling, everything else down-routes to `sonnet`, escalating to the ceiling if a down-routed task struggles — logged per task for audit. Plus a hard **never-Haiku guarantee**: `resolve()` bumps any role configured to `haiku` → `sonnet` (warned — a stronger response than the `review: sonnet` soft-opus-floor warn-and-apply), `select_impl_model` floors an unknown/haiku ceiling to `sonnet`, and Step 8's dispatch never sends `model: haiku` even when the session model under `inherit` is Haiku. No config schema change — same `modelRouting.implementation` key, clarified meaning.
+
 ### v2.47.0 (2026-07-03)
 - **Diff-stage cross-model adversarial review (#131).** WF5's engine gains a `diff` artifact type (refutation lens: hunts fail-open guards, silently-passing error paths, weakened security checks) plus a fail-closed `--findings-json` sidecar for embedded consumers. WF2 Step 11 gains an opt-in cross-model diff review sub-step, gated on `adversarialReview.workflows` containing `implement-feature` AND the change touching a security surface (a high-risk path pattern, or any plan task marked `riskLevel: high`); non-blocking, report-only, with a 4-state marker (`findings_present`/`no_findings`/`failed`/`skipped`) and completion-gate enforcement so an opted-in run can't silently skip it.
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -357,15 +357,26 @@ Each value is one of `opus` / `sonnet` / `haiku` / `fable` / `inherit`. Resolved
 which is invoked by the dispatching skill's `<model-routing-resolve>` preamble
 (right after `<config-loading>`, before any subagent dispatch).
 
+rawgentic **never uses Haiku for routed work**: a `haiku` value is accepted (not
+rejected to `inherit`) but hard-bumped to `sonnet` with a warning, for every role.
+
 **Fail-open by design** — routing is an optimization knob, never a gate:
 a missing workspace file, malformed JSON, a non-dict `modelRouting` block, or an
 unknown/invalid model value all resolve to `inherit` with a stderr warning; the CLI
 always exits 0 and never blocks the calling workflow.
 
-**Soft opus floor (review only):** an explicit `sonnet` or `haiku` for the `review`
-role still applies (routing is honored, not overridden) but emits an advisory stderr
-warning that review quality may drop below the recommended `opus` floor. `analysis`
-and `implementation` have no such floor.
+**Soft opus floor (review only):** an explicit `sonnet` for the `review` role still
+applies (routing is honored, not overridden) but emits an advisory stderr warning
+that review quality may drop below the recommended `opus` floor. An explicit `haiku`
+for `review` does **not** merely warn-and-apply — it is bumped to `sonnet` by the
+never-Haiku rule above. `analysis` and `implementation` have no opus floor.
+
+**`implementation` is a ceiling, not a blanket assignment.** The resolved value is
+the *maximum* model WF2 Step 8 will use, not the model every task gets. Step 8 calls
+`model_routing_lib.select_impl_model(ceiling, riskLevel, complexity)` per task:
+high-risk or `complex_feature` tasks get the ceiling; standard/simple tasks
+down-route to `sonnet`, escalating to the ceiling if a down-routed task struggles.
+No schema change — same `modelRouting.implementation` key, clarified meaning.
 
 ### `peerConsult`
 

--- a/docs/design/2026-07-03-model-ceiling-downrouting.html
+++ b/docs/design/2026-07-03-model-ceiling-downrouting.html
@@ -1,0 +1,204 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Model-Ceiling Down-Routing (#132)</title>
+<style>
+:root{
+  --ink:#1C2733; --ink-2:#46545F; --ink-3:#6B7A85;
+  --paper:#F7F8F6; --card:#FFFFFF; --line:#DDE3E0;
+  --accent:#C77D0A; --accent-ink:#8A5606;
+  --code-bg:#EFF2EF; --good:#2E6B4F; --warn:#9A4A0B;
+}
+@media (prefers-color-scheme: dark){:root{
+  --ink:#E8ECEA; --ink-2:#ADB9BE; --ink-3:#7E8B91;
+  --paper:#10161D; --card:#171F28; --line:#2A3540;
+  --accent:#E09A2D; --accent-ink:#E09A2D;
+  --code-bg:#1C2630; --good:#5FAE8C; --warn:#D98B4A;
+}}
+:root[data-theme="dark"]{
+  --ink:#E8ECEA; --ink-2:#ADB9BE; --ink-3:#7E8B91;
+  --paper:#10161D; --card:#171F28; --line:#2A3540;
+  --accent:#E09A2D; --accent-ink:#E09A2D;
+  --code-bg:#1C2630; --good:#5FAE8C; --warn:#D98B4A;
+}
+:root[data-theme="light"]{
+  --ink:#1C2733; --ink-2:#46545F; --ink-3:#6B7A85;
+  --paper:#F7F8F6; --card:#FFFFFF; --line:#DDE3E0;
+  --accent:#C77D0A; --accent-ink:#8A5606;
+  --code-bg:#EFF2EF; --good:#2E6B4F; --warn:#9A4A0B;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--paper);color:var(--ink);
+  font:16px/1.65 -apple-system,"Segoe UI",system-ui,Roboto,sans-serif;}
+main{max-width:76ch;margin:0 auto;padding:3.5rem 1.25rem 5rem;
+  display:flex;flex-direction:column;gap:2.75rem}
+header{border-bottom:2px solid var(--accent);padding-bottom:1.5rem}
+.eyebrow{font-size:.72rem;font-weight:600;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--accent-ink)}
+h1{font-size:1.9rem;line-height:1.2;margin:.4rem 0 .6rem;font-weight:700;
+  letter-spacing:-.015em;text-wrap:balance}
+.meta{color:var(--ink-3);font-size:.88rem;display:flex;gap:1.5rem;flex-wrap:wrap}
+.meta b{color:var(--ink-2);font-weight:600}
+section{display:flex;flex-direction:column;gap:.8rem}
+h2{font-size:1.22rem;margin:0;font-weight:700;letter-spacing:-.01em;text-wrap:balance}
+h3{font-size:1rem;margin:.4rem 0 0;font-weight:650}
+p{margin:0;color:var(--ink-2)}
+p strong,li strong{color:var(--ink)}
+ul,ol{margin:0;padding-left:1.3rem;color:var(--ink-2);display:flex;
+  flex-direction:column;gap:.45rem}
+code{font-family:ui-monospace,"Cascadia Code",Menlo,Consolas,monospace;
+  font-size:.86em;background:var(--code-bg);padding:.1em .35em;border-radius:3px}
+pre{background:var(--code-bg);border:1px solid var(--line);border-radius:6px;
+  padding:.9rem 1.1rem;overflow-x:auto;margin:0}
+pre code{background:none;padding:0;font-size:.84rem;line-height:1.55}
+.tablewrap{overflow-x:auto}
+table{border-collapse:collapse;width:100%;font-size:.88rem;background:var(--card);
+  font-variant-numeric:tabular-nums}
+th{font-size:.7rem;letter-spacing:.09em;text-transform:uppercase;
+  color:var(--ink-3);font-weight:600;text-align:left;white-space:nowrap}
+th,td{padding:.55rem .75rem;border:1px solid var(--line);vertical-align:top}
+td code{white-space:nowrap}
+.model-opus{color:var(--accent-ink);font-weight:700}
+.model-sonnet{color:var(--good);font-weight:700}
+.model-fable{color:var(--ink);font-weight:700}
+.model-haiku{color:var(--warn);font-weight:700;text-decoration:line-through;
+  text-decoration-thickness:1.5px}
+.model-inherit{color:var(--ink-3);font-style:italic;font-weight:600}
+.callout{border-left:3px solid var(--accent);background:var(--card);
+  padding:.8rem 1.1rem;border-radius:0 6px 6px 0;color:var(--ink-2)}
+.callout strong{color:var(--ink)}
+.decision{display:grid;grid-template-columns:auto 1fr;gap:.35rem .9rem;
+  font-size:.92rem;color:var(--ink-2)}
+.decision dt{font-weight:650;color:var(--ink);white-space:nowrap}
+.decision dd{margin:0}
+.flow{display:flex;flex-direction:column;gap:.5rem}
+.flow-step{display:grid;grid-template-columns:1.6rem 1fr;gap:.7rem;align-items:baseline}
+.flow-step .n{font-family:ui-monospace,Menlo,monospace;font-size:.8rem;
+  color:var(--accent-ink);font-weight:700;text-align:right}
+.rankbar{display:flex;align-items:center;gap:.5rem}
+.rankbar .fill{height:.55rem;border-radius:2px;background:var(--accent)}
+.stale{color:var(--warn);font-weight:600}
+:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+@media (prefers-reduced-motion: no-preference){
+  section{animation:rise .35s ease both}
+  @keyframes rise{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+}
+</style>
+
+<main>
+<header>
+  <div class="eyebrow">Rawgentic · Design Spec · Issue #132 · lean gate (1 design pass)</div>
+  <h1>modelRouting.implementation as a Ceiling</h1>
+  <div class="meta">
+    <span><b>Target</b> v2.47.1</span>
+    <span><b>Basis</b> feature/132-model-ceiling-downrouting @ a7059a5</span>
+    <span><b>Companion</b> same-name <code>.md</code> in docs/design/</span>
+  </div>
+</header>
+
+<section>
+  <div class="eyebrow">Problem</div>
+  <h2>A blanket assignment overspends on well-specified work</h2>
+  <p>WF2 Step 8's delegation dispatched <strong>every</strong> plan task with <code>model: &lt;implementation&gt;</code>. With <code>implementation: opus</code>, well-specified, 2-file, mechanical/TDD tasks that Sonnet already handles fine were still built on Opus — over-spend the project owner flagged directly. The signals to do better already exist and were sitting unused: Step 2's complexity classification (<code>simple_change</code> / <code>standard_feature</code> / <code>complex_feature</code>) and Step 5's per-task <code>riskLevel: high | standard</code> (<code>plan_lib.RISK_CRITERIA</code>).</p>
+  <div class="callout"><strong>Approach:</strong> stop treating <code>modelRouting.implementation</code> as a floor every task inherits, and start treating it as a <strong>ceiling</strong> — the most expensive model a task is <em>allowed</em> to reach, not the one it defaults to.</div>
+</section>
+
+<section>
+  <div class="eyebrow">Approach</div>
+  <h2><code>select_impl_model(ceiling, riskLevel, complexity) → (model, reason)</code></h2>
+  <p>One pure function added to <code>hooks/model_routing_lib.py</code>. Fail-open, never raises. Returns a <code>(model, reason)</code> pair — the reason is logged per task for audit (AC3).</p>
+  <div class="tablewrap"><table>
+    <tr><th>Model</th><th>Rank</th><th>Role in the ceiling clamp</th></tr>
+    <tr><td><span class="model-sonnet">sonnet</span></td><td>1</td><td>down-route target — also the coding floor, so "never below sonnet" falls out for free</td></tr>
+    <tr><td><span class="model-opus">opus</span></td><td>2</td><td>mid ceiling</td></tr>
+    <tr><td><span class="model-fable">fable</span></td><td>3</td><td>top ceiling</td></tr>
+    <tr><td><span class="model-haiku">haiku</span></td><td>—</td><td>deliberately unrankable for implementation — standing project rule: never Haiku for coding</td></tr>
+  </table></div>
+  <div class="flow">
+    <div class="flow-step"><span class="n">1</span><p><code>ceiling == "inherit"</code> → <span class="model-inherit">inherit</span>, <em>"no routing configured — session model."</em> Routing off ⇒ no per-task logic; Step 8 behaves exactly as before this feature.</p></div>
+    <div class="flow-step"><span class="n">2</span><p><code>ceiling</code> not one of <code>{sonnet, opus, fable}</code> (i.e. <code>haiku</code> or unknown) → floors to <span class="model-sonnet">sonnet</span>, <em>"not a valid implementation model — floor to sonnet."</em> A misconfigured haiku ceiling for coding is degraded to the sonnet floor rather than forwarded — and deliberately <strong>not</strong> to <code>inherit</code>, since the session model itself could be Haiku.</p></div>
+    <div class="flow-step"><span class="n">3</span><p><strong>Desired tier:</strong> <code>riskLevel == "high"</code> OR <code>complexity == "complex_feature"</code> → <code>desired = ceiling</code> (hardest work gets the configured max). Otherwise <code>desired = "sonnet"</code> (down-route target for standard/simple, well-specified tasks).</p></div>
+    <div class="flow-step"><span class="n">4</span><p><strong>Clamp to ceiling:</strong> <code>actual = desired</code> if <code>rank[desired] ≤ rank[ceiling]</code>, else <code>actual = ceiling</code>. A ceiling is a hard cap, never exceeded — this branch is defensive/unreachable while sonnet stays rank&nbsp;1, the minimum.</p></div>
+    <div class="flow-step"><span class="n">5</span><p><strong>Reason strings</strong> for the audit log: <code>"high-risk/complex → ceiling &lt;m&gt;"</code> · <code>"standard/simple → down-routed to sonnet"</code> · <code>"standard/simple, clamped to ceiling &lt;m&gt;"</code> (the defensive branch).</p></div>
+  </div>
+</section>
+
+<section>
+  <div class="eyebrow">WF2 Step 8</div>
+  <h2>Per-task dispatch, escalate on struggle</h2>
+  <ul>
+    <li>Before each task's dispatch, Step 8 calls <code>select_impl_model(&lt;resolved implementation ceiling&gt;, task.riskLevel, &lt;Step-2 complexity&gt;)</code> and dispatches that task's subagent with the returned model.</li>
+    <li><strong>Logged per task</strong> in session notes: <code>task &lt;id&gt;: model &lt;m&gt; (&lt;reason&gt;)</code> — makes over/under-routing auditable (AC3).</li>
+    <li><strong>Escalate on struggle:</strong> the existing clean-state-restore-and-retry-once path now retries at the <strong>ceiling</strong> model, not the down-routed one, before falling through to normal Step 8 failure handling (AC2). One escalation, then normal handling — no infinite ladder.</li>
+    <li>When the ceiling is <code>inherit</code>, the block stays inert exactly as before: the function returns <code>inherit</code> and dispatch omits <code>model:</code>.</li>
+  </ul>
+</section>
+
+<section>
+  <div class="eyebrow">Hard guarantee</div>
+  <h2>rawgentic never dispatches <code>model: haiku</code></h2>
+  <p>Three independent layers, so a single misconfiguration can't slip Haiku into coding work:</p>
+  <ul>
+    <li><code>resolve()</code> bumps any role — <code>review</code>, <code>analysis</code>, <code>implementation</code> — configured to <span class="model-haiku">haiku</span> up to <span class="model-sonnet">sonnet</span>, with a stderr warning. This is a harder response than the soft opus floor: <code>review: sonnet</code> merely warns-and-applies, but <code>review: haiku</code> is <em>overridden</em>, not just flagged.</li>
+    <li><code>select_impl_model</code> floors an unknown or <span class="model-haiku">haiku</span> ceiling to <span class="model-sonnet">sonnet</span> (step 2 above) — and specifically not to <code>inherit</code>, because the session model under <code>inherit</code> could itself be Haiku.</li>
+    <li>Step 8's dispatch never emits <code>model: haiku</code>: if the session model is Haiku under <code>inherit</code>, dispatch uses <span class="model-sonnet">sonnet</span> instead.</li>
+  </ul>
+</section>
+
+<section>
+  <div class="eyebrow">Files</div>
+  <h2>What changed to ship this</h2>
+  <ul>
+    <li><code>hooks/model_routing_lib.py</code> — <code>select_impl_model</code> + rank map; <code>resolve()</code> gains the haiku→sonnet bump.</li>
+    <li><code>tests/hooks/test_model_routing.py</code> — selection matrix (<code>TestSelectImplModel</code>) + haiku-bump coverage for <code>review</code>/<code>analysis</code>.</li>
+    <li><code>skills/implement-feature/SKILL.md</code> — Step 8 delegation prose (ceiling + per-task <code>select_impl_model</code> call + escalation) and a <code>&lt;model-routing-resolve&gt;</code> note that <code>implementation</code> is a ceiling.</li>
+    <li><code>docs/config-reference.md</code> — ceiling semantics documented; no schema change, same <code>modelRouting.implementation</code> key.</li>
+    <li><code>skills/setup/SKILL.md</code>, <code>README.md</code> — routing choices and changelog updated to describe the ceiling + never-Haiku behavior.</li>
+    <li>Version bump patch → <strong>2.47.1</strong> — a behavior refinement, no new config.</li>
+  </ul>
+</section>
+
+<section>
+  <div class="eyebrow">Test matrix</div>
+  <h2><code>select_impl_model</code> — 12 parametrized cases, as shipped</h2>
+  <p>Ground truth is <code>tests/hooks/test_model_routing.py::TestSelectImplModel</code> against the code actually in <code>hooks/model_routing_lib.py</code> on this branch.</p>
+  <div class="tablewrap"><table>
+    <tr><th>Ceiling</th><th>Risk level</th><th>Complexity</th><th>Expected model</th><th>Reason class</th></tr>
+    <tr><td><span class="model-opus">opus</span></td><td>high</td><td>standard_feature</td><td><span class="model-opus">opus</span></td><td>high-risk → ceiling</td></tr>
+    <tr><td><span class="model-opus">opus</span></td><td>standard</td><td>simple_change</td><td><span class="model-sonnet">sonnet</span></td><td>down-routed</td></tr>
+    <tr><td><span class="model-opus">opus</span></td><td>standard</td><td>standard_feature</td><td><span class="model-sonnet">sonnet</span></td><td>down-routed</td></tr>
+    <tr><td><span class="model-opus">opus</span></td><td>standard</td><td>complex_feature</td><td><span class="model-opus">opus</span></td><td>complex → ceiling</td></tr>
+    <tr><td><span class="model-opus">opus</span></td><td>high</td><td>complex_feature</td><td><span class="model-opus">opus</span></td><td>high-risk + complex → ceiling</td></tr>
+    <tr><td><span class="model-sonnet">sonnet</span></td><td>high</td><td>complex_feature</td><td><span class="model-sonnet">sonnet</span></td><td>ceiling equals desired tier</td></tr>
+    <tr><td><span class="model-sonnet">sonnet</span></td><td>standard</td><td>simple_change</td><td><span class="model-sonnet">sonnet</span></td><td>down-routed (no-op, already floor)</td></tr>
+    <tr><td><span class="model-fable">fable</span></td><td>high</td><td>standard_feature</td><td><span class="model-fable">fable</span></td><td>high-risk → ceiling</td></tr>
+    <tr><td><span class="model-fable">fable</span></td><td>standard</td><td>simple_change</td><td><span class="model-sonnet">sonnet</span></td><td>down-routed</td></tr>
+    <tr><td><span class="model-inherit">inherit</span></td><td>high</td><td>complex_feature</td><td><span class="model-inherit">inherit</span></td><td>routing off — session model</td></tr>
+    <tr><td><span class="model-haiku">haiku</span></td><td>high</td><td>complex_feature</td><td><span class="model-sonnet">sonnet</span></td><td>never-Haiku floor</td></tr>
+    <tr><td>bogus</td><td>standard</td><td>simple_change</td><td><span class="model-sonnet">sonnet</span></td><td>unknown ceiling → floor</td></tr>
+  </table></div>
+  <div class="callout"><strong>Supersedes an earlier sketch:</strong> the companion <code>.md</code>'s test-matrix prose was drafted before the never-Haiku hardening commit (<code>8530f7c</code>) landed on this branch and still reads <span class="stale">"ceiling=haiku → (inherit, misconfig)."</span> The table above matches what actually shipped and what the test suite actually asserts: a haiku or unknown ceiling floors to <span class="model-sonnet">sonnet</span>, never <code>inherit</code> — because <code>inherit</code> could itself resolve to a Haiku session model. The <code>.md</code> is left as originally staged per process; this page renders the shipped behavior.</div>
+</section>
+
+<section>
+  <div class="eyebrow">Out of scope</div>
+  <h2>Named and left</h2>
+  <ul>
+    <li><code>review</code> / <code>analysis</code> role down-routing — a cheaper reviewer weakens a gate; separate discussion, explicitly deferred per issue.</li>
+    <li>Other dispatch sites (WF3, WF8) — follow-up once WF2 is proven.</li>
+    <li>Any config schema change — same <code>modelRouting.implementation</code> key throughout.</li>
+  </ul>
+</section>
+
+<section>
+  <div class="eyebrow">AC coverage</div>
+  <h2>Acceptance criteria → verification</h2>
+  <div class="tablewrap"><table>
+    <tr><th>AC</th><th>Requirement</th><th>Verified by</th></tr>
+    <tr><td>AC1</td><td>Per-task model chosen from <code>(riskLevel, complexity)</code>, capped at the configured ceiling</td><td><code>select_impl_model</code> + the Step 8 per-task call site</td></tr>
+    <tr><td>AC2</td><td>A struggling down-routed task escalates to the ceiling before normal failure handling</td><td>Step 8 retry-once-at-ceiling prose</td></tr>
+    <tr><td>AC3</td><td>Per-task routing decisions are auditable</td><td>Step 8 session-note log line: <code>task &lt;id&gt;: model &lt;m&gt; (&lt;reason&gt;)</code></td></tr>
+    <tr><td>AC4</td><td>Ceiling semantics documented; no config schema change</td><td><code>docs/config-reference.md</code> "implementation ceiling" note</td></tr>
+    <tr><td>AC5</td><td>Selection logic covered by a matrix, not spot checks</td><td><code>tests/hooks/test_model_routing.py::TestSelectImplModel</code> — 12 parametrized cases</td></tr>
+  </table></div>
+</section>
+</main>

--- a/docs/design/2026-07-03-model-ceiling-downrouting.md
+++ b/docs/design/2026-07-03-model-ceiling-downrouting.md
@@ -1,0 +1,56 @@
+# Design: modelRouting.implementation as a CEILING — per-task down-routing (#132)
+
+Date: 2026-07-03 · Issue #132 · Complexity: standard_feature · lean gate (1 design pass)
+
+## Problem
+
+`modelRouting.implementation` is applied as a blanket assignment: WF2 Step 8's delegation dispatches EVERY plan task with `model: <implementation>`. With `implementation: opus`, well-specified 2-file mechanical/TDD tasks that Sonnet handles fine are built on Opus — over-spend (owner-flagged). Signals to do better already exist: Step 2 complexity classification (simple_change/standard_feature/complex_feature) + Step 5 per-task `riskLevel: high|standard` (`plan_lib.RISK_CRITERIA`).
+
+## Approach
+
+Treat `modelRouting.implementation` as a **ceiling, not a floor**. Add ONE pure function to `hooks/model_routing_lib.py`; Step 8 calls it per task and dispatches with the returned model.
+
+### `select_impl_model(ceiling: str, risk_level: str, complexity: str) -> tuple[str, str]`
+
+Pure, fail-open, never raises. Returns `(model, reason)` for per-task audit logging (AC3).
+
+Model rank (cheap→capable): `sonnet=1, opus=2, fable=3` — **haiku is deliberately NOT rankable for implementation** (standing project rule: never Haiku for coding). Ranks used only for the ceiling clamp.
+
+Logic:
+1. `ceiling == "inherit"` → `("inherit", "no routing configured — session model")`. No per-task logic when routing is off; Step 8 behaves exactly as today.
+2. `ceiling not in {sonnet,opus,fable}` (unknown/haiku) → `("inherit", "ceiling <c> not a valid impl model — session model")` (fail-open; haiku ceiling for coding is a misconfig, degrade to session model rather than force Haiku).
+3. Desired tier:
+   - `risk_level == "high"` OR `complexity == "complex_feature"` → `desired = ceiling` (hardest work gets the configured max).
+   - else → `desired = "sonnet"` (down-route target for standard/simple, well-specified).
+4. Clamp to ceiling: `actual = desired if rank[desired] <= rank[ceiling] else ceiling`. (If ceiling is sonnet, a high-risk task stays sonnet — a ceiling is a hard cap, never exceeded.)
+5. Reasons: `"high-risk/complex → ceiling <m>"`, `"standard/simple → down-routed to sonnet"`, `"clamped to ceiling <m>"`.
+
+Floor note: the down-route target is `sonnet` (never below), satisfying "no Haiku for coding" without a separate clamp — sonnet is already the lowest desired tier.
+
+### WF2 Step 8 (`skills/implement-feature/SKILL.md`) — delegation block
+
+Currently: "When routing resolved the `implementation` role to a non-`inherit` model, execute each plan task via a subagent (`model: <implementation>`)". Change:
+- Before each task's dispatch, call `select_impl_model(<resolved implementation ceiling>, task.riskLevel, <Step-2 complexity>)`; dispatch that task's subagent with the returned model.
+- **Log per task** (session notes): `task <id>: model <m> (<reason>)` — makes over/under-routing auditable (AC3).
+- **Escalate on struggle:** the existing clean-state restore + retry-once path now retries at the **ceiling** model (not the down-routed one) before falling through to normal Step 8 failure handling (AC2). One escalation, then normal handling.
+- When ceiling is `inherit`, the block is inert exactly as today (function returns inherit → dispatch with no `model:`).
+
+## Files
+- `hooks/model_routing_lib.py`: `select_impl_model` (+ rank map).
+- `tests/hooks/test_model_routing.py`: selection matrix.
+- `skills/implement-feature/SKILL.md`: Step 8 delegation prose (ceiling + per-task select + escalation) + a `<model-routing-resolve>` note that implementation is a ceiling.
+- `docs/config-reference.md`: document ceiling semantics (no schema change — same `modelRouting.implementation` key, clarified meaning). README if it describes routing.
+- Version bump patch → 2.47.1 (behavior refinement, no new config).
+
+## Test matrix (TDD)
+`select_impl_model`:
+- ceiling=opus, high risk → (opus, high-risk); ceiling=opus, standard+simple_change → (sonnet, down-routed); ceiling=opus, standard+complex_feature → (opus, complex); ceiling=opus, standard+standard_feature → (sonnet, down-routed)
+- ceiling=sonnet, high risk → (sonnet, clamped); ceiling=sonnet, standard → (sonnet)
+- ceiling=fable, high → (fable); ceiling=fable, standard → (sonnet)
+- ceiling=inherit → (inherit, …); ceiling=haiku → (inherit, misconfig); ceiling="bogus" → (inherit)
+
+## Out of scope
+`review`/`analysis` role down-routing (a cheaper reviewer weakens a gate — separate discussion, explicitly deferred per issue). Other dispatch sites (WF3/WF8) — follow-up once WF2 proven. No config schema change.
+
+## AC coverage
+AC1 per-task model from (riskLevel, complexity), ceiling=max → select_impl_model + Step 8 call. AC2 escalation → retry-at-ceiling prose. AC3 logging → per-task session-note line. AC4 docs ceiling semantics, no schema change → config-reference. AC5 selection-matrix tests.

--- a/docs/design/2026-07-03-model-ceiling-downrouting.md
+++ b/docs/design/2026-07-03-model-ceiling-downrouting.md
@@ -49,6 +49,15 @@ Currently: "When routing resolved the `implementation` role to a non-`inherit` m
 - ceiling=fable, high → (fable); ceiling=fable, standard → (sonnet)
 - ceiling=inherit → (inherit, …); ceiling=haiku → (inherit, misconfig); ceiling="bogus" → (inherit)
 
+## Supersession note (never-Haiku directive, mid-implementation)
+
+After this doc was drafted, the owner directed: **rawgentic must never route work to Haiku.** That changed two rows of the matrix below and the fallback semantics as SHIPPED (commit 8530f7c):
+- `select_impl_model` step 2 (haiku / unknown ceiling) → **`("sonnet", …)`**, NOT `("inherit", …)` — never punt coding to a session model that might be Haiku.
+- `resolve()` bumps ANY role configured to `haiku` → `sonnet` (warned), all roles.
+- Step 8 dispatch never uses `model: haiku`; under `inherit` with a Haiku session model, dispatch `sonnet`.
+
+The matrix rows for `ceiling=haiku`/`bogus` therefore resolve to `sonnet` (not `inherit`) in the shipped code and tests. The rest of the design stands.
+
 ## Out of scope
 `review`/`analysis` role down-routing (a cheaper reviewer weakens a gate — separate discussion, explicitly deferred per issue). Other dispatch sites (WF3/WF8) — follow-up once WF2 proven. No config schema change.
 

--- a/hooks/model_routing_lib.py
+++ b/hooks/model_routing_lib.py
@@ -20,6 +20,9 @@ VALID_MODELS: Final[frozenset[str]] = frozenset(
 INHERIT: Final[str] = "inherit"
 # review-role soft floor: explicit models weaker than opus warn (but still apply)
 _BELOW_OPUS: Final[frozenset[str]] = frozenset({"sonnet", "haiku"})
+# per-task implementation ceiling clamp, cheap -> capable. haiku deliberately
+# absent — never Haiku for coding (standing project rule).
+_IMPL_RANK: Final[dict[str, int]] = {"sonnet": 1, "opus": 2, "fable": 3}
 
 
 def _warn(msg: str) -> None:
@@ -73,6 +76,36 @@ def resolve(workspace_path: str, project_name: str, role: str) -> str:
             f"— review quality may drop"
         )
     return value
+
+
+def select_impl_model(ceiling: str, risk_level: str, complexity: str) -> tuple[str, str]:
+    """Pick the per-task implementation model under a resolved ceiling.
+
+    Pure, never raises, fail-open: any ceiling outside _IMPL_RANK (including
+    'inherit', 'haiku', or an unknown string) degrades to ('inherit', ...).
+    """
+    if ceiling == "inherit":
+        return "inherit", "no routing configured — session model"
+    if ceiling not in _IMPL_RANK:
+        return "inherit", f"ceiling {ceiling!r} not a valid implementation model — session model"
+
+    if risk_level == "high" or complexity == "complex_feature":
+        desired = ceiling
+    else:
+        desired = "sonnet"
+
+    if _IMPL_RANK[desired] <= _IMPL_RANK[ceiling]:
+        actual = desired
+    else:
+        actual = ceiling  # defensive: unreachable while sonnet is rank 1 (the minimum)
+
+    if desired == ceiling:
+        reason = f"high-risk/complex → ceiling {actual}"
+    elif actual == desired:
+        reason = f"standard/simple → down-routed to {actual}"
+    else:
+        reason = f"standard/simple, clamped to ceiling {actual}"
+    return actual, reason
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/hooks/model_routing_lib.py
+++ b/hooks/model_routing_lib.py
@@ -61,7 +61,15 @@ def _load_block(workspace_path: str, project_name: str) -> dict:
 
 
 def resolve(workspace_path: str, project_name: str, role: str) -> str:
-    """Resolve a dispatch role to a model name (or 'inherit'). Never raises."""
+    """Resolve a dispatch role to a model name (or 'inherit'). Never raises.
+
+    rawgentic NEVER uses Haiku for any routed subagent role: a config value of
+    ``haiku`` is accepted (not rejected to inherit) but hard-bumped to ``sonnet``
+    with a warning, so a misconfigured entry can never send review/analysis/
+    implementation work to Haiku. (A session model of Haiku when a role is
+    ``inherit`` is guarded at the dispatch site, not here — see the WF2 Step 8
+    delegation block.)
+    """
     block = _load_block(workspace_path, project_name)
     value = block.get(role, INHERIT)
     if not isinstance(value, str) or value not in VALID_MODELS:
@@ -70,6 +78,12 @@ def resolve(workspace_path: str, project_name: str, role: str) -> str:
             f"(valid: {sorted(VALID_MODELS)}); using inherit"
         )
         return INHERIT
+    if value == "haiku":
+        _warn(
+            f"role '{role}' configured to 'haiku' — rawgentic never uses Haiku for "
+            f"routed work; using 'sonnet' instead"
+        )
+        return "sonnet"
     if role == "review" and value in _BELOW_OPUS:
         _warn(
             f"review role resolved to '{value}', below recommended opus floor "
@@ -81,13 +95,18 @@ def resolve(workspace_path: str, project_name: str, role: str) -> str:
 def select_impl_model(ceiling: str, risk_level: str, complexity: str) -> tuple[str, str]:
     """Pick the per-task implementation model under a resolved ceiling.
 
-    Pure, never raises, fail-open: any ceiling outside _IMPL_RANK (including
-    'inherit', 'haiku', or an unknown string) degrades to ('inherit', ...).
+    Pure, never raises, fail-open. `inherit` ceiling → ('inherit', ...) (routing
+    off, use the session model). A `haiku` or otherwise-unknown ceiling floors to
+    ('sonnet', ...) — rawgentic never routes coding to Haiku, and never punts to a
+    session model that might BE Haiku. Otherwise picks the cheapest sufficient
+    model under the ceiling: high-risk/complex → ceiling, else sonnet.
     """
     if ceiling == "inherit":
         return "inherit", "no routing configured — session model"
     if ceiling not in _IMPL_RANK:
-        return "inherit", f"ceiling {ceiling!r} not a valid implementation model — session model"
+        # haiku / unknown ceiling: never route coding to Haiku and never punt to a
+        # session model that might BE Haiku — fall back to the sonnet coding floor.
+        return "sonnet", f"ceiling {ceiling!r} not a valid implementation model — floor to sonnet"
 
     if risk_level == "high" or complexity == "complex_feature":
         desired = ceiling

--- a/hooks/model_routing_lib.py
+++ b/hooks/model_routing_lib.py
@@ -108,22 +108,21 @@ def select_impl_model(ceiling: str, risk_level: str, complexity: str) -> tuple[s
         # session model that might BE Haiku — fall back to the sonnet coding floor.
         return "sonnet", f"ceiling {ceiling!r} not a valid implementation model — floor to sonnet"
 
-    if risk_level == "high" or complexity == "complex_feature":
-        desired = ceiling
-    else:
-        desired = "sonnet"
+    # Reason keys off WHY the task was routed (the branch taken), NOT off a
+    # desired==ceiling coincidence — a standard task under a sonnet ceiling is a
+    # down-route to sonnet, and must not be logged as "high-risk/complex".
+    high_or_complex = risk_level == "high" or complexity == "complex_feature"
+    desired = ceiling if high_or_complex else "sonnet"
 
     if _IMPL_RANK[desired] <= _IMPL_RANK[ceiling]:
         actual = desired
     else:
         actual = ceiling  # defensive: unreachable while sonnet is rank 1 (the minimum)
 
-    if desired == ceiling:
+    if high_or_complex:
         reason = f"high-risk/complex → ceiling {actual}"
-    elif actual == desired:
-        reason = f"standard/simple → down-routed to {actual}"
     else:
-        reason = f"standard/simple, clamped to ceiling {actual}"
+        reason = f"standard/simple → down-routed to {actual}"
     return actual, reason
 
 

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -800,15 +800,24 @@ Execute the implementation plan task by task.
    ```
 
 <!-- model-routing: role=implementation -->
-**Optional implementation delegation (`implementation` role).** When routing resolved the `implementation` role to a non-`inherit` model, execute each plan task via a subagent (`model: <implementation>`) instead of inline, subject to a per-task **clean-state boundary**:
+**Optional implementation delegation (`implementation` role).** When routing resolved the `implementation` role to a non-`inherit` model, execute each plan task via a subagent instead of inline, subject to a per-task **clean-state boundary**. The resolved `implementation` model is a **CEILING, not a blanket assignment** — pick the cheapest sufficient model per task (issue #132), so a well-specified mechanical task is not built on the ceiling model when a cheaper one suffices.
 
+0. **Per-task model selection (ceiling semantics).** For each task, choose its dispatch model with:
+   ```bash
+   python3 -c "import sys; sys.path.insert(0,'hooks'); from model_routing_lib import select_impl_model; m,r=select_impl_model('<ceiling>','<riskLevel>','<complexity>'); print(m); print(r)"
+   ```
+   - `<ceiling>` = the resolved `implementation` value from `<model-routing-resolve>`.
+   - `<riskLevel>` = this task's `riskLevel` (`high`|`standard`) from the Step 5 plan.
+   - `<complexity>` = the **Step 2** authoritative complexity classification (`simple_change`|`standard_feature`|`complex_feature`) carried forward from Step 2 item 7; if it is unavailable/unknown in context, pass `standard_feature` (the conservative middle) and note that in the per-task log.
+   `select_impl_model` returns `(model, reason)`: high-risk **or** `complex_feature` → the ceiling; otherwise → `sonnet` (down-routed); a `haiku`/unknown ceiling floors to `sonnet` (rawgentic never routes coding to Haiku). Dispatch this task's subagent with `model: <model>`. **Never dispatch an implementation subagent with `model: haiku`** — if the resolved model is `inherit` and the session model is Haiku, pass `model: sonnet` instead.
+   **Log per task** in session notes: `impl task <id>: model <model> (<reason>)` — makes over/under-routing auditable.
 1. **Before dispatch:** record the pre-task state — current `HEAD` and `git status --porcelain` (the tree must already be clean from the previous task's commit).
-2. **Dispatch one task-agent** (serial — one at a time; each task builds on the previous commit) with the brief: the design doc, this plan task, the TDD requirement, project conventions, and the current test baseline. The agent implements the task test-first and commits it.
+2. **Dispatch one task-agent** (serial — one at a time; each task builds on the previous commit) with the per-task `model` from item 0 and the brief: the design doc, this plan task, the TDD requirement, project conventions, and the current test baseline. The agent implements the task test-first and commits it.
 3. **After it returns:** re-run the test suite and diff against the recorded baseline. On success (tests green, only expected paths changed, task committed) → proceed to the next task.
-4. **On failure or vacuous return:** **restore** the pre-task state first — `git reset --hard <recorded HEAD>` and `git clean -fd` to discard the agent's partial edits — then retry that task once inline in the main loop. Log the fallback. Because the restore runs first, the inline retry never operates on a half-mutated tree.
+4. **On failure or vacuous return:** **restore** the pre-task state first — `git reset --hard <recorded HEAD>` and `git clean -fd` to discard the agent's partial edits — then **retry that task once at the CEILING model** (escalate: a down-routed task that struggled gets the configured maximum, dispatched the same clean-state way, or inline if the ceiling is `inherit`). Log the escalation. Because the restore runs first, the retry never operates on a half-mutated tree.
 5. Delegation can never block Step 8: a second failure falls through to the normal Step 8 failure handling.
 
-When the `implementation` role is `inherit` (default), Step 8 runs inline exactly as today — no delegation, no behavior change.
+When the `implementation` role is `inherit` (default), Step 8 runs inline exactly as today — no delegation, no behavior change (and if the session model is Haiku, dispatch any implementation subagent with `model: sonnet`).
 
 **Parallel task execution (validated, currently serial):** Use the parallel-eligibility result from Step 5's `plan_lib.validate_parallel_groups(tasks)` to know which groups *could* run concurrently. **Until isolated concurrent execution lands (issue #85), execute ALL tasks sequentially in plan order**, including parallel-eligible groups. Do NOT dispatch concurrent Agent calls that write to the working tree: with no worktree isolation, concurrent edits to the shared tree can collide and corrupt commits — sequential execution is the safe floor. **Staging backstop:** the "stage ONLY this task's files, never `git add -A`" rule above applies to every task; when a task additionally declares `files`, that rule becomes machine-checkable — assert the staged set is a subset of the declared `files` and STOP to reconcile if not. (A task in a parallel_group that declared no `files` is already non-eligible and runs sequentially under the same stage-only-this-task's-files rule.)
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -268,10 +268,16 @@ This step runs on **every** setup invocation (including Sub-flow A re-runs).
 
 Offer per-project subagent model routing. Ask whether to route the three dispatch roles to specific models (skip any role = inherit the session model). Suggested defaults: `review: opus`, `analysis: sonnet`, `implementation: opus`.
 
-- If the user opts in, collect a model (`opus`/`sonnet`/`haiku`/`fable`) or "skip" per role, and stage:
+- If the user opts in, collect a model (`opus`/`sonnet`/`haiku`/`fable` — a `haiku`
+  choice is bumped to `sonnet` at resolve time, since rawgentic never routes work
+  to Haiku) or "skip" per role, and stage:
   `"modelRouting": { "<role>": "<model>", ... }` (omit skipped roles).
 - If the user declines, stage nothing (absent block = inherit everywhere; byte-identical default).
-- Note the soft opus floor: routing `review` below opus warns at run time but still applies.
+- Note the soft opus floor: routing `review` to `sonnet` warns at run time but still
+  applies (`haiku` is bumped to `sonnet` instead, per the never-Haiku rule).
+- Note that `implementation` acts as a per-task ceiling, not a blanket assignment:
+  WF2 Step 8 down-routes standard/simple tasks to `sonnet` and reserves the
+  configured model for high-risk or complex tasks.
 
 ## Step 2g: Peer Consult (WF13) Integration
 

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -34,7 +34,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.47.0"
+    assert plugin["version"] == "2.47.1"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_model_routing.py
+++ b/tests/hooks/test_model_routing.py
@@ -85,11 +85,12 @@ def test_review_below_opus_floor_warns_sonnet(tmp_path, capsys):
     assert "opus floor" in capsys.readouterr().err
 
 
-def test_review_haiku_also_warns_floor(tmp_path, capsys):
+def test_review_haiku_bumped_to_sonnet(tmp_path, capsys):
+    # rawgentic never uses Haiku for routed work: a haiku config bumps to sonnet.
     ws = _ws(tmp_path, {"name": "app", "path": "./p",
                         "modelRouting": {"review": "haiku"}})
-    assert mr.resolve(ws, "app", "review") == "haiku"
-    assert "opus floor" in capsys.readouterr().err
+    assert mr.resolve(ws, "app", "review") == "sonnet"
+    assert "never uses Haiku" in capsys.readouterr().err
 
 
 def test_review_inherit_and_fable_do_not_warn_floor(tmp_path, capsys):
@@ -99,11 +100,23 @@ def test_review_inherit_and_fable_do_not_warn_floor(tmp_path, capsys):
     assert "opus floor" not in capsys.readouterr().err
 
 
-def test_analysis_below_opus_does_not_warn_floor(tmp_path, capsys):
+def test_analysis_haiku_bumped_to_sonnet(tmp_path, capsys):
+    # never-Haiku is global (all roles), not just review; and it is NOT the
+    # review-only opus floor.
     ws = _ws(tmp_path, {"name": "app", "path": "./p",
                         "modelRouting": {"analysis": "haiku"}})
-    assert mr.resolve(ws, "app", "analysis") == "haiku"
-    assert "opus floor" not in capsys.readouterr().err  # floor is review-only
+    assert mr.resolve(ws, "app", "analysis") == "sonnet"
+    err = capsys.readouterr().err
+    assert "never uses Haiku" in err
+    assert "opus floor" not in err
+
+
+def test_analysis_sonnet_no_floor_warn(tmp_path, capsys):
+    # a non-haiku sub-opus model on a non-review role warns nothing (floor is review-only).
+    ws = _ws(tmp_path, {"name": "app", "path": "./p",
+                        "modelRouting": {"analysis": "sonnet"}})
+    assert mr.resolve(ws, "app", "analysis") == "sonnet"
+    assert "opus floor" not in capsys.readouterr().err
 
 
 def test_cli_resolve_prints_value_exit_zero(tmp_path, capsys):
@@ -136,11 +149,14 @@ class TestSelectImplModel:
             ("fable", "high", "standard_feature", "fable"),
             ("fable", "standard", "simple_change", "sonnet"),
             ("inherit", "high", "complex_feature", "inherit"),
-            ("haiku", "high", "complex_feature", "inherit"),
-            ("bogus", "standard", "simple_change", "inherit"),
+            # never-Haiku: a haiku or unknown ceiling floors to sonnet (never
+            # inherit, which could resolve to a Haiku session model).
+            ("haiku", "high", "complex_feature", "sonnet"),
+            ("bogus", "standard", "simple_change", "sonnet"),
         ],
     )
     def test_select_impl_model(self, ceiling, risk_level, complexity, expected):
         model, reason = mr.select_impl_model(ceiling, risk_level, complexity)
         assert model == expected
         assert isinstance(reason, str) and reason
+        assert model != "haiku"  # rawgentic never routes coding to Haiku

--- a/tests/hooks/test_model_routing.py
+++ b/tests/hooks/test_model_routing.py
@@ -120,3 +120,27 @@ def test_cli_resolve_bad_config_still_exit_zero(tmp_path, capsys):
     rc = mr.main(["resolve", "--workspace", ws, "--project", "app", "--role", "review"])
     assert rc == 0  # fail-open: never non-zero
     assert capsys.readouterr().out.strip() == "inherit"
+
+
+class TestSelectImplModel:
+    @pytest.mark.parametrize(
+        "ceiling, risk_level, complexity, expected",
+        [
+            ("opus", "high", "standard_feature", "opus"),
+            ("opus", "standard", "simple_change", "sonnet"),
+            ("opus", "standard", "standard_feature", "sonnet"),
+            ("opus", "standard", "complex_feature", "opus"),
+            ("opus", "high", "complex_feature", "opus"),
+            ("sonnet", "high", "complex_feature", "sonnet"),
+            ("sonnet", "standard", "simple_change", "sonnet"),
+            ("fable", "high", "standard_feature", "fable"),
+            ("fable", "standard", "simple_change", "sonnet"),
+            ("inherit", "high", "complex_feature", "inherit"),
+            ("haiku", "high", "complex_feature", "inherit"),
+            ("bogus", "standard", "simple_change", "inherit"),
+        ],
+    )
+    def test_select_impl_model(self, ceiling, risk_level, complexity, expected):
+        model, reason = mr.select_impl_model(ceiling, risk_level, complexity)
+        assert model == expected
+        assert isinstance(reason, str) and reason

--- a/tests/hooks/test_model_routing.py
+++ b/tests/hooks/test_model_routing.py
@@ -160,3 +160,14 @@ class TestSelectImplModel:
         assert model == expected
         assert isinstance(reason, str) and reason
         assert model != "haiku"  # rawgentic never routes coding to Haiku
+
+    def test_reason_reflects_branch_not_ceiling_coincidence(self):
+        # a standard/simple task under a sonnet ceiling is a down-route, not
+        # "high-risk/complex", even though desired==ceiling==sonnet.
+        model, reason = mr.select_impl_model("sonnet", "standard", "simple_change")
+        assert model == "sonnet"
+        assert "down-routed" in reason
+        assert "high-risk" not in reason
+        # and a genuine high-risk task IS labelled as such
+        _, hi_reason = mr.select_impl_model("sonnet", "high", "standard_feature")
+        assert "high-risk/complex" in hi_reason

--- a/tests/hooks/test_model_routing_dispatch.py
+++ b/tests/hooks/test_model_routing_dispatch.py
@@ -47,7 +47,8 @@ def test_step8_documents_ceiling_downrouting():
     text = (SKILLS / "implement-feature" / "SKILL.md").read_text()
     assert "CEILING, not a blanket assignment" in text
     assert "select_impl_model" in text
-    # never-Haiku guarantee is stated at the dispatch site (covers inherit→session-model)
-    assert "never" in text.lower() and "haiku" in text.lower()
+    # never-Haiku guarantee is stated at the dispatch site (covers inherit→session-model):
+    # pin the specific guard sentence, not just the two words appearing somewhere.
+    assert "Never dispatch an implementation subagent with `model: haiku`" in text
     # per-task audit log line
     assert "impl task <id>: model" in text

--- a/tests/hooks/test_model_routing_dispatch.py
+++ b/tests/hooks/test_model_routing_dispatch.py
@@ -37,4 +37,17 @@ def test_step8_delegation_documents_clean_state_boundary():
     assert "clean-state boundary" in text
     assert "git status --porcelain" in text
     assert "restore" in text.lower()
-    assert "retries that task once inline" in text or "retry that task once inline" in text
+    # #132: a struggling down-routed task escalates — retry at the CEILING model
+    # (restore-first), not a flat inline retry.
+    assert "retry that task once at the CEILING model" in text
+
+
+def test_step8_documents_ceiling_downrouting():
+    """#132: implementation model is a per-task ceiling, selected via select_impl_model."""
+    text = (SKILLS / "implement-feature" / "SKILL.md").read_text()
+    assert "CEILING, not a blanket assignment" in text
+    assert "select_impl_model" in text
+    # never-Haiku guarantee is stated at the dispatch site (covers inherit→session-model)
+    assert "never" in text.lower() and "haiku" in text.lower()
+    # per-task audit log line
+    assert "impl task <id>: model" in text


### PR DESCRIPTION
## Summary

Treats `modelRouting.implementation` as a **per-task ceiling** instead of a blanket assignment (issue #132): WF2 Step 8 picks the cheapest sufficient model per task — high-risk or `complex_feature` tasks get the configured ceiling, everything else down-routes to `sonnet`, and a struggling down-routed task **escalates to the ceiling** on retry. Directly cuts the over-spend of building well-specified mechanical tasks on Opus.

Bundles a hard **never-Haiku** guarantee (owner directive): rawgentic never routes any work to Haiku.

Closes #132

## What changed
- **`hooks/model_routing_lib.py`**: `select_impl_model(ceiling, risk_level, complexity) -> (model, reason)` — pure, fail-open, per-task ceiling selection with an audit reason that reflects the routing *branch* (not a desired==ceiling coincidence). `resolve()` now bumps any role configured to `haiku` → `sonnet` (warned, all roles); `select_impl_model` floors haiku/unknown ceilings to `sonnet` (never punt to a session model that might be Haiku).
- **WF2 Step 8 (`skills/implement-feature/SKILL.md`)**: per-task model selection via `select_impl_model` (Step-2 complexity source named, missing⇒`standard_feature`), per-task audit log line, escalate-at-ceiling retry within the clean-state boundary, and a dispatch guard that never uses `model: haiku` (inherit + Haiku session → `sonnet`).
- **Docs**: `docs/config-reference.md` (ceiling semantics + never-Haiku, corrected stale "soft opus floor" haiku wording), `skills/setup/SKILL.md`, README changelog, design doc + standalone HTML. Version → **2.47.1**.

## Verification
- Full suite: **1489 passed / 5 failed** — the 5 are pre-existing, non-branch (4× untracked `test_codex_plugin_packaging.py` from a separate STARS session; 1× `test_shared_block_drift::test_sync_is_idempotent`, a shutil race on untracked stale `.pytest_tmp` eval dirs). **Zero regressions.** Branch tests (`test_model_routing*`) all green.
- Never-Haiku pinned red-green (haiku/unknown ceiling → sonnet; resolve haiku → sonnet; `assert model != "haiku"` on every selector case).

## Quality Gate Summary
- Design critique (Step 4): 1 Codex cross-model pass — 1 High + 2 Med, all folded (haiku→sonnet not inherit; Step-2 complexity source named; stale test-matrix reason). No loop-back needed.
- Code review (Step 11): 1 reviewer — NO BLOCKING FINDINGS; one Low (audit-reason coincidence) fixed.
- Security scan (Step 11.5): 0 blocking / 0 advisory / 0 errors; skipped iac (n/a), sca (osv: no lockfile).

## Note
Applies the review-budget policy set mid-campaign: ≤3 review cycles, lean design gate (Codex cross-model pass, no 3-judge panel), one code-review cycle. This is also the feature dogfooding itself — its standard-risk tasks were built on sonnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
