### PR TITLE
docs(134): autonomous multi-issue driver design (pattern, not skill)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.50.0",
+  "version": "2.50.1",
   "description": "12 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, peer consultation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -714,6 +714,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v2.50.1 (2026-07-04)
+- **Design: autonomous multi-issue driver (#134, design-only).** Records the decision to build the backlog driver as a documented orchestration pattern + a committed queue state file (`claude_docs/.driver-state/<campaign>.json`) rather than a new skill — the loop is control flow the orchestrator already runs reliably; the value is the conventions (queue schema, DEFER taxonomy, rollback-anchor protocol, resumption reconciliation table). The driver never weakens WF2: each iteration invokes `/rawgentic:implement-feature` fresh and terminates at Step 16. Design doc + HTML in `docs/design/`; Codex adversarial pass folded (0C/1H/3M); build follow-up filed as #148.
+
 ### v2.50.0 (2026-07-04)
 - **First-class deferred-to-target verification state (#138).** When the dev env fundamentally cannot exercise an artifact (NSIS uninstaller with no `makensis`, native Win32 built from WSL, an OS-native tray that can't render headless), a plan task may declare `- verification: deferred-to-target (<reason>)`. It is NOT a skip — the task still requires its best local proxy (compile/typecheck/extractable unit tests); deferral covers only the unexercisable remainder and never counts as verified. `plan_lib.parse_tasks` records the reason (a deferral with no reason fails closed), `deferred_tasks`/`assert_deferrals_recorded` are the gate helpers, the run-record gains a structured `verification_deferred` list `[{task_id, reason, local_proxy, target_check}]` (old records stay valid), the PR body gets a `## Deferred verification` section, and `<completion-gate>` fails on any unrecorded deferral so a deferred surface can never silently vanish into a pass.
 

--- a/docs/design/2026-07-04-multi-issue-driver.html
+++ b/docs/design/2026-07-04-multi-issue-driver.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Multi-Issue Driver (#134)</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #ffffff;
+    --fg: #1b1f23;
+    --muted: #57606a;
+    --border: #d0d7de;
+    --card: #f6f8fa;
+    --code-bg: #eef1f4;
+    --link: #0969da;
+    --accent: #8250df;
+    --chosen: #1a7f37;
+    --rejected: #cf222e;
+    --thead-bg: #eaeef2;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117;
+      --fg: #e6edf3;
+      --muted: #9198a1;
+      --border: #30363d;
+      --card: #161b22;
+      --code-bg: #1c2128;
+      --link: #4493f8;
+      --accent: #a371f7;
+      --chosen: #3fb950;
+      --rejected: #ff7b72;
+      --thead-bg: #1c2128;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #0d1117;
+    --fg: #e6edf3;
+    --muted: #9198a1;
+    --border: #30363d;
+    --card: #161b22;
+    --code-bg: #1c2128;
+    --link: #4493f8;
+    --accent: #a371f7;
+    --chosen: #3fb950;
+    --rejected: #ff7b72;
+    --thead-bg: #1c2128;
+  }
+  :root[data-theme="light"] {
+    --bg: #ffffff;
+    --fg: #1b1f23;
+    --muted: #57606a;
+    --border: #d0d7de;
+    --card: #f6f8fa;
+    --code-bg: #eef1f4;
+    --link: #0969da;
+    --accent: #8250df;
+    --chosen: #1a7f37;
+    --rejected: #cf222e;
+    --thead-bg: #eaeef2;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--fg);
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    line-height: 1.6;
+    padding: 2.5rem 1.25rem 5rem;
+    max-width: 880px;
+    margin: 0 auto;
+  }
+  h1, h2, h3, h4 {
+    line-height: 1.3;
+    font-weight: 600;
+    scroll-margin-top: 1rem;
+  }
+  h1 {
+    font-size: 1.7rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.6rem;
+    margin-bottom: 0.3rem;
+  }
+  h1 + p {
+    color: var(--muted);
+    font-size: 0.92rem;
+    margin-top: 0.4rem;
+  }
+  h2 {
+    font-size: 1.28rem;
+    margin-top: 2.4rem;
+    padding-bottom: 0.3rem;
+    border-bottom: 1px solid var(--border);
+  }
+  h3 {
+    font-size: 1.05rem;
+    margin-top: 1.8rem;
+    color: var(--accent);
+  }
+  p { margin: 0.7rem 0; }
+  ul, ol { padding-left: 1.4rem; }
+  li { margin: 0.35rem 0; }
+  li > ul, li > ol { margin-top: 0.35rem; }
+  code {
+    background: var(--code-bg);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.88em;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+  pre {
+    background: var(--code-bg);
+    padding: 1rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    border: 1px solid var(--border);
+  }
+  pre code { background: none; padding: 0; }
+  a { color: var(--link); }
+  strong { font-weight: 650; }
+  hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+  blockquote {
+    margin: 1rem 0;
+    padding: 0.5rem 1rem;
+    border-left: 3px solid var(--accent);
+    background: var(--card);
+    color: var(--muted);
+  }
+  blockquote p { margin: 0.3rem 0; }
+
+  .table-wrap {
+    overflow-x: auto;
+    margin: 1.1rem 0 1.5rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+  }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    min-width: 560px;
+    font-size: 0.92rem;
+  }
+  thead th {
+    background: var(--thead-bg);
+    text-align: left;
+    font-weight: 650;
+    border-bottom: 1px solid var(--border);
+  }
+  th, td {
+    padding: 0.55rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr:hover { background: var(--card); }
+
+  .badge {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 650;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    color: var(--muted);
+    margin: 0 0.3rem 0.3rem 0;
+  }
+  .meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin: 0.6rem 0 1.6rem;
+  }
+  footer {
+    margin-top: 3rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+</style>
+</head>
+<body>
+
+<div class="meta">
+  <span class="badge">Issue #134</span>
+  <span class="badge">design-only</span>
+  <span class="badge">L program / M design</span>
+  <span class="badge">2026-07-04</span>
+</div>
+<h1>Design: autonomous multi-issue driver (#134)</h1>
+<p>Date: 2026-07-04 · Issue #134 · <strong>design-only</strong> — this issue is the design gate, not the build.</p>
+<blockquote><p>Codex adversarial pass folded — 0 Critical / 1 High / 3 Medium, all incorporated in place (no design loop-back per the lean review policy).</p></blockquote>
+
+<h2>Problem</h2>
+<p>WF2 is per-issue by contract: <code>&lt;termination-rule&gt;</code> ends at Step 16 and forbids auto-continuation. An autonomous backlog (N issues, push/PR/merge each) means re-invoking the 16-step skill N times with <strong>no shared state</strong>. This very campaign (six issues merged) hand-rolled every missing piece:</p>
+<div class="table-wrap"><table>
+<thead><tr><th>Hand-rolled this campaign</th><th>Where it lived</th><th>Failure risk when improvised</th></tr></thead>
+<tbody>
+<tr><td>Ordered queue with per-issue status</td><td>impact-order list in the handoff</td><td>drift between "what's next" and reality</td></tr>
+<tr><td>Rollback anchor per issue</td><td>base SHA at branch creation</td><td>none captured → can't cleanly revert a bad merge</td></tr>
+<tr><td>Alignment ledger</td><td><code>campaign-131-140.handoff.md</code></td><td>lost across compaction if not written</td></tr>
+<tr><td>Inter-issue policy (review budget, never-Haiku)</td><td>operator memory + standing rules</td><td>silently forgotten mid-run</td></tr>
+<tr><td>DEFER (park + keep going)</td><td><em>never existed</em></td><td>an owner-reserved surface would stall the whole loop</td></tr>
+</tbody></table></div>
+<p>Two real bugs trace to the missing structure: <strong>#138</strong> was committed to local <code>main</code> (no driver enforced "branch before first commit"); <strong>#140</strong> fixed a Step-7 base bug that only bites in a multi-issue loop (branching off a stale sibling). Both are exactly what a driver prevents.</p>
+
+<h2>Decision (AC2): documented PATTERN + a small committed state file — NOT a new skill</h2>
+<p><strong>Recommendation: documented pattern.</strong> Why the skill alternative loses:</p>
+<ul>
+<li><strong>A skill adds ceremony where the agent is already competent.</strong> The looping — run WF2, advance on success, park on DEFER, repeat — is control flow an orchestrator runs reliably without a skill (six issues, zero loop-control errors this campaign).</li>
+<li><strong>The value is in CONVENTIONS (data + docs), not executable logic:</strong> the queue schema, DEFER taxonomy, rollback-anchor protocol, resumption contract. Those are a pattern doc + one JSON state file, optionally a thin pure validator — not a 16-step skill.</li>
+<li><strong>A skill would be tempted to re-implement or weaken WF2's gates.</strong> A pattern that invokes <code>/rawgentic:implement-feature</code> fresh per issue makes weakening WF2 structurally impossible — AC3.</li>
+</ul>
+<p>Ships (in the follow-up build, not here): <code>docs/multi-issue-driver.md</code>; a committed queue state file <code>claude_docs/.driver-state/&lt;campaign&gt;.json</code>; OPTIONAL thin <code>hooks/driver_lib.py</code> pure validators, added only if hand-maintained JSON proves error-prone.</p>
+
+<h2>Queue schema (AC1)</h2>
+<p>Per-campaign <code>claude_docs/.driver-state/&lt;campaign&gt;.json</code>: <code>policy</code> {order, deploy, has_deploy, smoke_gate, review_budget, never_haiku}, <code>base_default_branch_sha</code>, and an <code>issues</code> array with {number, status, pr, merge_sha, rollback_anchor, deferred_reason, deferred_branch, branch_preservation}.</p>
+<p><strong>Status transitions</strong> (folded F1 — <code>pr_open</code> is first-class so headless is representable):</p>
+<pre><code>queued → in_progress → { pr_open | merged | deferred | abandoned }
+pr_open → { merged | deferred | abandoned }   # headless stops at pr_open</code></pre>
+<p>One issue <code>in_progress</code>/<code>pr_open</code> at a time (serial; parallel needs worktrees, #136/#85).</p>
+
+<h2>DEFER taxonomy (AC1)</h2>
+<div class="table-wrap"><table>
+<thead><tr><th>Type</th><th>Trigger</th><th>Loop action</th></tr></thead>
+<tbody>
+<tr><td><code>owner-decision</code></td><td>needs a human product/risk call</td><td>park, ledger, next issue</td></tr>
+<tr><td><code>owner-reserved</code></td><td>touches an owner-reserved surface</td><td>park, note the gate, next issue</td></tr>
+<tr><td><code>cross-repo</code></td><td>change spans another repo</td><td>park with the blocking dependency</td></tr>
+<tr><td><code>budget</code></td><td>campaign token/time budget exhausted</td><td>park remaining queued, stop cleanly</td></tr>
+</tbody></table></div>
+<p><strong>Branch preservation on DEFER</strong> (folded F2 — deterministic + persisted): <code>branch_preservation ∈ {pushed, discarded, none}</code> with <code>deferred_branch</code>. Resumable deferrals with commits → <code>pushed</code>; abandoned approach → <code>discarded</code> (branch deleted); no commits → <code>none</code>. Resumption never assumes a discarded branch or loses pushed work.</p>
+
+<h2>Rollback-anchor protocol (AC1)</h2>
+<p>Capture <code>origin/&lt;default&gt;</code> SHA as each issue's <code>rollback_anchor</code> before its branch is created (this campaign captured it implicitly; the driver persists it). Bad merge → <code>git revert &lt;merge_sha&gt;</code>. The anchor also asserts the next issue branches from a fresh base (the #140 fix), not a stale sibling.</p>
+
+<h2>Deploy policy (AC1)</h2>
+<p><code>per-issue</code> (deploy + smoke each merge; safest, slowest), <code>batch</code> (deploy once at end), <code>none</code> (libraries / PR-terminal — this campaign). <code>has_deploy</code> + <code>smoke_gate</code> copied from <code>capabilities</code> into the state file (folded F4); <code>deploy: per-issue</code> with <code>has_deploy: false</code> is a rejected config error.</p>
+
+<h2>Resumption (AC1) — reconciliation table (folded F3)</h2>
+<p>The committed state file is the resumption substrate. Observed remote state wins over the stale queue value:</p>
+<div class="table-wrap"><table>
+<thead><tr><th>Real gh/git state</th><th>Reconciled action</th></tr></thead>
+<tbody>
+<tr><td>PR merged</td><td>mark <code>merged</code>, advance</td></tr>
+<tr><td>PR open, CI green</td><td>non-headless → merge + advance; headless → leave <code>pr_open</code>, stop</td></tr>
+<tr><td>PR open, CI red/pending</td><td>resume WF2 at Step 13</td></tr>
+<tr><td>no PR, branch has commits</td><td>resume WF2 at Step 9/11 per <code>resume_lib</code></td></tr>
+<tr><td>no PR, empty branch</td><td>resume WF2 at Step 8</td></tr>
+<tr><td>no branch</td><td>restart at WF2 Step 7 (fresh base)</td></tr>
+<tr><td><code>branch_preservation: discarded</code></td><td>honor the deferral, do not seek the branch</td></tr>
+<tr><td><code>branch_preservation: pushed</code></td><td>re-open per deferral reason when unblocked</td></tr>
+</tbody></table></div>
+<p>The driver decides only the driver-layer action; intra-WF2 resume is delegated to WF2's own <code>resume_lib</code> so the driver never re-implements step detection.</p>
+
+<h2><code>&lt;termination-rule&gt;</code> interplay (AC3 — not weakened)</h2>
+<p>The driver never re-enters or extends a WF2 run. Each iteration invokes <code>/rawgentic:implement-feature</code> fresh for one issue; that run terminates at Step 16 with all its gates. The driver observes the outcome and advances its own queue — it owns queue/deferral/anchor/policy, never a WF2 step.</p>
+
+<h2>Follow-up issues (AC4) — filed from this design once approved</h2>
+<ol>
+<li>Build the pattern + queue state schema + resumption contract.</li>
+<li>(evidence-gated) thin <code>driver_lib.py</code> validator — only if hand-maintained JSON proves error-prone.</li>
+<li>Parallel multi-issue execution — depends on worktrees (#136/#85); deferred.</li>
+</ol>
+
+<h2>Codex findings folded</h2>
+<div class="table-wrap"><table>
+<thead><tr><th>Sev</th><th>Finding</th><th>Fold</th></tr></thead>
+<tbody>
+<tr><td style="color:var(--rejected)">High</td><td>state machine excluded <code>pr_open</code> (headless needs it)</td><td>added <code>pr_open</code> status + transitions</td></tr>
+<tr><td style="color:var(--accent)">Med</td><td>DEFER branch preservation ambiguous</td><td><code>branch_preservation</code>/<code>deferred_branch</code> + rule</td></tr>
+<tr><td style="color:var(--accent)">Med</td><td>resumption only referenced, not specified</td><td>ordered reconciliation table</td></tr>
+<tr><td style="color:var(--accent)">Med</td><td><code>has_deploy</code>/<code>smoke_gate</code> absent from schema</td><td>added to <code>policy</code> from capabilities</td></tr>
+</tbody></table></div>
+
+<h2>Out of scope</h2>
+<p>Implementation (follow-ups above); parallel issue execution (#136/#85); changing any WF2 gate.</p>
+
+<footer>
+  Rendered from <code>docs/design/2026-07-04-multi-issue-driver.md</code> —
+  the Markdown file is the source of truth; this HTML is a static, standalone rendering for visual review.
+</footer>
+
+</body>
+</html>

--- a/docs/design/2026-07-04-multi-issue-driver.md
+++ b/docs/design/2026-07-04-multi-issue-driver.md
@@ -1,0 +1,129 @@
+# Design: autonomous multi-issue driver (#134)
+
+Date: 2026-07-04 · Issue #134 · Complexity: L program / M design · **design-only** (this issue is the design gate, not the build)
+
+## Problem
+
+WF2 is per-issue by contract: `<termination-rule>` ends the workflow at Step 16 and forbids auto-continuation. Running an autonomous backlog (N issues, push/PR/merge each) therefore means re-invoking the full 16-step skill N times with **no shared state**. This very campaign (#131→#132→#135→#133→#140→#138…, six issues merged) hand-rolled every missing piece:
+
+| Hand-rolled this campaign | Where it lived | Failure risk when improvised |
+|---|---|---|
+| Ordered queue with per-issue status | an impact-order list in the handoff | drift between "what's next" and reality |
+| Rollback anchor per issue | the base SHA captured at branch creation | none captured → can't cleanly revert a bad merge |
+| Alignment ledger (status changed mid-loop) | `claude_docs/session_notes/campaign-131-140.handoff.md` | lost across compaction if not written |
+| Inter-issue policy (review budget, never-Haiku) | operator memory + standing rules | silently forgotten mid-run |
+| DEFER (park an issue, keep going) | *never exercised* — no convention existed | an owner-reserved surface would have stalled the whole loop |
+
+Two real bugs this campaign traces directly to the missing structure: (a) #138 was committed to local `main` because no driver enforced "branch before first commit"; (b) #140 fixed a Step-7 base bug that only bites in a *multi-issue* loop (branching off a stale sibling). Both are exactly the failure modes a driver exists to prevent.
+
+## Decision (AC2): a documented orchestration PATTERN + a small committed state file — NOT a new skill
+
+**Recommendation: documented pattern, not a driver skill.** Rationale, leading with why the alternative loses:
+
+- **A driver skill adds ceremony where the agent is already competent.** The *looping* itself — "run WF2, on success advance, on DEFER park, repeat" — is control flow an orchestrator executes reliably without a skill (this campaign proved it: six issues, zero loop-control errors). A skill wrapping that loop would be mostly prose restating WF2's own contract.
+- **The value is in the CONVENTIONS, which are data + docs, not executable logic:** the queue schema, the DEFER taxonomy, the rollback-anchor protocol, and the resumption contract. Those are a documented pattern + one JSON state file, and (optionally) a *thin pure validator* — not a 16-step skill.
+- **A skill would be tempted to re-implement WF2's gates** (or worse, weaken them to "go faster across the backlog"). Keeping the driver as a pattern that invokes `/rawgentic:implement-feature` fresh per issue makes it structurally impossible to weaken WF2 — AC3.
+
+**What ships (in the follow-up build issue, not here):**
+1. `docs/multi-issue-driver.md` — the pattern: the loop, the policies, the resumption contract.
+2. A committed queue state file schema, `claude_docs/.driver-state/<campaign>.json` (per-campaign, so concurrent campaigns don't collide — mirrors the per-branch review-state pointer).
+3. OPTIONAL thin `hooks/driver_lib.py` — pure functions `validate_queue(state)`, `next_issue(state)`, `record_outcome(state, issue, outcome)`, `defer_issue(state, issue, reason)` — added ONLY if the state transitions prove error-prone in practice. Default: the pattern doc + hand-maintained JSON is enough (it was this campaign). File as a *second* follow-up, gated on evidence.
+
+## Queue schema (AC1)
+
+`claude_docs/.driver-state/<campaign>.json`:
+```json
+{
+  "schema_version": 1,
+  "campaign": "issues-131-140",
+  "policy": {"order": "impact", "deploy": "per-issue|batch|none",
+             "has_deploy": false, "smoke_gate": null,
+             "review_budget": 3, "never_haiku": true},
+  "base_default_branch_sha": "<origin/default HEAD when the campaign started>",
+  "issues": [
+    {"number": 133, "status": "merged", "pr": 145, "merge_sha": "ab650ac",
+     "rollback_anchor": "5591174", "deferred_reason": null,
+     "deferred_branch": null, "branch_preservation": null},
+    {"number": 137, "status": "queued|in_progress|pr_open|merged|deferred|abandoned",
+     "pr": null, "merge_sha": null, "rollback_anchor": null,
+     "deferred_reason": null, "deferred_branch": null, "branch_preservation": null}
+  ]
+}
+```
+**Status transitions [Codex F1 — `pr_open` is a first-class state so headless is representable]:**
+```
+queued → in_progress → { pr_open | merged | deferred | abandoned }
+pr_open → { merged | deferred | abandoned }     # headless stops at pr_open; a human/merge-driver advances it
+```
+Only one issue `in_progress`/`pr_open` at a time (serial; parallel is out of scope — needs worktrees, #136/#85). `pr_open` is the terminal state for a headless driver (PR-terminal); a non-headless driver passes through it to `merged`.
+
+**`policy.has_deploy` / `policy.smoke_gate` [Codex F4]:** copied from `capabilities` at campaign start into the state file so the driver reads deploy-availability + the required smoke command from committed state, not ambient config. `deploy: "per-issue"` with `has_deploy: false` is a config error the driver rejects at start; `smoke_gate: null` with `deploy != none` means "deploy but no automated smoke" (log the gap, don't silently pass).
+
+## DEFER taxonomy (AC1)
+
+An issue hits a wall mid-build → park it with a typed reason and **continue the loop** (never stall the backlog):
+
+| DEFER type | Trigger | Example this program | Loop action |
+|---|---|---|---|
+| `owner-decision` | needs a human product/risk call | AskUserQuestion with no durable answer | park, surface in ledger, next issue |
+| `owner-reserved` | touches a surface the owner reserved | a run gated behind owner approval | park, note the gate, next issue |
+| `cross-repo` | change spans another repo | a fix needing an upstream PR first | park with the blocking dependency |
+| `budget` | token/time budget for the campaign exhausted | — | park remaining queued issues, stop cleanly |
+
+**Branch preservation on DEFER [Codex F2 — deterministic, persisted]:** the outcome is recorded in `branch_preservation` + `deferred_branch`, decided by this rule (no ambiguity for resumption):
+- **`pushed`** — the branch has ≥1 commit AND the deferral may be resumed later (`owner-decision`, `owner-reserved`, `cross-repo`): push it, set `deferred_branch: <name>`, `branch_preservation: "pushed"`. Resumption knows the work exists.
+- **`discarded`** — the branch has commits but the deferral abandons the approach: `git checkout <default> && git branch -D`, set `branch_preservation: "discarded"`, `deferred_branch: null`. Resumption must NOT expect the branch.
+- **`none`** — no commits were made before the wall (deferred at design/plan): nothing to preserve, `branch_preservation: "none"`.
+
+`budget` deferrals of not-yet-started issues stay `queued` (no branch, not `deferred`). The ledger records type + reason + these fields so resumption never assumes a branch that was discarded or loses work that was pushed.
+
+## Rollback-anchor protocol (AC1)
+
+Before each issue's branch is created, capture the current `origin/<default>` SHA as that issue's `rollback_anchor` (this campaign captured it implicitly as the branch base — the driver makes it explicit and persisted). On a bad merge/deploy discovered *after* merge: `git revert <merge_sha>` (preferred, preserves history) or reset a not-yet-pushed main to the anchor. The anchor also validates the next issue branches from a *fresh* base (the #140 fix) — driver asserts `new base == current origin/<default>`, not a stale sibling.
+
+## Deploy policy options (AC1)
+
+- **`per-issue`** (deploy-after-each): each merged issue deploys before the next starts. Safest for catching a regression early; slowest. Requires `has_deploy` + a smoke gate per issue.
+- **`batch`**: merge all, deploy once at the end. Faster; a late regression is harder to bisect (mitigated by per-issue rollback anchors).
+- **`none`**: library/PR-terminal campaigns (this one — rawgentic has no deploy). Queue advances on merge; no deploy step.
+Default = `none` for libraries, `per-issue` when `has_deploy` and not headless.
+
+## Interaction with `<termination-rule>` (AC3 — not weakened)
+
+The driver **never** re-enters or extends a WF2 run. Each queue iteration invokes `/rawgentic:implement-feature` **fresh** for one issue; that run terminates at Step 16 exactly as today (all gates, its own completion-gate). The driver observes the *outcome* (merged PR / DEFER) and advances its own queue state — it owns only queue/deferral/anchor/policy, never a WF2 step. WF2's per-issue termination is a precondition the driver relies on, not something it overrides.
+
+## Headless interplay
+
+In headless mode WF2 is PR-terminal (no merge/deploy). The driver therefore advances the queue on **PR creation**, not merge, when headless: status goes `in_progress → pr_open`, and a human (or a separate merge-driver) completes the merge. A non-headless driver advances on merge. This keeps the driver honest about what actually happened — it never marks `merged` on a run that only reached PR.
+
+## Resumption across sessions (AC1)
+
+The committed queue state file IS the resumption substrate (survives compaction/`/clear`, unlike in-context memory — the lesson of this campaign's handoff file). On resume: read `<campaign>.json`, find the single `in_progress`/`pr_open` issue (if any) and reconcile its recorded status against the real git/gh state. **Reconciliation table (precedence top-to-bottom; the observed remote state wins over the stale queue value) [Codex F3 — spelled out, not deferred to `resume_lib`]:**
+
+| Real gh/git state | Queue says | Reconciled action |
+|---|---|---|
+| PR merged | any | mark `merged` (record `merge_sha`), advance to next issue |
+| PR open, CI green | `in_progress`/`pr_open` | non-headless → merge then advance; headless → leave `pr_open`, stop |
+| PR open, CI red/pending | any | resume the WF2 run at Step 13 (push CI fixes) |
+| no PR, branch has commits | `in_progress` | resume the WF2 run at Step 9/11 per its own `resume_lib` on that branch |
+| no PR, branch exists no commits | `in_progress` | resume WF2 at Step 8 |
+| no branch | `in_progress` | restart the issue at WF2 Step 7 (branch from fresh `origin/<default>`) |
+| `branch_preservation: discarded` | `deferred` | do NOT look for the branch; honor the deferral, next issue |
+| `branch_preservation: pushed` | `deferred` | branch exists on origin; re-open per the deferral reason when unblocked |
+
+Within a single issue, the driver delegates the *intra-WF2* resume point to WF2's own `resume_lib` (it already encodes the Step-13/14/16 precedence) — the table above only decides the *driver-level* action (advance / merge / resume / restart / honor-defer). This keeps the driver from re-implementing WF2's step detection while still being fully specified at its own layer.
+
+## Follow-up issues (AC4) — filed from this design once approved
+1. **Build the documented pattern + queue state schema** (`docs/multi-issue-driver.md` + `claude_docs/.driver-state/` schema + resumption contract).
+2. **(evidence-gated) thin `driver_lib.py` validator** — only if hand-maintained JSON proves error-prone.
+3. **Parallel multi-issue execution** — depends on worktree isolation (#136/#85); explicitly deferred.
+
+## Codex adversarial review — findings folded (2026-07-04, 0 Critical / 1 High / 3 Medium)
+1. [High] state machine excluded `pr_open` but headless needs it → added `pr_open` status + transitions (headless-terminal).
+2. [Medium] DEFER branch preservation ambiguous → `branch_preservation: pushed|discarded|none` + `deferred_branch` fields + deterministic rule.
+3. [Medium] resumption reconciliation only referenced, not specified → added the ordered reconciliation table (driver layer) that delegates only intra-WF2 resume to `resume_lib`.
+4. [Medium] `has_deploy`/`smoke_gate` referenced but absent from schema → added to `policy`, copied from `capabilities` at campaign start.
+No Critical/blocker → no design loop-back (lean policy); folded in place. Report: `docs/reviews/2026-07-04-multi-issue-driver-md-2026-07-04.md`.
+
+## Out of scope
+Implementation (follow-ups above); parallel issue execution (#136/#85); changing any WF2 gate.

--- a/docs/reviews/2026-07-04-multi-issue-driver-md-2026-07-04.md
+++ b/docs/reviews/2026-07-04-multi-issue-driver-md-2026-07-04.md
@@ -1,0 +1,48 @@
+# Adversarial Review — 2026-07-04-multi-issue-driver.md
+
+- Date: 2026-07-04
+- Artifact type: design
+- Reviewer: Codex (model config-default, reasoning effort high)
+- Findings: 4 (Critical 0, High 1, Medium 3, Low 0)
+
+## Summary
+
+The artifact proposes a documented multi-issue orchestration pattern plus a committed queue state file, but several state-machine and resumption details are internally inconsistent or delegated to unspecified future text. The largest risk is that the headless path cannot be represented by the schema as written.
+
+## Findings
+
+### 1. [High] internal-consistency · high confidence — Queue schema (AC1) / Headless interplay
+
+> Status transitions: `queued → in_progress → {merged | deferred | abandoned}`. Only one issue `in_progress` at a time (serial; parallel is out of scope — needs worktrees, #136/#85).
+
+The declared state machine excludes `pr_open`, but the Headless interplay section later requires `in_progress → pr_open`. A headless implementation following the schema cannot persist the required terminal PR state, so validation, resumption, or queue advancement will either reject valid headless runs or mark them incorrectly.
+
+**Recommendation:** In `Queue schema (AC1)`, add `pr_open` to the allowed status values and update the transition rule to include `in_progress → pr_open`, with explicit allowed next states from `pr_open`.
+
+### 2. [Medium] ambiguity · high confidence — DEFER taxonomy (AC1)
+
+> A deferred issue's branch is left pushed (if any commits) or discarded per its rollback anchor; the ledger records the type + reason so resumption knows why.
+
+The DEFER behavior leaves an implementation choice between preserving and discarding a partially built branch, but does not define who decides, when it happens, or how the queue records which path was taken. Resumption can therefore mis-handle a deferred issue by assuming a branch exists when it was discarded, or by losing committed work that was expected to remain available.
+
+**Recommendation:** In `DEFER taxonomy (AC1)`, add explicit fields such as `deferred_branch`, `branch_preservation: pushed|discarded|none`, and a deterministic rule for when each value is used.
+**Ambiguity:** The phrase gives two possible branch outcomes without specifying the decision rule or persisted state.
+
+### 3. [Medium] completeness · high confidence — Resumption across sessions (AC1)
+
+> The pattern doc specifies the exact reconciliation, mirroring WF2's own `resume_lib` precedence so a half-done issue resumes at the right point rather than restarting.
+
+The artifact claims exact reconciliation is specified, but this design text does not provide the reconciliation rules and instead depends on an external `resume_lib` precedence that is not included in the provided artifact. An implementer cannot determine from this design how to resolve conflicting states such as local branch exists, PR open, queue says `in_progress`, and remote already merged.
+
+**Recommendation:** In `Resumption across sessions (AC1)`, include the actual ordered reconciliation table for queue status, branch state, PR state, and merge state, instead of deferring to `resume_lib` by reference.
+
+### 4. [Medium] completeness · medium confidence — Deploy policy options (AC1)
+
+> Requires `has_deploy` + a smoke gate per issue.
+
+The deploy policy introduces required capabilities, but neither `has_deploy` nor the smoke gate is present in the queue schema or policy object. A driver implementing `per-issue` cannot tell from the committed state file whether deploy is available or what gate must pass before advancing.
+
+**Recommendation:** In `Queue schema (AC1)`, extend `policy` with explicit `has_deploy` and `smoke_gate` fields, or state that those values are supplied by a named external config and define how missing values are handled.
+
+---
+_Report-only: this review does not edit the artifact. Findings are advisory; incorporate them at your discretion._

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -34,7 +34,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.50.0"
+    assert plugin["version"] == "2.50.1"
 
 
 def test_descriptions_consistent_count():


### PR DESCRIPTION
## Summary

Design-only deliverable for #134 (this issue is the design gate, not the build). Designs an **autonomous multi-issue driver** that loops WF2 over a backlog queue, grounded in what the #131–140 campaign hand-rolled (queue = impact-order list, ledger = handoff file, rollback anchors = base SHAs, and the DEFER mechanism that never had a convention).

## Recorded decision (AC2): documented PATTERN, not a new skill

The looping is control flow the orchestrator already runs reliably (six issues this campaign, zero loop-control errors); the value is in the **conventions** — queue schema, DEFER taxonomy, rollback-anchor protocol, resumption contract — which are docs + one JSON state file, not a 16-step skill. Keeping it a pattern that invokes `/rawgentic:implement-feature` fresh per issue makes weakening WF2 structurally impossible (AC3).

## Covers (AC1)

Queue schema (`claude_docs/.driver-state/<campaign>.json`, status incl. `pr_open` for headless); DEFER taxonomy (owner-decision / owner-reserved / cross-repo / budget) + a deterministic branch-preservation rule (pushed/discarded/none); rollback-anchor protocol; deploy policy options (per-issue/batch/none with `has_deploy`/`smoke_gate`); a full resumption reconciliation table that delegates only intra-WF2 resume to `resume_lib`.

## Deliverables

- `docs/design/2026-07-04-multi-issue-driver.md` + standalone HTML (repo convention). **Note:** the issue said `docs/planning/`, but rawgentic's established home for design docs is `docs/design/` (all sibling designs + HTML live there) — used that for consistency.
- Codex adversarial pass folded — 0 Critical / 1 High / 3 Medium (`pr_open` state; DEFER branch-preservation fields; resumption table spelled out; `has_deploy`/`smoke_gate` in schema). Report committed.
- Build follow-up filed: **#148** (AC4). The evidence-gated `driver_lib.py` validator and parallel execution (#136/#85) are noted, not filed speculatively.

## Gates

- No code changed (design + docs only); version 2.50.0 → 2.50.1; version-pin test updated; registration suite 29 passed; security scan PASS.

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
