### PR TITLE
docs(162): data-gate decision — abandon review switch per AC4, with evidence-recomputing drift guards

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.64.1",
+  "version": "2.64.2",
   "description": "6 SDLC workflow skills + 6 deprecated stubs (removal at v3.0.0) + 4 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/.rawgentic/review-state/feature-162-review-switch-data-gate-decision.json
+++ b/.rawgentic/review-state/feature-162-review-switch-data-gate-decision.json
@@ -1,0 +1,6 @@
+{
+  "branch": "feature/162-review-switch-data-gate-decision",
+  "last_review_log_status": "applied",
+  "schema_version": 1,
+  "ts": "2026-07-05T02:55:36Z"
+}

--- a/README.md
+++ b/README.md
@@ -640,7 +640,8 @@ The `docs/` directory contains detailed design documentation for contributors:
   - [Dual Memory Backend (draft)](docs/superpowers/specs/2026-04-08-dual-memory-backend-design.md)
 - **Planning documents** (in `docs/planning/`):
   - [Workflow Modernization Review (2026-07)](docs/planning/2026-07-04-workflow-modernization-review.md) ([visual](docs/planning/2026-07-04-workflow-modernization-review.html)) — 12-AC findings: model-routing topology verdict, /goal + multi-issue design, skill restructure, plugin dispositions, deprecation audit
-  - [Workflow Modernization Roadmap](docs/planning/2026-07-04-workflow-modernization-roadmap.md) — 4 milestones (M1 instrument → M2 restructure/v3.0.0 → M3 multi-issue → M4 headless), WF1-ready draft issues (not yet filed)
+  - [Workflow Modernization Roadmap](docs/planning/2026-07-04-workflow-modernization-roadmap.md) — 4 milestones (M1 instrument → M2 restructure/v3.0.0 → M3 multi-issue → M4 headless); issues filed under epics #167–#170
+  - [Issue #162 Data-Gate Decision (2026-07-05)](docs/measurements/2026-07-05-issue-162-data-gate-decision.md) — review-switch abandoned per its own AC4 data gate (candidate arm 0 runs vs ≥10 required, token telemetry null); deferral pending telemetry, not a rejection of built-in `/code-review`
 - **[Run-Records](docs/run-records.md)** — Per-run structured run-record schema + store + the `work_summary.py` CLI (WF2 Step 16; Tier-2 telemetry substrate)
 - **[Testing](docs/testing.md)** — Test suite overview, hook test descriptions, skill evaluation methodology
 - **Diagrams** (in `diagrams/`): Excalidraw visual diagrams for each workflow and the framework architecture

--- a/docs/measurements/2026-07-05-issue-162-data-gate-decision.md
+++ b/docs/measurements/2026-07-05-issue-162-data-gate-decision.md
@@ -18,7 +18,7 @@ Success metric: *"Findings-yield per token by reviewer_kind before vs after; Cri
 | Fact | Measured | Gate requirement |
 |---|---|---|
 | `builtin_code_review` reviewer_kind | **0 gate-instances** in 23 records — the candidate arm has never run | ≥10 runs |
-| Token/cost telemetry (`usage.input_tokens` / `output_tokens` / `cost_estimate_usd`) | **null in all 23 records** (11 carry only `wall_clock_s`) | needed to compute yield-per-token for *any* arm |
+| Token/cost telemetry (`usage.input_tokens` / `output_tokens` / `cost_estimate_usd`) | **null in all 23 records** (11 carry a `usage` block, 10 of those with only `wall_clock_s` populated) | needed to compute yield-per-token for *any* arm |
 | `hand_rolled_multi` | 41 findings / 11 gate-instances | incumbent baseline exists |
 | `codex` | 16 findings / 4 gate-instances | WF5 arm exists |
 | `inline` | 19 findings / 13 gate-instances | reflect arm exists |
@@ -28,8 +28,8 @@ the success metric is incomputable because no run-record ever captured token usa
 
 ## Design flaw in the gate (named, not laundered)
 
-The modernization roadmap (docs/planning/2026-07-04-workflow-modernization-roadmap.md, execution-order
-row 25) assumed *"data gate satisfied by the program's own ≥10 reviewer_kind runs — the program is its
+The modernization roadmap (docs/planning/2026-07-04-workflow-modernization-roadmap.md, the
+execution-order table's slot-11 `#162 review switch` row) assumed *"data gate satisfied by the program's own ≥10 reviewer_kind runs — the program is its
 own A/B."* That assumption was **circular**: the campaign's runs could only generate `builtin_code_review`
 data *after* switching Step 11 to the built-in reviewer — which is precisely the change this gate blocks.
 As designed, the gate could only ever fail. The abandon branch firing is therefore the gate working as

--- a/docs/measurements/2026-07-05-issue-162-data-gate-decision.md
+++ b/docs/measurements/2026-07-05-issue-162-data-gate-decision.md
@@ -1,0 +1,53 @@
+# Issue #162 data-gate decision — ABANDONED per AC4 (2026-07-05)
+
+**Issue:** #162 `feat(wf2): Step 4 reflect-only + Step 11 built-in /code-review + WF5 diff pass (data-gated)`
+**Decision:** **Abandon**, taking AC4's explicit branch: *"otherwise abandon this issue with the data cited."*
+**Framing:** This is **not a rejection** of the built-in `/code-review` reviewer. It is a deferral: the gate's
+required evidence does not exist yet, and per the issue's own header ("no A/B evidence, no switch") the
+switch cannot be made without it. Cross-model peer consult (Codex, 2026-07-05) concurred and requested
+this framing be explicit.
+
+## The gate, as written
+
+AC4: *"if built-in+Codex matched hand-rolled yield over ≥10 runs at lower cost, delete the hand-rolled
+path; otherwise abandon this issue with the data cited."*
+Success metric: *"Findings-yield per token by reviewer_kind before vs after; Critical-miss rate stays 0."*
+
+## The data (docs/measurements/run_records.jsonl, 23 records as of 2026-07-04)
+
+| Fact | Measured | Gate requirement |
+|---|---|---|
+| `builtin_code_review` reviewer_kind | **0 gate-instances** in 23 records — the candidate arm has never run | ≥10 runs |
+| Token/cost telemetry (`usage.input_tokens` / `output_tokens` / `cost_estimate_usd`) | **null in all 23 records** (11 carry only `wall_clock_s`) | needed to compute yield-per-token for *any* arm |
+| `hand_rolled_multi` | 41 findings / 11 gate-instances | incumbent baseline exists |
+| `codex` | 16 findings / 4 gate-instances | WF5 arm exists |
+| `inline` | 19 findings / 13 gate-instances | reflect arm exists |
+
+The gate fails twice over: the candidate arm's sample size is 0 (vs ≥10 required), and the cost axis of
+the success metric is incomputable because no run-record ever captured token usage.
+
+## Design flaw in the gate (named, not laundered)
+
+The modernization roadmap (docs/planning/2026-07-04-workflow-modernization-roadmap.md, execution-order
+row 25) assumed *"data gate satisfied by the program's own ≥10 reviewer_kind runs — the program is its
+own A/B."* That assumption was **circular**: the campaign's runs could only generate `builtin_code_review`
+data *after* switching Step 11 to the built-in reviewer — which is precisely the change this gate blocks.
+As designed, the gate could only ever fail. The abandon branch firing is therefore the gate working as
+written, but the experiment it wanted was never actually runnable.
+
+## Reopen conditions (what would satisfy the gate honestly)
+
+1. **Generate the candidate arm without trading away coverage:** run built-in `/code-review` as an
+   *additional* Step 11 reviewer alongside the hand-rolled path for ≥10 runs, recording
+   `reviewer_kind: builtin_code_review` gate entries (findings, resolved, severity mix). Coverage never
+   drops during the pilot, so Critical-miss risk stays bounded.
+2. **Close the token-telemetry gap:** populate `usage` token/cost fields in run-records (the ccusage
+   backfill follow-up), so yield-per-token is computable for both arms.
+3. When both exist, re-file with the same AC4 comparison — the decision rule itself was sound.
+
+## Outcome
+
+- WF2 Step 4 (reflexion critique / reflect split) and Step 11 (hand-rolled multi-agent review) are
+  **unchanged**. WF5 Codex diff-pass triggering is **unchanged** (AC3 holds trivially).
+- Issue #162 closed as *not planned*, with this record cited.
+- Drift guard: `tests/test_decision_records.py` pins this record and its load-bearing numbers.

--- a/docs/planning/2026-07-04-workflow-modernization-review.html
+++ b/docs/planning/2026-07-04-workflow-modernization-review.html
@@ -97,7 +97,7 @@ footer{margin-top:56px;padding-top:18px;border-top:1px solid var(--line);color:v
 
 <div class="wrap">
 <header class="hero">
-  <div class="eyebrow">rawgentic v2.53.0 · report-only review 2026-07-04 · updated 2026-07-04 20:12 MDT</div>
+  <div class="eyebrow">rawgentic v2.53.0 · report-only review 2026-07-04 · updated 2026-07-04 20:43 MDT</div>
   <h1>Workflow Modernization Review</h1>
   <p class="sub">Evidence-backed findings across 12 acceptance criteria, a definitive model-topology verdict, plugin dispositions, and a four-milestone roadmap. Full detail lives in the committed markdown docs; this dashboard is the navigable summary.</p>
   <div class="meta">
@@ -113,7 +113,7 @@ footer{margin-top:56px;padding-top:18px;border-top:1px solid var(--line);color:v
 
 <section id="roadmap">
   <h2>Roadmap — four independently shippable milestones</h2>
-  <p class="h2sub">All issues are <b>filed</b>: epics <b>M1 #167 · M2 #168 · M3 #169 · M4 #170</b> (label <code>epic:modernization</code>) track children via task lists. M1 COMPLETE — slots 1-4 merged. M2: slots 5-9 (PRs #177-#181) merged; M2 COMPLETE (slots 5-9.5 merged, PRs #177-#183). M3 started — slot 10 (#148+#163) built, v2.64.0, PR open. <span class="up">⬆ upgrade point</span> marks where refreshing the installed plugin unlocks the new capability.</p>
+  <p class="h2sub">All issues are <b>filed</b>: epics <b>M1 #167 · M2 #168 · M3 #169 · M4 #170</b> (label <code>epic:modernization</code>) track children via task lists. M1 COMPLETE — slots 1-4 merged. M2: slots 5-9 (PRs #177-#181) merged; M2 COMPLETE (slots 5-9.5 merged, PRs #177-#183). M3: slot 10 (#148+#163) merged (PR #185, v2.64.0; post-merge hardening PR #186, v2.64.1); slot 11 (#162) ABANDONED per its own AC4 data gate, v2.64.2. <span class="up">⬆ upgrade point</span> marks where refreshing the installed plugin unlocks the new capability.</p>
   <div class="note"><b>Dogfood program (approved 2026-07-04) — milestones ARE the execution phases.</b> rawgentic implements its own updates; the plugin is refreshed after each merge, so each issue's build runs on — and field-proves — the features shipped before it. Re-cut from the original capability grouping: #166 M4→M1 · #164 M3→M2 · #162+#161 M2→M3 (<b>v3.0.0 now ships in M3</b>). Full slot table, rationale + risks in the roadmap markdown.</div>
   <div class="rail">
     <div class="mstone"><h3>M1 · Instrument + guard <span class="chip c-conf">epic #167</span></h3><div class="v">slots 1–4 · v2.54–2.57 · instrument first: every later build is measured, guarded, and security-reviewed</div>
@@ -136,19 +136,20 @@ footer{margin-top:56px;padding-top:18px;border-top:1px solid var(--line);color:v
         <tr><td><b>9.5 · #174</b> design artifact lifecycle (S) <span class="chip c-conf">slot 9.5 · PR #183 merged 500fd94 · v2.63.0 · DONE</span></td><td>HTML design artifact created at issue creation (WF1), created/updated pre-PR in WF2/WF3, embeds run-record telemetry (absorbs #122)</td><td>Design docs &amp; dashboards stay current automatically — no manual redeploy step after each PR</td></tr>
       </table></div>
       <div class="metric">Milestone metric: load ≤450 lines; suite green; corpus −44%; stubs live; quality non-regressed over 5 runs · <b>Upgrade: after each merge</b></div></div>
-    <div class="mstone"><h3>M3 · Autonomy + v3.0.0 <span class="chip c-conf">epic #169</span></h3><div class="v">slots 10–12 · <b>v3.0.0 ships here</b> · the tail (#162, #161) runs as the first driver campaign</div>
+    <div class="mstone"><h3>M3 · Autonomy + v3.0.0 <span class="chip c-conf">epic #169</span></h3><div class="v">slots 10–13 · <b>v3.0.0 ships here</b> · the tail (#162, #184, #161) runs as the first driver campaign · <b>#184 inserted before #161 (owner, 2026-07-04)</b></div>
       <div class="tscroll"><table>
         <tr><th>Slot · Issue</th><th>What ships</th><th>Benefit you'll see</th></tr>
         <tr><td><b>10 · #148</b> driver build <span class="chip c-conf">slot 10 · PR #185 merged d7ea584 · v2.64.0 · DONE</span> <span class="chip c-conf">post-merge review: 7 findings fixed · v2.64.1</span></td><td>queue state file + pattern doc (pre-existing issue)</td><td>Campaigns stop being hand-rolled — resumable, rollback-anchored, DEFER-aware <span class="up">⬆</span></td></tr>
         <tr><td><b>10 · #163</b> DAG + epic anchor (M) <span class="chip c-conf">slot 10 · PR #185 merged d7ea584 · v2.64.0 · DONE</span> <span class="chip c-conf">post-merge review: 7 findings fixed · v2.64.1</span></td><td>depends_on parsing, topo-sort, one-way epic mirror; lockout→DEFER</td><td>Dependency-ordered campaigns with visible progress; headless runs get their comms channel — <b>then the flagship proves itself on the program's own tail</b> <span class="up">⬆</span></td></tr>
-        <tr><td><b>11 · #162</b> review switch (M)</td><td>Step 4 reflect-only; Step 11 built-in /code-review + WF5 diff</td><td>Fewer review tokens at equal yield — data gate satisfied by the program's own ≥10 runs, or abandoned with the data cited <span class="up">⬆</span></td></tr>
-        <tr><td><b>12 · #161</b> v3.0.0 (S)</td><td>stub removal + docs/upgrade-3.0.md</td><td>One clean migration event; stub cycle (slot 7) already elapsed — no waiting · <b>follow the upgrade guide, not just a refresh</b> <span class="up">⬆</span></td></tr>
+        <tr><td><b>11 · #162</b> review switch (M) <span class="chip c-defer">slot 11 · ABANDONED per AC4 data gate · v2.64.2</span></td><td>Step 4 reflect-only; Step 11 built-in /code-review + WF5 diff</td><td>Fewer review tokens at equal yield — data gate satisfied by the program's own ≥10 runs, or abandoned with the data cited <span class="up">⬆</span> · <b>Outcome: abandoned</b> — candidate arm 0 runs vs ≥10 required, token telemetry null in all 23 run-records; decision record in docs/measurements/2026-07-05-issue-162-data-gate-decision.md</td></tr>
+        <tr><td><b>12 · #184</b> version-aware setup prompt (S) <span class="chip c-conf">filed 2026-07-04 · slot 12 (owner-inserted before #161)</span></td><td>setup nag when a new version ships setup-requiring features + decline instructions</td><td>Upgrades stop silently missing their opt-in config; pairs with the #161 upgrade guide — <b>lands before v3.0.0 so the guide can point at it</b></td></tr>
+        <tr><td><b>13 · #161</b> v3.0.0 (S)</td><td>stub removal + docs/upgrade-3.0.md</td><td>One clean migration event; stub cycle (slot 7) already elapsed — no waiting · <b>follow the upgrade guide, not just a refresh</b> <span class="up">⬆</span></td></tr>
       </table></div>
       <div class="metric">Milestone metric: tail campaign dependency-ordered, 0 interventions; v3.0.0 published via upgrade guide</div></div>
-    <div class="mstone"><h3>M4 · Headless platform <span class="chip c-conf">epic #170</span></h3><div class="v">slot 13 · v3.1 · rides on M1 goal guard + M3 driver, on stable v3</div>
+    <div class="mstone"><h3>M4 · Headless platform <span class="chip c-conf">epic #170</span></h3><div class="v">slot 14 · v3.1 · rides on M1 goal guard + M3 driver, on stable v3</div>
       <div class="tscroll"><table>
         <tr><th>Slot · Issue</th><th>What ships</th><th>Benefit you'll see</th></tr>
-        <tr><td><b>13 · #165</b> Action pilot (L)</td><td>label `rawgentic:auto` → headless WF2 → PR; folds #48/#51/#52; subscription-OAuth default</td><td><b>Label an issue, get a PR overnight — no laptop attached.</b> Crown move: run the pilot by labeling a final issue. The Action pulls the plugin at run time; local refresh only matters for local headless</td></tr>
+        <tr><td><b>14 · #165</b> Action pilot (L)</td><td>label `rawgentic:auto` → headless WF2 → PR; folds #48/#51/#52; subscription-OAuth default</td><td><b>Label an issue, get a PR overnight — no laptop attached.</b> Crown move: run the pilot by labeling a final issue. The Action pulls the plugin at run time; local refresh only matters for local headless</td></tr>
       </table></div>
       <div class="metric">Milestone metric: 1 issue label→PR with zero operator touches · <b>Upgrade: repo-side workflows; no local refresh required</b></div></div>
   </div>
@@ -352,7 +353,7 @@ footer{margin-top:56px;padding-top:18px;border-top:1px solid var(--line);color:v
 </section>
 
 <footer>
-  <div><strong>Last updated: 2026-07-04 18:40 MDT</strong> · M2 complete; slot 10 (#148) next</div>
+  <div><strong>Last updated: 2026-07-04 20:43 MDT</strong> · M3: slot 10 done, slot 11 (#162) abandoned per data gate; slot 12 (#184 setup prompt) next, then #161 v3.0.0, then #165</div>
   Report-only review · rawgentic v2.53.0 @ 6b7d009 · Findings: docs/planning/2026-07-04-workflow-modernization-review.md · Roadmap: …-roadmap.md · Every claim tagged confirmed/inferred in the markdown; external sources live-fetched 2026-07-04.
 </footer>
 </div>

--- a/docs/planning/2026-07-04-workflow-modernization-roadmap.md
+++ b/docs/planning/2026-07-04-workflow-modernization-roadmap.md
@@ -6,6 +6,8 @@ Date: 2026-07-04 · Companion to [findings](2026-07-04-workflow-modernization-re
 >
 > **Re-scoped 2026-07-04 (owner-approved): milestones ARE the execution phases.** The original capability grouping (instrument / restructure / autonomy / headless) was re-cut so milestone membership matches the dogfood execution order — no cross-milestone execution, no confusion. Moves from the original cut: #166 M4→M1 · #164 M3→M2 · #162+#161 M2→M3 (v3.0.0 now ships in M3).
 >
+> **Status 2026-07-04 (owner directive): #184 (version-aware setup prompt, epic #169) inserted into the campaign as slot 12, BEFORE #161** — the v3.0.0 upgrade guide can then point at the shipped prompt. Tail order is now #162 → #184 → #161 → #165 (slots 11–14).
+>
 > **Status 2026-07-05: #162 (slot 11) ABANDONED per its own AC4 data gate** — the candidate arm (`builtin_code_review`) had 0 recorded runs vs ≥10 required, and token telemetry was null in all 23 run-records. Row 25's assumption ("the program is its own A/B") was circular: campaign runs could only generate candidate-arm data *after* the switch this gate blocks. Decision record + reopen conditions: [2026-07-05-issue-162-data-gate-decision.md](../measurements/2026-07-05-issue-162-data-gate-decision.md).
 
 ## The dogfood program

--- a/docs/planning/2026-07-04-workflow-modernization-roadmap.md
+++ b/docs/planning/2026-07-04-workflow-modernization-roadmap.md
@@ -5,6 +5,8 @@ Date: 2026-07-04 · Companion to [findings](2026-07-04-workflow-modernization-re
 > **Status 2026-07-04: approved and FILED.** Epics: **M1 #167 · M2 #168 · M3 #169 · M4 #170** (label `epic:modernization`). Draft-issue mapping: A→#154 B→#155 C→#156 D→#157 E→#158 F→#159 G→#160 H→#161 I→#162 J→#163 K→#164 L→#165 M→#166. The epics' task lists are the live tracking surface; this doc is the design record.
 >
 > **Re-scoped 2026-07-04 (owner-approved): milestones ARE the execution phases.** The original capability grouping (instrument / restructure / autonomy / headless) was re-cut so milestone membership matches the dogfood execution order — no cross-milestone execution, no confusion. Moves from the original cut: #166 M4→M1 · #164 M3→M2 · #162+#161 M2→M3 (v3.0.0 now ships in M3).
+>
+> **Status 2026-07-05: #162 (slot 11) ABANDONED per its own AC4 data gate** — the candidate arm (`builtin_code_review`) had 0 recorded runs vs ≥10 required, and token telemetry was null in all 23 run-records. Row 25's assumption ("the program is its own A/B") was circular: campaign runs could only generate candidate-arm data *after* the switch this gate blocks. Decision record + reopen conditions: [2026-07-05-issue-162-data-gate-decision.md](../measurements/2026-07-05-issue-162-data-gate-decision.md).
 
 ## The dogfood program
 

--- a/docs/planning/2026-07-04-workflow-modernization-roadmap.md
+++ b/docs/planning/2026-07-04-workflow-modernization-roadmap.md
@@ -8,7 +8,7 @@ Date: 2026-07-04 · Companion to [findings](2026-07-04-workflow-modernization-re
 >
 > **Status 2026-07-04 (owner directive): #184 (version-aware setup prompt, epic #169) inserted into the campaign as slot 12, BEFORE #161** — the v3.0.0 upgrade guide can then point at the shipped prompt. Tail order is now #162 → #184 → #161 → #165 (slots 11–14).
 >
-> **Status 2026-07-05: #162 (slot 11) ABANDONED per its own AC4 data gate** — the candidate arm (`builtin_code_review`) had 0 recorded runs vs ≥10 required, and token telemetry was null in all 23 run-records. Row 25's assumption ("the program is its own A/B") was circular: campaign runs could only generate candidate-arm data *after* the switch this gate blocks. Decision record + reopen conditions: [2026-07-05-issue-162-data-gate-decision.md](../measurements/2026-07-05-issue-162-data-gate-decision.md).
+> **Status 2026-07-05: #162 (slot 11) ABANDONED per its own AC4 data gate** — the candidate arm (`builtin_code_review`) had 0 recorded runs vs ≥10 required, and token telemetry was null in all 23 run-records. The #162 execution-order row's assumption ("the program is its own A/B") was circular: campaign runs could only generate candidate-arm data *after* the switch this gate blocks. Decision record + reopen conditions: [2026-07-05-issue-162-data-gate-decision.md](../measurements/2026-07-05-issue-162-data-gate-decision.md).
 
 ## The dogfood program
 

--- a/docs/planning/campaign-log.html
+++ b/docs/planning/campaign-log.html
@@ -37,7 +37,7 @@ footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:v
 <body>
 <div class="wrap">
 <header>
-<div class="eyebrow">rawgentic design artifact · updated 2026-07-04 19:27 MDT</div>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-04 20:56 MDT</div>
 <h1>Rawgentic modernization — campaign log</h1>
 
 </header>
@@ -52,7 +52,39 @@ footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:v
 <p>Milestones: <strong>M1</strong> instrument+guard (done) · <strong>M2</strong> enable+restructure (done) ·</p>
 <p><strong>M3</strong> multi-issue autonomy + v3.0.0 (in progress) · <strong>M4</strong> headless.</p>
 <p>---</p>
-<h2>Slot 10 — #148 + #163: multi-issue driver (M3 start) · v2.64.0</h2>
+<h2>Slot 11 — #162: review switch — ABANDONED per AC4 data gate · v2.64.2</h2>
+<p><strong>Issue.</strong> #162 (Step 4 reflect-only + Step 11 built-in /code-review + WF5 diff</p>
+<p>pass) was <strong>data-gated</strong> by its own header (&quot;no A/B evidence, no switch&quot;) and</p>
+<p>AC4 (&quot;matched hand-rolled yield over ≥10 runs at lower cost … otherwise abandon</p>
+<p>this issue with the data cited&quot;).</p>
+<p><strong>The data (23 run-records as of 2026-07-04).</strong> The candidate arm</p>
+<p>(<code>builtin_code_review</code>) has <strong>0 gate-instances</strong> — it never ran (≥10 required).</p>
+<p>Token/cost telemetry (<code>usage.input_tokens</code>/<code>output_tokens</code>/<code>cost_estimate_usd</code>)</p>
+<p>is <strong>null in all 23 records</strong>, so the success metric (findings-yield per token)</p>
+<p>is incomputable for *any* arm. Incumbent arms: hand_rolled_multi 41 findings/11</p>
+<p>gates · codex 16/4 · inline 19/13.</p>
+<p><strong>Decision.</strong> Abandon per AC4&#x27;s explicit branch — a **deferral pending</p>
+<p>telemetry, not a rejection** of built-in <code>/code-review</code> (Codex peer-consult</p>
+<p>concurred). The roadmap&#x27;s &quot;the program is its own A/B&quot; assumption was circular:</p>
+<p>campaign runs could only generate candidate-arm data *after* the switch this</p>
+<p>gate blocks. Reopen conditions: pilot built-in <code>/code-review</code> as an *additional*</p>
+<p>Step 11 reviewer for ≥10 runs + backfill token telemetry. Full record:</p>
+<p><code>docs/measurements/2026-07-05-issue-162-data-gate-decision.md</code> (drift-guarded</p>
+<p>by <code>tests/test_decision_records.py</code>, which recomputes the evidence basis from</p>
+<p><code>run_records.jsonl</code> records[:23]).</p>
+<p><strong>What shipped.</strong> Decision record + 3 drift-guard tests (one recomputes the</p>
+<p>evidence from the store) · README/roadmap/dashboard annotations · v2.64.2.</p>
+<p><strong>Owner directives (mid-slot).</strong> #184 (version-aware setup prompt) inserted</p>
+<p>into the campaign as <strong>slot 12, before #161</strong> — slots renumbered 12=#184,</p>
+<p>13=#161, 14=#165; run doc, dashboard, roadmap updated.</p>
+<p><strong>Reviews.</strong> Step 11: opus reviewer (2 Low: citation + count fix, both applied)</p>
+<p>+ Codex adversarial diff pass (2 Medium: drift-guard vacuity — test now parses</p>
+<p>the store; applied). Security scan clean (iac/sca visible skips).</p>
+<p><strong>Status.</strong> PR + CI + merge SHA filled by the next slot&#x27;s pass (established</p>
+<p>convention). Telemetry embedded below. Issue closed as *not planned*, data</p>
+<p>cited.</p>
+<p>---</p>
+<h2>Slot 10 — #148 + #163: multi-issue driver (M3 start) · v2.64.0 &lt;br&gt;*(status backfill: PR #185 squash-merged <code>d7ea584</code>; post-merge hardening review → PR #186 <code>5e15862</code>, 7 findings fixed, v2.64.1, suite 1863/0)*</h2>
 <p><strong>Issues.</strong> #148 (build the multi-issue driver as a documented pattern + queue</p>
 <p>state schema, from design #134) and #163 (dependency-DAG + epic anchor,</p>
 <p>schema v2) — implemented together in one PR (#163 extends #148&#x27;s queue).</p>
@@ -98,9 +130,9 @@ footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:v
 <p>clean.</p>
 <p><strong>Status.</strong> PR + CI + merge SHA filled by the next slot&#x27;s pass (established</p>
 <p>convention). Telemetry for this slot is embedded below.</p>
-<section class='telemetry-section'><h2>Run telemetry</h2><table class='telemetry'><tbody><tr><th>Issue</th><td>#148 (feature, standard)</td></tr><tr><th>Lane</th><td>small-standard</td></tr><tr><th>Tests</th><td>56 added · 1856/1856 passing</td></tr><tr><th>Security scan</th><td>0 blocking resolved · 0 advisory · skipped: iac, sca</td></tr><tr><th>Outcome</th><td>PR None · merged: False · CI: pending</td></tr><tr><th>Usage</th><td>in None / out None tokens</td></tr></tbody></table><h2>Quality gates</h2><table class='gates'><thead><tr><th>Step</th><th>Gate</th><th>Findings</th><th>Resolved</th><th>Status</th></tr></thead><tbody><tr><td>4</td><td>Design Critique</td><td>0</td><td>0</td><td>fast_path</td></tr><tr><td>6</td><td>Plan Drift</td><td>0</td><td>0</td><td>skipped</td></tr><tr><td>8a</td><td>Per-task Review</td><td>5</td><td>5</td><td>pass</td></tr><tr><td>9</td><td>Implementation Drift</td><td>0</td><td>0</td><td>pass</td></tr><tr><td>11</td><td>Code Review</td><td>6</td><td>6</td><td>pass</td></tr><tr><td>15</td><td>Post-Deploy</td><td>0</td><td>0</td><td>skipped</td></tr></tbody></table></section>
+<section class='telemetry-section'><h2>Run telemetry</h2><table class='telemetry'><tbody><tr><th>Issue</th><td>#162 (feature, simple)</td></tr><tr><th>Lane</th><td>small-standard</td></tr><tr><th>Tests</th><td>3 added · 1866/1866 passing</td></tr><tr><th>Security scan</th><td>0 blocking resolved · 0 advisory · skipped: iac, sca</td></tr><tr><th>Outcome</th><td>PR None · merged: False · CI: pending</td></tr><tr><th>Usage</th><td>in None / out None tokens</td></tr></tbody></table><h2>Quality gates</h2><table class='gates'><thead><tr><th>Step</th><th>Gate</th><th>Findings</th><th>Resolved</th><th>Status</th></tr></thead><tbody><tr><td>4</td><td>Design Critique</td><td>0</td><td>0</td><td>fast_path</td></tr><tr><td>6</td><td>Plan Drift</td><td>0</td><td>0</td><td>skipped</td></tr><tr><td>9</td><td>Implementation Drift</td><td>0</td><td>0</td><td>pass</td></tr><tr><td>11</td><td>Code Review</td><td>4</td><td>4</td><td>pass</td></tr><tr><td>15</td><td>Post-Deploy</td><td>0</td><td>0</td><td>skipped</td></tr></tbody></table></section>
 </main>
-<footer>Last updated: 2026-07-04 19:27 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+<footer>Last updated: 2026-07-04 20:56 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
 </div>
 </body>
 </html>

--- a/docs/planning/campaign-log.md
+++ b/docs/planning/campaign-log.md
@@ -12,7 +12,48 @@ Milestones: **M1** instrument+guard (done) · **M2** enable+restructure (done) �
 
 ---
 
-## Slot 10 — #148 + #163: multi-issue driver (M3 start) · v2.64.0
+## Slot 11 — #162: review switch — ABANDONED per AC4 data gate · v2.64.2
+
+**Issue.** #162 (Step 4 reflect-only + Step 11 built-in /code-review + WF5 diff
+pass) was **data-gated** by its own header ("no A/B evidence, no switch") and
+AC4 ("matched hand-rolled yield over ≥10 runs at lower cost … otherwise abandon
+this issue with the data cited").
+
+**The data (23 run-records as of 2026-07-04).** The candidate arm
+(`builtin_code_review`) has **0 gate-instances** — it never ran (≥10 required).
+Token/cost telemetry (`usage.input_tokens`/`output_tokens`/`cost_estimate_usd`)
+is **null in all 23 records**, so the success metric (findings-yield per token)
+is incomputable for *any* arm. Incumbent arms: hand_rolled_multi 41 findings/11
+gates · codex 16/4 · inline 19/13.
+
+**Decision.** Abandon per AC4's explicit branch — a **deferral pending
+telemetry, not a rejection** of built-in `/code-review` (Codex peer-consult
+concurred). The roadmap's "the program is its own A/B" assumption was circular:
+campaign runs could only generate candidate-arm data *after* the switch this
+gate blocks. Reopen conditions: pilot built-in `/code-review` as an *additional*
+Step 11 reviewer for ≥10 runs + backfill token telemetry. Full record:
+`docs/measurements/2026-07-05-issue-162-data-gate-decision.md` (drift-guarded
+by `tests/test_decision_records.py`, which recomputes the evidence basis from
+`run_records.jsonl` records[:23]).
+
+**What shipped.** Decision record + 3 drift-guard tests (one recomputes the
+evidence from the store) · README/roadmap/dashboard annotations · v2.64.2.
+
+**Owner directives (mid-slot).** #184 (version-aware setup prompt) inserted
+into the campaign as **slot 12, before #161** — slots renumbered 12=#184,
+13=#161, 14=#165; run doc, dashboard, roadmap updated.
+
+**Reviews.** Step 11: opus reviewer (2 Low: citation + count fix, both applied)
++ Codex adversarial diff pass (2 Medium: drift-guard vacuity — test now parses
+the store; applied). Security scan clean (iac/sca visible skips).
+
+**Status.** PR + CI + merge SHA filled by the next slot's pass (established
+convention). Telemetry embedded below. Issue closed as *not planned*, data
+cited.
+
+---
+
+## Slot 10 — #148 + #163: multi-issue driver (M3 start) · v2.64.0 <br>*(status backfill: PR #185 squash-merged `d7ea584`; post-merge hardening review → PR #186 `5e15862`, 7 findings fixed, v2.64.1, suite 1863/0)*
 
 **Issues.** #148 (build the multi-issue driver as a documented pattern + queue
 state schema, from design #134) and #163 (dependency-DAG + epic anchor,

--- a/docs/reviews/rawgentic-diff-review-162-patch-unknown-date.md
+++ b/docs/reviews/rawgentic-diff-review-162-patch-unknown-date.md
@@ -1,0 +1,35 @@
+# Adversarial Review — .rawgentic-diff-review-162.patch
+
+- Date: unknown-date
+- Artifact type: diff
+- Reviewer: Codex (model config-default, reasoning effort high)
+- Findings: 2 (Critical 0, High 0, Medium 2, Low 0)
+
+## Summary
+
+The diff is mostly a documentation/version bump plus a new drift-guard test for the Issue #162 data-gate decision. The main risk is that the added test claims to pin measured decision data but only checks loose strings in the decision record, so the guard can pass after the underlying evidence or key decision facts drift.
+
+## Findings
+
+### 1. [Medium] correctness · high confidence — tests/test_decision_records.py
+
+> +    assert "run_records.jsonl" in body          # data source named
+
+The new drift guard treats naming the data source as sufficient, but it never reads or validates the actual `run_records.jsonl` data that the decision claims to be based on. If the run-record data is absent, corrupt, or later changes to include candidate runs/token telemetry, this test still passes as long as the markdown keeps the same words, so the guard is vacuous for the measured evidence.
+
+**Recommendation:** Change `tests/test_decision_records.py` to parse `docs/measurements/run_records.jsonl` and assert the measured facts used by the decision, including candidate-arm count, total records, and token/cost telemetry state, instead of only checking that the document names the source.
+
+### 2. [Medium] internal-consistency · high confidence — tests/test_decision_records.py
+
+> +    # the two facts the abandon decision rests on
+> +    assert "builtin_code_review" in body
+> +    assert "0 gate-instances" in body          # candidate arm never ran
+> +    assert "≥10" in body or ">=10" in body      # AC4's required sample size
+> +    assert "run_records.jsonl" in body          # data source named
+
+The test says it pins “the two facts the abandon decision rests on,” but the decision record states the gate failed twice, including token telemetry being null in all records. The test does not assert the token telemetry fact at all, so the record could drop or alter one of its stated load-bearing reasons while the drift guard remains green.
+
+**Recommendation:** In `test_issue_162_decision_cites_the_gate_data`, add explicit assertions for the second gate-failure fact, such as `token telemetry`, `null in all 23 records`, and the relevant `usage.input_tokens` / `output_tokens` / `cost_estimate_usd` fields, or rename the comment and outcome claim to state that only the candidate-arm sample-size fact is pinned.
+
+---
+_Report-only: this review does not edit the artifact. Findings are advisory; incorporate them at your discretion._

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "2.64.1",
+  "version": "2.64.2",
   "description": "SDLC workflow skills for Codex and Claude Code: project setup, issue creation, feature implementation, bug fixing, refactoring, documentation, dependency updates, security audits, performance optimization, incident response, test suite creation, and cross-model adversarial review.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -38,7 +38,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "2.64.1"
+    assert plugin["version"] == "2.64.2"
 
 
 def test_descriptions_consistent_count():

--- a/tests/test_decision_records.py
+++ b/tests/test_decision_records.py
@@ -1,0 +1,27 @@
+"""Drift guards for data-gated decision records under docs/measurements/.
+
+A data-gated issue's outcome is a *decision record* citing the measured data
+(e.g. #162's AC4: switch or abandon-with-data). These pins keep the record —
+and the specific numbers the decision rests on — from silently vanishing or
+being edited into a different conclusion without a deliberate test change.
+"""
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOC_162 = REPO_ROOT / "docs" / "measurements" / "2026-07-05-issue-162-data-gate-decision.md"
+
+
+def test_issue_162_decision_record_exists():
+    assert DOC_162.exists(), "issue #162 data-gate decision record must exist"
+
+
+def test_issue_162_decision_cites_the_gate_data():
+    body = DOC_162.read_text()
+    # the two facts the abandon decision rests on
+    assert "builtin_code_review" in body
+    assert "0 gate-instances" in body          # candidate arm never ran
+    assert "≥10" in body or ">=10" in body      # AC4's required sample size
+    assert "run_records.jsonl" in body          # data source named
+    # the decision and its framing (deferral, not rejection of /code-review)
+    assert "abandon" in body.lower()
+    assert "not a rejection" in body.lower()

--- a/tests/test_decision_records.py
+++ b/tests/test_decision_records.py
@@ -5,10 +5,24 @@ A data-gated issue's outcome is a *decision record* citing the measured data
 and the specific numbers the decision rests on — from silently vanishing or
 being edited into a different conclusion without a deliberate test change.
 """
+import json
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOC_162 = REPO_ROOT / "docs" / "measurements" / "2026-07-05-issue-162-data-gate-decision.md"
+RUN_RECORDS = REPO_ROOT / "docs" / "measurements" / "run_records.jsonl"
+
+# The #162 decision was made over the store's first 23 records (as of
+# 2026-07-04). The store is append-only, so the decision's evidence basis is
+# exactly records[:23] — later appends (e.g. a builtin_code_review pilot, the
+# documented reopen path) must NOT flip these guards.
+DECISION_BASIS_COUNT = 23
+
+
+def _basis_records():
+    lines = [l for l in RUN_RECORDS.read_text().splitlines() if l.strip()]
+    assert len(lines) >= DECISION_BASIS_COUNT, "run-record store shrank below the decision basis"
+    return [json.loads(l) for l in lines[:DECISION_BASIS_COUNT]]
 
 
 def test_issue_162_decision_record_exists():
@@ -17,11 +31,31 @@ def test_issue_162_decision_record_exists():
 
 def test_issue_162_decision_cites_the_gate_data():
     body = DOC_162.read_text()
-    # the two facts the abandon decision rests on
+    # both facts the abandon decision rests on:
+    # (1) candidate-arm sample size zero vs the AC4 floor
     assert "builtin_code_review" in body
-    assert "0 gate-instances" in body          # candidate arm never ran
-    assert "≥10" in body or ">=10" in body      # AC4's required sample size
-    assert "run_records.jsonl" in body          # data source named
-    # the decision and its framing (deferral, not rejection of /code-review)
+    assert "0 gate-instances" in body
+    assert "≥10" in body or ">=10" in body
+    # (2) the cost axis was never measured
+    assert "null in all 23 records" in body
+    assert "cost_estimate_usd" in body
+    # data source named + decision and its framing
+    assert "run_records.jsonl" in body
     assert "abandon" in body.lower()
     assert "not a rejection" in body.lower()
+
+
+def test_issue_162_decision_basis_matches_the_store():
+    """Recompute the decision's evidence from the store itself (non-vacuous:
+    the doc could keep its words while the cited data never existed)."""
+    recs = _basis_records()
+    gates = [g for r in recs for g in r.get("gates", [])]
+    builtin = [g for g in gates if g.get("reviewer_kind") == "builtin_code_review"]
+    assert builtin == [], "decision basis claims candidate arm never ran"
+    for r in recs:
+        usage = r.get("usage") or {}
+        for field in ("input_tokens", "output_tokens", "cost_estimate_usd"):
+            assert usage.get(field) is None, (
+                f"decision basis claims token/cost telemetry null; "
+                f"record #{r['issue']['number']} has {field}={usage.get(field)!r}"
+            )


### PR DESCRIPTION
## Summary

Issue #162 (Step 4 reflect-only + Step 11 built-in `/code-review` switch) was **data-gated** by its own AC4: *"if built-in+Codex matched hand-rolled yield over ≥10 runs at lower cost, delete the hand-rolled path; otherwise abandon this issue with the data cited."* This PR delivers the **abandon branch**: a decision record citing the measured data, drift-guarded by tests that recompute the evidence basis from the store.

**The data (23 run-records):** the candidate arm (`builtin_code_review`) has **0 gate-instances** — it never ran (≥10 required); token/cost telemetry is **null in all 23 records**, so findings-yield-per-token is incomputable for any arm. Codex peer-consult concurred: abandon, framed as **deferral pending telemetry, not a rejection** of built-in `/code-review`. Reopen conditions documented (pilot built-in as an *additional* reviewer ≥10 runs + token backfill).

Ships: `docs/measurements/2026-07-05-issue-162-data-gate-decision.md` + `tests/test_decision_records.py` (3 guards, one recomputes from `run_records.jsonl` records[:23]) · README/roadmap annotations · dashboard slot updates **including owner-directed #184 insertion as slot 12 before #161** (slots renumbered 13=#161, 14=#165) · campaign-log slot-11 section + slot-10 status backfill · v2.64.2 (3 surfaces, pin red-first).

NOT closed via merge keyword: #162 will be closed as **not planned** with a data-cited comment after merge (the switch is not shipping; the decision is).

Named flaw (not laundered): the roadmap's "the program is its own A/B" assumption was circular — campaign runs could only generate candidate-arm data *after* the switch this gate blocks. The gate as designed could only fail; the decision rule itself stays sound for a re-filed issue.

## Design Decisions

- AC4 abandon branch taken (AC1/AC2 deliberately NOT implemented; AC3 holds trivially — WF5 untouched).
- Drift guard recomputes evidence over the store's first 23 records (append-only decision basis) so a future `builtin_code_review` pilot — the reopen path — does not flip the guard.
- Decision framed as deferral; reopen conditions are the deliverable's forward edge.

## Verification

- Full suite: **1866 passed / 0 failed** (baseline 1863; +3 new drift-guard tests; 0 regressions).
- Version pin test red-first (2.64.1→2.64.2 on both plugin.json surfaces).
- Decision-record numbers independently recounted by the Step 11 reviewer against `run_records.jsonl` (all match).

## Quality Gate Summary
- Design critique (Step 4): 0 findings (lane reflect; 3 process notes applied)
- Plan drift check (Step 6): skipped (small-standard lane)
- Implementation drift check (Step 9): 0 findings (evidence-only; AC coverage verified)
- Code review (Step 11): 4 findings (2 Medium Codex adversarial + 2 Low opus reviewer; all resolved, no Critical/High)
- Security scan (Step 11.5): 0 blocking, 0 advisory, skipped: iac (not applicable), sca (nothing to scan)
- Branch protection: none — review/CI gates enforced by WF2 only, not by GitHub (a direct push or unreviewed merge is not blocked server-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EuB7ZdJAvUEQh7RkWvVjm
