### PR TITLE
feat(wf2): probe branch protection + state which layer enforces each gate (#139)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.51.0",
+  "version": "2.52.0",
   "description": "12 SDLC workflow skills + 4 workspace management + 1 planning skill + 1 security skill + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, refactoring, adversarial review, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, peer consultation, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -714,6 +714,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v2.52.0 (2026-07-04)
+- **Branch-protection probe + gate-layer honesty (#139).** WF2 Step 1 probes `gh api repos/<r>/branches/<default>/protection` (advisory, fail-open) and classifies it via `plan_lib.classify_branch_protection` (protected / unprotected / unknown). The Step 12 PR body's Quality Gate Summary then states which layer actually enforces the shipping gates (e.g. "Branch protection: none — review/CI gates enforced by WF2 only, not by GitHub"), so a passed PR doesn't overstate its server-side protection. Step 14 calls `plan_lib.quarantine_protection_contradiction` to catch the quarantined-CI × required-status-check case (a merge that would hit a server-side wall) before attempting it. No gate pass/fail logic changed — visibility only.
+
 ### v2.51.0 (2026-07-04)
 - **CI-quarantine state — CI present but declared untrustworthy no longer gates (#137).** A repo whose CI is chronically red for reasons unrelated to any diff can declare `ci.status: "quarantined"` (+ required `ci.quarantineReason`, optional `ci.quarantinedSince`) in `.rawgentic.json`. `capabilities_lib.derive` surfaces `ci_quarantined`/`ci_quarantine_reason`/`ci_quarantined_since` (quarantine of an undeclared or reason-less CI is a config error). WF2/WF3's CI step then **observes** the run but records it as a visible non-gate ("CI quarantined (<reason>): run <status>, not gating") — never blocks, never claims green; completion-gate item 6 becomes "CI passed OR quarantine recorded"; a Step-1 nag fires when a quarantine is >30 days old. Quarantine is a human declaration only — the workflow never enters or lifts it.
 

--- a/docs/reviews/wf2-139-review-diff-2026-07-04.md
+++ b/docs/reviews/wf2-139-review-diff-2026-07-04.md
@@ -1,0 +1,42 @@
+# Adversarial Review — .wf2-139-review.diff
+
+- Date: 2026-07-04
+- Artifact type: diff
+- Reviewer: Codex (model config-default, reasoning effort high)
+- Findings: 3 (Critical 0, High 1, Medium 2, Low 0)
+
+## Summary
+
+The change adds an advisory branch-protection probe and a pre-merge contradiction check for CI quarantine versus required status checks. The main risk is that the probe can misclassify unavailable or malformed protection responses as definitive states, which undermines the gate-layer honesty it is meant to add.
+
+## Findings
+
+### 1. [High] correctness · high confidence — hooks/plan_lib.py: classify_branch_protection
+
+> +    if status_code == 404:
+> +        return ("unprotected", {"required_checks": []})
+
+The classifier treats every 404 as proof that the branch is unprotected, but the surrounding workflow command can also produce a 404 for wrong repo, wrong branch, inaccessible resource, or a malformed branch path. That makes an absent/corrupt probe look like a successful unprotected result, so the PR body can falsely state GitHub does not enforce protection and Step 14 will skip the contradiction check.
+
+**Recommendation:** Change `classify_branch_protection` so 404 is only `unprotected` when the response body is the expected branch-protection-not-found shape; otherwise return `unknown`. Also make Step 1 record probe command failures separately from a confirmed unprotected branch.
+
+### 2. [Medium] correctness · high confidence — skills/implement-feature/SKILL.md: Step 1 item 9
+
+> +   gh api repos/${capabilities.repo}/branches/${capabilities.default_branch}/protection
+
+The probe interpolates the branch name directly into a URL path without encoding. A default branch containing a slash or other path-significant character can hit the wrong endpoint or return 404, which the new classifier then records as `unprotected`.
+
+**Recommendation:** In Step 1 item 9, require URL-encoding `capabilities.default_branch` before constructing the API path, or use a helper that builds the `branches/{branch}/protection` request safely.
+
+### 3. [Medium] correctness · high confidence — hooks/plan_lib.py: classify_branch_protection
+
+> +    if status_code == 200 and isinstance(body, dict):
+> +        rsc = body.get("required_status_checks") or {}
+> +        checks: list[str] = []
+
+A 200 response with a malformed or unexpected body is still classified as `protected` with an empty `required_checks` list. That makes a corrupt parse silently pass as valid protection data, so `quarantine_protection_contradiction` will not stop a merge even when required checks may exist but were not parsed.
+
+**Recommendation:** Change `classify_branch_protection` to return `unknown` when `status_code == 200` but the protection body has an unexpected type or malformed `required_status_checks` shape; only return `protected` after successfully recognizing the relevant fields.
+
+---
+_Report-only: this review does not edit the artifact. Findings are advisory; incorporate them at your discretion._

--- a/hooks/plan_lib.py
+++ b/hooks/plan_lib.py
@@ -1280,33 +1280,56 @@ def validate_build_receipt(
 # --- Branch-protection probe classification (#139) ---
 
 
+_PROTECTION_KEYS = frozenset({
+    "required_status_checks", "required_pull_request_reviews", "enforce_admins",
+    "restrictions", "url", "required_signatures", "required_linear_history",
+    "allow_force_pushes", "allow_deletions", "required_conversation_resolution",
+    "lock_branch", "block_creations",
+})
+
+
 def classify_branch_protection(status_code: int, body) -> tuple[str, dict]:
     """Classify a `gh api .../branches/<b>/protection` result (#139).
 
     Returns (state, details) where state is 'protected' | 'unprotected' |
-    'unknown'. The probe is ADVISORY and fail-open: a 403/401 (not visible) or
-    any unexpected error is 'unknown', never a run failure. 404 = the branch has
-    no protection. 200 parses required status checks (new `checks` or legacy
-    `contexts` shape) and whether reviews are required. `details` always carries
-    `required_checks: list[str]`.
+    'unknown'. The probe is ADVISORY and fail-open, but it must NOT misread an
+    ambiguous result as a definitive one (that would overstate OR understate
+    protection):
+    - 404 is 'unprotected' ONLY when the body is the GitHub "Branch not
+      protected" shape; any other 404 (wrong repo/branch, inaccessible) is
+      'unknown', so an absent probe never reads as a confirmed no-protection.
+    - 200 is 'protected' ONLY when the body is a recognizable protection object;
+      a 200 with a non-dict, unrecognized, or malformed `required_status_checks`
+      body is 'unknown' (a corrupt parse must not silently pass as valid data,
+      or the contradiction check would be skipped).
+    - 403/401/other -> 'unknown'.
+    `details` always carries `required_checks: list[str]`.
     """
-    if status_code == 200 and isinstance(body, dict):
-        rsc = body.get("required_status_checks") or {}
+    if status_code == 200:
+        if not isinstance(body, dict) or not (_PROTECTION_KEYS & set(body)):
+            return ("unknown", {"required_checks": []})
         checks: list[str] = []
-        if isinstance(rsc, dict):
+        if "required_status_checks" in body:
+            rsc = body["required_status_checks"]
+            if not isinstance(rsc, dict):
+                return ("unknown", {"required_checks": []})
             if isinstance(rsc.get("checks"), list):
                 checks = [c.get("context") for c in rsc["checks"]
                           if isinstance(c, dict) and isinstance(c.get("context"), str)]
             elif isinstance(rsc.get("contexts"), list):
                 checks = [c for c in rsc["contexts"] if isinstance(c, str)]
+            elif "checks" in rsc or "contexts" in rsc:
+                return ("unknown", {"required_checks": []})  # present but wrong type
         reviews = body.get("required_pull_request_reviews")
         return ("protected", {
             "required_checks": checks,
             "required_reviews": isinstance(reviews, dict),
         })
-    if status_code == 404:
+    if status_code == 404 and isinstance(body, dict) \
+            and "not protected" in str(body.get("message", "")).lower():
         return ("unprotected", {"required_checks": []})
-    # 403/401 (forbidden/not visible) or any other status -> fail-open unknown.
+    # 403/401 (forbidden/not visible), a non-"not protected" 404, or any other
+    # status -> fail-open unknown.
     return ("unknown", {"required_checks": []})
 
 

--- a/hooks/plan_lib.py
+++ b/hooks/plan_lib.py
@@ -1277,6 +1277,81 @@ def validate_build_receipt(
     return (len(errors) == 0, errors, normalized)
 
 
+# --- Branch-protection probe classification (#139) ---
+
+
+def classify_branch_protection(status_code: int, body) -> tuple[str, dict]:
+    """Classify a `gh api .../branches/<b>/protection` result (#139).
+
+    Returns (state, details) where state is 'protected' | 'unprotected' |
+    'unknown'. The probe is ADVISORY and fail-open: a 403/401 (not visible) or
+    any unexpected error is 'unknown', never a run failure. 404 = the branch has
+    no protection. 200 parses required status checks (new `checks` or legacy
+    `contexts` shape) and whether reviews are required. `details` always carries
+    `required_checks: list[str]`.
+    """
+    if status_code == 200 and isinstance(body, dict):
+        rsc = body.get("required_status_checks") or {}
+        checks: list[str] = []
+        if isinstance(rsc, dict):
+            if isinstance(rsc.get("checks"), list):
+                checks = [c.get("context") for c in rsc["checks"]
+                          if isinstance(c, dict) and isinstance(c.get("context"), str)]
+            elif isinstance(rsc.get("contexts"), list):
+                checks = [c for c in rsc["contexts"] if isinstance(c, str)]
+        reviews = body.get("required_pull_request_reviews")
+        return ("protected", {
+            "required_checks": checks,
+            "required_reviews": isinstance(reviews, dict),
+        })
+    if status_code == 404:
+        return ("unprotected", {"required_checks": []})
+    # 403/401 (forbidden/not visible) or any other status -> fail-open unknown.
+    return ("unknown", {"required_checks": []})
+
+
+def branch_protection_line(state: str, details: dict) -> str:
+    """One-line summary for session notes + the Step 12 PR body (#139).
+
+    States plainly which layer enforces the shipping gates so a passed PR does
+    not overstate its server-side protection.
+    """
+    checks = (details or {}).get("required_checks") or []
+    if state == "protected":
+        parts = []
+        if checks:
+            parts.append("required checks: " + ", ".join(checks))
+        if (details or {}).get("required_reviews"):
+            parts.append("reviews required")
+        detail = f" ({'; '.join(parts)})" if parts else ""
+        return f"Branch protection: enabled{detail} — GitHub enforces these server-side."
+    if state == "unprotected":
+        return ("Branch protection: none — review/CI gates enforced by WF2 only, "
+                "not by GitHub (a direct push or unreviewed merge is not blocked server-side).")
+    return ("Branch protection: unknown (protection API not visible — e.g. token "
+            "lacks scope) — treat as WF2-only enforcement.")
+
+
+def quarantine_protection_contradiction(
+    ci_quarantined: bool,
+    protection_state: str,
+    required_checks: list,
+) -> str | None:
+    """Flag the quarantined-CI × required-status-check contradiction (#139).
+
+    If CI is quarantined (WF2 won't gate on it) but branch protection REQUIRES
+    status checks, a merge attempt will hit a server-side wall. Surface it before
+    Step 14 rather than merging into the wall. Returns a message or None.
+    """
+    if ci_quarantined and protection_state == "protected" and required_checks:
+        return (
+            "CONTRADICTION: CI is quarantined (WF2 treats it as non-gating) but "
+            f"branch protection requires status checks {list(required_checks)} — "
+            "a merge will be blocked server-side. Lift the quarantine, fix CI, or "
+            "adjust protection before attempting Step 14.")
+    return None
+
+
 # --- Committed per-branch review-state pointer (.rawgentic/review-state/) ---
 
 _REVIEW_STATE_DIR = ".rawgentic/review-state"

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -473,6 +473,12 @@ This enables workflow resumption if context is lost.
 
 8. **CI-quarantine staleness nag (#137):** if `capabilities.ci_quarantined == true` and `capabilities.ci_quarantined_since` is set, compute `(current local date from the workflow env) − (the YYYY-MM-DD date) > 30 calendar days`; if so, log a "fix or retire CI" advisory in session notes (quarantine is meant to be temporary; this keeps it from silently becoming permanent). Advisory only — never blocks. `ci_quarantined_since` is guaranteed a valid ISO date by `capabilities_lib` (a malformed value already fails the derive), so no parse-guard is needed here. If `ci_quarantined_since` is unset, note that a date should be added so staleness can be tracked.
 
+9. **Branch-protection probe (#139 — advisory, fail-open).** So a passed PR does not overstate its server-side protection, probe once here:
+   ```bash
+   gh api repos/${capabilities.repo}/branches/${capabilities.default_branch}/protection
+   ```
+   Capture the HTTP status and body, then classify with `plan_lib.classify_branch_protection(status, body)` → `(state, details)` (state ∈ `protected`/`unprotected`/`unknown`; 404→unprotected, 403/401/error→unknown — NEVER fail the run on an API error). Record `plan_lib.branch_protection_line(state, details)` in session notes; carry `state` + `details["required_checks"]` forward for Step 12 (PR body) and Step 14 (contradiction check).
+
 ### Failure Modes
 - Issue does not exist -> ask for correct number
 - Issue is closed -> ask if user wants to reopen or use different issue
@@ -1348,6 +1354,7 @@ recorded for the PR body and session notes.
    - Implementation drift check (Step 9): N findings
    - Code review (Step 11): N findings (all Critical/High resolved)
    - Security scan (Step 11.5): N blocking resolved, N advisory, skipped: <kinds or "none">
+   - <the `plan_lib.branch_protection_line(...)` string from Step 1 item 9 (#139) — states which layer enforces the gates>
    ```
    The `## Deferred verification` heading is the one canonical string (Step 9, Step 16, and `<completion-gate>` all key on it); do not reword it.
 
@@ -1398,6 +1405,8 @@ CI status, quarantine notice, or skip confirmation.
 **[Headless: AUTO-RESOLVE — SKIP THIS ENTIRE STEP. In headless mode the PR is the terminal deliverable: do NOT merge, do NOT deploy, do NOT SSH anywhere. Proceed directly to Step 16. CI handles deployment when a human merges the PR. (The `ssh`/`script`/`compose` deploy paths below would otherwise run unconditionally — this is the gap that caused the chorestory #309 dev-VM incident.) `wal-guard` also blocks any SSH at the hook layer as a backstop. Append the skip marker per Step 16 item 1b.]**
 
 **P15 pre-merge gate:** re-read via `plan_lib.read_review_state(repo_root, branch)`. If None or `last_review_log_status != "applied"`, refuse to merge. Cleanup of `claude_docs/.wf2-state/<issue>/` AND the branch's `.rawgentic/review-state/<branch-sanitized>.json` happens on merge success.
+
+**Quarantine × protection contradiction check (#139):** before attempting the merge, call `plan_lib.quarantine_protection_contradiction(capabilities.ci_quarantined, <protection state from Step 1 item 9>, <required_checks>)`. A non-None message means CI is quarantined (WF2 non-gating) but branch protection REQUIRES a status check — the squash-merge below would hit a server-side wall. Surface the message to the user and STOP rather than merging into the wall. **[Headless: QUESTION — post the contradiction message, suspend for a human to lift the quarantine, fix CI, or adjust protection.]**
 
 1. **Merge PR (squash merge):**
    ```bash

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -473,11 +473,12 @@ This enables workflow resumption if context is lost.
 
 8. **CI-quarantine staleness nag (#137):** if `capabilities.ci_quarantined == true` and `capabilities.ci_quarantined_since` is set, compute `(current local date from the workflow env) − (the YYYY-MM-DD date) > 30 calendar days`; if so, log a "fix or retire CI" advisory in session notes (quarantine is meant to be temporary; this keeps it from silently becoming permanent). Advisory only — never blocks. `ci_quarantined_since` is guaranteed a valid ISO date by `capabilities_lib` (a malformed value already fails the derive), so no parse-guard is needed here. If `ci_quarantined_since` is unset, note that a date should be added so staleness can be tracked.
 
-9. **Branch-protection probe (#139 — advisory, fail-open).** So a passed PR does not overstate its server-side protection, probe once here:
+9. **Branch-protection probe (#139 — advisory, fail-open).** So a passed PR does not overstate its server-side protection, probe once here. **URL-encode the branch** (a default branch like `release/v1` has a `/` that would otherwise hit the wrong endpoint and look like a 404):
    ```bash
-   gh api repos/${capabilities.repo}/branches/${capabilities.default_branch}/protection
+   BR_ENC=$(printf %s "${capabilities.default_branch}" | jq -sRr @uri)
+   gh api "repos/${capabilities.repo}/branches/${BR_ENC}/protection" -i
    ```
-   Capture the HTTP status and body, then classify with `plan_lib.classify_branch_protection(status, body)` → `(state, details)` (state ∈ `protected`/`unprotected`/`unknown`; 404→unprotected, 403/401/error→unknown — NEVER fail the run on an API error). Record `plan_lib.branch_protection_line(state, details)` in session notes; carry `state` + `details["required_checks"]` forward for Step 12 (PR body) and Step 14 (contradiction check).
+   Capture the HTTP status AND body, then classify with `plan_lib.classify_branch_protection(status, body)` → `(state, details)`. The classifier is strict: only the GitHub "Branch not protected" 404 body → `unprotected`; a 200 that isn't a recognizable protection object, or any 403/401/other → `unknown`. **NEVER fail the run on an API error** — record a probe-command failure (non-zero `gh` exit, network error) as `unknown` in session notes, *distinct* from a confirmed `unprotected`. Record `plan_lib.branch_protection_line(state, details)` in session notes; carry `state` + `details["required_checks"]` forward for Step 12 (PR body) and Step 14 (contradiction check).
 
 ### Failure Modes
 - Issue does not exist -> ask for correct number

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -34,7 +34,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.51.0"
+    assert plugin["version"] == "2.52.0"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_headless.py
+++ b/tests/hooks/test_headless.py
@@ -1264,7 +1264,7 @@ class TestHeadlessInteractionBlock:
 
     # Expected [Headless annotation counts per skill
     EXPECTED_COUNTS = {
-        "implement-feature": 31,  # 17 base + 7 P15 (#73): Step 5 warn/halt/decompose + 8a ambiguity/dispatch-failure/design-flaw/headless-suspend + Step 11 deferred-High + 1 Step 11.5 security-scan block + 1 Step 2 trivial-work suggestion + 3 headless remote-ops guards (#47): Step 2 SSH-probe skip, Step 14 merge/deploy skip, Step 15 post-deploy skip + 1 Step 7 base-mismatch ERROR (#140) + 1 Step 13 CI-quarantine-change approval (#137)
+        "implement-feature": 32,  # 17 base + 7 P15 (#73): Step 5 warn/halt/decompose + 8a ambiguity/dispatch-failure/design-flaw/headless-suspend + Step 11 deferred-High + 1 Step 11.5 security-scan block + 1 Step 2 trivial-work suggestion + 3 headless remote-ops guards (#47): Step 2 SSH-probe skip, Step 14 merge/deploy skip, Step 15 post-deploy skip + 1 Step 7 base-mismatch ERROR (#140) + 1 Step 13 CI-quarantine-change approval (#137) + 1 Step 14 quarantine×protection contradiction (#139)
         "fix-bug": 11,            # 10 interaction points + 1 Step 2 trivial-work suggestion
     }
 

--- a/tests/hooks/test_plan_lib.py
+++ b/tests/hooks/test_plan_lib.py
@@ -1593,3 +1593,48 @@ class TestBranchProtection:
     def test_no_contradiction_when_no_required_checks(self):
         mod = _reload_plan_lib()
         assert mod.quarantine_protection_contradiction(True, "protected", []) is None
+
+
+class TestBranchProtectionHardening:
+    """Codex Step-11 folds (#139)."""
+
+    def test_404_only_unprotected_for_not_protected_message(self):
+        mod = _reload_plan_lib()
+        # genuine "branch not protected"
+        st, _ = mod.classify_branch_protection(404, {"message": "Branch not protected"})
+        assert st == "unprotected"
+
+    def test_404_generic_not_found_is_unknown(self):
+        """A 404 for a wrong repo/branch/inaccessible resource is NOT proof of
+        an unprotected branch — must be unknown, not a false 'no protection'."""
+        mod = _reload_plan_lib()
+        st, _ = mod.classify_branch_protection(404, {"message": "Not Found"})
+        assert st == "unknown"
+
+    def test_404_non_dict_body_is_unknown(self):
+        mod = _reload_plan_lib()
+        st, _ = mod.classify_branch_protection(404, "Not Found")
+        assert st == "unknown"
+
+    def test_200_non_dict_body_is_unknown(self):
+        mod = _reload_plan_lib()
+        st, _ = mod.classify_branch_protection(200, "surprise")
+        assert st == "unknown"
+
+    def test_200_unrecognized_body_is_unknown(self):
+        """A 200 whose body is not a protection object must not read as protected."""
+        mod = _reload_plan_lib()
+        st, _ = mod.classify_branch_protection(200, {"foo": "bar"})
+        assert st == "unknown"
+
+    def test_200_malformed_required_checks_is_unknown(self):
+        mod = _reload_plan_lib()
+        st, _ = mod.classify_branch_protection(200, {"required_status_checks": "nope"})
+        assert st == "unknown"
+
+    def test_200_enforce_admins_only_is_protected_no_checks(self):
+        """A valid protection object with no required checks is still protected."""
+        mod = _reload_plan_lib()
+        st, details = mod.classify_branch_protection(200, {"enforce_admins": {"enabled": True}})
+        assert st == "protected"
+        assert details["required_checks"] == []

--- a/tests/hooks/test_plan_lib.py
+++ b/tests/hooks/test_plan_lib.py
@@ -1527,3 +1527,69 @@ class TestDeferralGateHardening:
         mod = _reload_plan_lib()
         ok, errs = mod.assert_pr_body_has_deferred_section("## Summary\n", [])
         assert ok is True and errs == []
+
+
+# --- #139: branch-protection probe classification ---
+
+class TestBranchProtection:
+    def test_protected_with_required_checks(self):
+        mod = _reload_plan_lib()
+        body = {
+            "required_status_checks": {"checks": [{"context": "test"}, {"context": "lint"}]},
+            "required_pull_request_reviews": {"required_approving_review_count": 1},
+        }
+        state, details = mod.classify_branch_protection(200, body)
+        assert state == "protected"
+        assert set(details["required_checks"]) == {"test", "lint"}
+        assert details["required_reviews"] is True
+
+    def test_protected_contexts_legacy_shape(self):
+        mod = _reload_plan_lib()
+        body = {"required_status_checks": {"contexts": ["ci/build"]}}
+        state, details = mod.classify_branch_protection(200, body)
+        assert state == "protected"
+        assert details["required_checks"] == ["ci/build"]
+
+    def test_unprotected_on_404(self):
+        mod = _reload_plan_lib()
+        state, details = mod.classify_branch_protection(404, {"message": "Branch not protected"})
+        assert state == "unprotected"
+        assert details["required_checks"] == []
+
+    def test_unknown_on_403(self):
+        mod = _reload_plan_lib()
+        state, _ = mod.classify_branch_protection(403, {"message": "Forbidden"})
+        assert state == "unknown"
+
+    def test_unknown_on_other_error(self):
+        mod = _reload_plan_lib()
+        state, _ = mod.classify_branch_protection(500, {})
+        assert state == "unknown"
+
+    def test_protection_line_unprotected(self):
+        mod = _reload_plan_lib()
+        line = mod.branch_protection_line("unprotected", {"required_checks": []})
+        assert "none" in line.lower()
+        assert "WF2 only" in line or "wf2" in line.lower()
+
+    def test_protection_line_protected(self):
+        mod = _reload_plan_lib()
+        line = mod.branch_protection_line("protected", {"required_checks": ["test"], "required_reviews": True})
+        assert "test" in line
+
+    def test_contradiction_when_quarantined_and_required_checks(self):
+        mod = _reload_plan_lib()
+        msg = mod.quarantine_protection_contradiction(True, "protected", ["test"])
+        assert msg is not None and "quarantin" in msg.lower()
+
+    def test_no_contradiction_when_not_quarantined(self):
+        mod = _reload_plan_lib()
+        assert mod.quarantine_protection_contradiction(False, "protected", ["test"]) is None
+
+    def test_no_contradiction_when_unprotected(self):
+        mod = _reload_plan_lib()
+        assert mod.quarantine_protection_contradiction(True, "unprotected", []) is None
+
+    def test_no_contradiction_when_no_required_checks(self):
+        mod = _reload_plan_lib()
+        assert mod.quarantine_protection_contradiction(True, "protected", []) is None

--- a/tests/test_wf2_clarity.py
+++ b/tests/test_wf2_clarity.py
@@ -339,7 +339,8 @@ class TestBranchProtectionProbe:
         assert s1, "Step 1 not found"
         body = s1.group(0)
         assert "classify_branch_protection" in body
-        assert "branches/${capabilities.default_branch}/protection" in body
+        assert "/protection" in body
+        assert "@uri" in body or "URL-encode" in body  # branch URL-encoded (#139 F2)
         assert "fail-open" in body.lower() or "never fail the run" in body.lower()
 
     def test_step12_pr_body_has_protection_line(self):

--- a/tests/test_wf2_clarity.py
+++ b/tests/test_wf2_clarity.py
@@ -329,3 +329,25 @@ class TestCiQuarantine:
         s1 = re.search(r"## Step 1:.*?(?=\n## Step 2:)", _text(), re.DOTALL)
         assert s1, "Step 1 not found"
         assert "ci_quarantined" in s1.group(0) and "30 calendar days" in s1.group(0)
+
+
+# --- #139: branch-protection probe + gate-layer honesty ---
+
+class TestBranchProtectionProbe:
+    def test_step1_probes_protection(self):
+        s1 = re.search(r"## Step 1:.*?(?=\n## Step 2:)", _text(), re.DOTALL)
+        assert s1, "Step 1 not found"
+        body = s1.group(0)
+        assert "classify_branch_protection" in body
+        assert "branches/${capabilities.default_branch}/protection" in body
+        assert "fail-open" in body.lower() or "never fail the run" in body.lower()
+
+    def test_step12_pr_body_has_protection_line(self):
+        s12 = re.search(r"## Step 12:.*?(?=\n## Step 13:)", _text(), re.DOTALL)
+        assert s12, "Step 12 not found"
+        assert "branch_protection_line" in s12.group(0)
+
+    def test_step14_checks_quarantine_protection_contradiction(self):
+        s14 = re.search(r"## Step 14:.*?(?=\n## Step 15:)", _text(), re.DOTALL)
+        assert s14, "Step 14 not found"
+        assert "quarantine_protection_contradiction" in s14.group(0)


### PR DESCRIPTION
## Summary

Branch-protection probe + gate-layer honesty (#139): so a PR that passed WF2's gates doesn't overstate its *server-side* protection. Field report (SayStory campaign): the repo had no branch protection, so WF2's shipping gates ran fine but were moot as enforcement — nothing server-side blocked a direct push or unreviewed merge.

## What's in

- **`plan_lib` helpers:** `classify_branch_protection(status, body)` → `protected | unprotected | unknown` (advisory, fail-open); `branch_protection_line(state, details)` states which layer enforces the gates; `quarantine_protection_contradiction(...)` flags quarantined-CI × required-status-check before a doomed merge.
- **WF2 Step 1** probes `gh api .../branches/<default>/protection` (URL-encoded branch) and records the classification. **Step 12** PR body Quality Gate Summary carries the protection line ("Branch protection: none — enforced by WF2 only, not by GitHub"). **Step 14** pre-merge runs the contradiction check. No gate pass/fail logic changed.

## Reviews folded (cross-model Codex, report-only)

**Step 11 diff pass** — 0 Critical / 1 High / 2 Medium:
- **[High]** a 404 was always read as "unprotected" — but a wrong-repo/branch/inaccessible 404 would then falsely claim GitHub enforces nothing. Now 404 → `unprotected` **only** for the GitHub "Branch not protected" body; else `unknown`.
- **[Medium]** a 200 with a non-dict/unrecognized/malformed body was classified `protected` with empty checks (which would skip the contradiction check). Now `unknown` unless it's a recognizable protection object with a well-typed `required_status_checks`.
- **[Medium]** Step 1 probe now URL-encodes the branch (a `release/v1` slash would hit the wrong endpoint) and records probe-command failures as `unknown`, distinct from a confirmed `unprotected`.

## Tests / gates

- 18 new tests (classification incl. hardening, line formatting, contradiction detection, drift guards).
- Full suite: **1623 passed / 5 failed** — the 5 are the pre-existing untracked-working-tree baseline (green in CI), not regressions.
- Security scan: PASS. Headless annotation count 31→32 (Step 14 contradiction QUESTION).

## Scope

**In:** probe, session-note/PR-body wording, contradiction check. **Out (per issue):** enabling/modifying protection; changing any gate's pass/fail logic.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
