### PR TITLE
fix(wf2): Step 7 branches from fresh origin/<default>, mutates nothing (#140)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.49.0",
+  "version": "2.49.1",
   "description": "12 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, peer consultation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -714,6 +714,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v2.49.1 (2026-07-04)
+- **WF2 Step 7 branches from a freshly-fetched `origin/<default>`, mutating nothing (#140).** The old `git pull origin <default> && git checkout -b <branch>` merged the default INTO the current checkout — on a multi-issue campaign that sat on a prior issue's feature branch, this mutated that branch and carried its unmerged commits into the new PR. Now: `git fetch origin <default>` + `git checkout -b <branch> origin/<default>` + a base assertion that STOPs on mismatch (headless: ERROR). Also hardened `incident`'s hotfix branch with an explicit `git fetch` (the one sibling that lacked it; the other 7 already fetch).
+
 ### v2.49.0 (2026-07-03)
 - **Whole-issue delegated build mode — opt-in single-subagent build with orchestrator-verified receipt (#133).** New workspace field `wholeIssueDelegation: { enabled: bool, workflows: [str] }` (per-project, mirrors `adversarialReview`/`peerConsult`, read via the same `adversarial_review_lib.load_adversarial_review_config(..., key="wholeIssueDelegation")` loader — no config-schema change beyond the field itself). When enabled for `implement-feature`, WF2 Step 8 dispatches one build-subagent to implement the whole plan and return a structured RECEIPT; the orchestrator validates it via `plan_lib.validate_build_receipt` and re-runs every gate (8a/9/11/11.5) against the real tree — the receipt is a hypothesis until confirmed, never self-certified. A rejected receipt restores the worktree and falls back to normal per-task Step 8. Default disabled; absent field → unchanged behavior.
 

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -852,10 +852,16 @@ Plan drift check result.
    ```
    If dirty: stash, create branch, ask user about stash. **[Headless: AUTO-RESOLVE — always stash, log to session notes AND post a brief comment to the issue noting uncommitted changes were stashed (include `git stash list` output for the stash ref).]**
 
-2. Pull latest default branch and create feature branch:
+2. Create the feature branch from a **freshly-fetched** default branch — never `git pull` into the current checkout first. `git pull origin <default>` merges the default INTO whatever branch is checked out; if the session still sits on a prior issue's feature branch (a multi-issue campaign, or a headless PR-terminal run that never ran Step 14), that mutates the sibling branch AND bases the new branch on the mixture, silently carrying the sibling's unmerged commits into this PR. Fetch, then branch off `origin/<default>` regardless of the starting checkout:
    ```bash
-   git pull origin ${capabilities.default_branch} && git checkout -b <branch_name>
+   git fetch origin ${capabilities.default_branch}
+   git checkout -b <branch_name> origin/${capabilities.default_branch}
    ```
+   **Base assertion — STOP on mismatch.** Confirm the new branch's base is exactly `origin/<default>` HEAD (nothing foreign rode along):
+   ```bash
+   [ "$(git merge-base HEAD origin/${capabilities.default_branch})" = "$(git rev-parse origin/${capabilities.default_branch})" ] && echo BASE_OK || echo BASE_MISMATCH
+   ```
+   `BASE_MISMATCH` → STOP and reconcile before writing any code (do not build on a wrong base). **[Headless: ERROR — post an error comment noting the base mismatch, add the `rawgentic:ai-error` label, exit.]** Because nothing is pulled into the current checkout, no pre-existing branch is mutated as a side effect.
 
 3. Push empty branch to origin:
    ```bash

--- a/skills/incident/SKILL.md
+++ b/skills/incident/SKILL.md
@@ -366,7 +366,7 @@ Log in session notes: `### WF11 Step 9: RCA Critique — DONE (confidence: high|
 
 If fix is within WF11 scope:
 
-1. Create hotfix branch: `git checkout -b hotfix/<incident-desc> origin/<default_branch>`
+1. Create hotfix branch from a freshly-fetched default (a stale `origin/<default_branch>` ref would silently base the hotfix on old code): `git fetch origin <default_branch> && git checkout -b hotfix/<incident-desc> origin/<default_branch>`
 2. Write test reproducing the incident condition.
 3. Implement permanent fix.
 4. Run all tests.

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -34,7 +34,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.49.0"
+    assert plugin["version"] == "2.49.1"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_headless.py
+++ b/tests/hooks/test_headless.py
@@ -1264,7 +1264,7 @@ class TestHeadlessInteractionBlock:
 
     # Expected [Headless annotation counts per skill
     EXPECTED_COUNTS = {
-        "implement-feature": 29,  # 17 base + 7 P15 (#73): Step 5 warn/halt/decompose + 8a ambiguity/dispatch-failure/design-flaw/headless-suspend + Step 11 deferred-High + 1 Step 11.5 security-scan block + 1 Step 2 trivial-work suggestion + 3 headless remote-ops guards (#47): Step 2 SSH-probe skip, Step 14 merge/deploy skip, Step 15 post-deploy skip
+        "implement-feature": 30,  # 17 base + 7 P15 (#73): Step 5 warn/halt/decompose + 8a ambiguity/dispatch-failure/design-flaw/headless-suspend + Step 11 deferred-High + 1 Step 11.5 security-scan block + 1 Step 2 trivial-work suggestion + 3 headless remote-ops guards (#47): Step 2 SSH-probe skip, Step 14 merge/deploy skip, Step 15 post-deploy skip + 1 Step 7 base-mismatch ERROR (#140)
         "fix-bug": 11,            # 10 interaction points + 1 Step 2 trivial-work suggestion
     }
 

--- a/tests/test_wf2_clarity.py
+++ b/tests/test_wf2_clarity.py
@@ -239,3 +239,44 @@ class TestSmallStandardLane:
         assert "NON-NEGOTIABLE in the lane" in block
         assert "Step 11" in block
         assert "11.5" in block
+
+
+# --- #140: Step 7 branches from fresh origin/<default>, mutates nothing ---
+
+def _step7() -> str:
+    """The Step 7 section text (## Step 7 ... up to the next ## Step)."""
+    text = _text()
+    m = re.search(r"## Step 7:.*?(?=\n## Step 8:)", text, re.DOTALL)
+    assert m, "Step 7 section not found"
+    return m.group(0)
+
+
+class TestStep7BranchBase:
+    def test_branches_from_fresh_origin_default(self):
+        s7 = _step7()
+        assert "git fetch origin" in s7, "Step 7 must fetch before branching"
+        # stance-independent create: checkout -b <branch> origin/<default>
+        assert re.search(
+            r"git checkout -b <branch_name> origin/\$\{capabilities\.default_branch\}", s7
+        ), "Step 7 must create the branch from origin/<default>, not the current HEAD"
+
+    def test_no_pull_into_current_branch(self):
+        s7 = _step7()
+        # the buggy form merged origin/main INTO whatever branch was checked out
+        assert "git pull origin ${capabilities.default_branch} && git checkout -b" not in s7, \
+            "Step 7 must not pull into the current branch before creating the new one"
+
+    def test_has_base_assertion(self):
+        s7 = _step7()
+        assert "merge-base" in s7, "Step 7 must assert the new branch's base == origin/<default>"
+
+
+def test_incident_hotfix_branch_fetches_first():
+    """#140 AC4: incident is the one sibling whose branch step lacked an explicit
+    fetch (the other 7 already fetch). Its hotfix branch must fetch first so a
+    stale origin/<default> ref can't reintroduce the bug."""
+    incident = (REPO_ROOT / "skills" / "incident" / "SKILL.md").read_text()
+    idx = incident.find("git checkout -b hotfix/")
+    assert idx != -1, "incident hotfix checkout not found"
+    preceding = incident[:idx]
+    assert "git fetch origin" in preceding, "incident must fetch origin before the hotfix checkout"


### PR DESCRIPTION
## Summary

WF2 Step 7 created the feature branch with `git pull origin <default> && git checkout -b <branch>` — which merges the default INTO **whatever branch is checked out**. In a multi-issue campaign where the session still sits on a prior issue's feature branch (or a headless PR-terminal run that never ran Step 14), this mutated that sibling branch AND based the new branch on the mixture, silently carrying the sibling's unmerged commits into the new PR (field report: SayStory 7-issue campaign).

## Fix

```bash
git fetch origin ${capabilities.default_branch}
git checkout -b <branch_name> origin/${capabilities.default_branch}
```
Plus a base assertion (`git merge-base HEAD origin/<default>` == `origin/<default>` HEAD) that STOPs on mismatch (headless: ERROR). Nothing is pulled into the current checkout, so no pre-existing branch is mutated.

## Correction to the issue's AC4

The issue claimed the sibling skills "already use `origin/<default>` as start point but rely on ref freshness" and asked to add `git fetch` to all of them. **Verified against origin/main: 7 of 8 siblings already fetch** (fix-bug, refactor, optimize-perf, security-audit, update-deps, update-docs, create-tests all have both `git fetch origin` and `checkout -b … origin/<default>`). Only **`incident`** lacked the explicit fetch — that one is hardened here. (Minor pre-existing note, not fixed here: `update-docs` hardcodes `origin main` rather than `origin <default>`.)

## Tests / gates

- Drift guards in `tests/test_wf2_clarity.py`: Step 7 fetches + branches from `origin/<default>`, has the base assertion, and no longer contains the buggy pull-then-checkout; `incident` fetches before its hotfix checkout.
- `test_headless.py` implement-feature annotation count 29 → 30 (the new base-mismatch ERROR).
- Full suite: **1551 passed / 5 failed** — the 5 are the pre-existing untracked-working-tree baseline (not in the branch checkout → green in CI), not regressions.
- Security scan: PASS.

## AC coverage

AC1 fresh-origin branch ✓ · AC2 no branch mutated ✓ · AC3 base assertion + STOP/headless-ERROR ✓ · AC4 explicit fetch — corrected scope (only `incident` needed it) ✓.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
