### PR TITLE
fix(pages): docs/.nojekyll so the Pages site builds — v3.11.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "6 SDLC workflow skills + 4 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -696,6 +696,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v3.11.1 (2026-07-05)
+- **Fix GitHub Pages build (`docs/.nojekyll`).** The Pages site (main + `/docs`) failed to build under the legacy Jekyll processor because several committed docs contain `{{ }}` sequences Jekyll parses as Liquid. Adding `docs/.nojekyll` disables Jekyll so the hand-authored static HTML/markdown (incl. `workflow-diagram.html`) is served verbatim. No workflow-spine change → no diagram REV bump.
+
 ### v3.11.0 (2026-07-05)
 - **Workflow diagram: REV dropdown + standing update mandate.** The REV selector in `docs/workflow-diagram.html` is now a `<select>` dropdown (scales to many future revisions instead of one button per rev); added a `<meta charset>` so em-dashes render when the file is served standalone. Updating the diagram is now a **mandatory pre-PR decision** — see the Pre-PR Checklist in `CLAUDE.md`, item 4 — whenever a PR alters a documented workflow spine, the same standing requirement as the README.
 

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "6 SDLC workflow skills + 4 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -38,7 +38,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.11.0"
+    assert plugin["version"] == "3.11.1"
 
 
 def test_descriptions_consistent_count():


### PR DESCRIPTION
## Summary
The GitHub Pages site (`main` + `/docs`, enabled this session) failed its build under the **legacy Jekyll** processor — `Page build failed` on commit ce00b24. Cause: 4 committed docs contain `{{ }}` sequences (Docker `--format` strings, template examples) that Jekyll's Liquid parser rejects.

`docs/.nojekyll` disables Jekyll, so the folder of hand-authored static HTML/markdown — including `workflow-diagram.html` — is served verbatim. This is the correct mode for this content (no Jekyll templating is wanted).

No workflow-spine change, so no diagram REV bump (deliberate, per the new Pre-PR Checklist item 4).

## Verification
- Confirmed the trigger: `grep -rl '{{' docs/` → 4 files (plans + a review doc).
- Pin/version tests green; patch bump 3.11.1 on all 3 surfaces.
- Post-merge: the merge retriggers the Pages build; I'll confirm the live URL returns 200 with the rendered SPA before reporting done.

- Branch protection: none — gates enforced by CI only, not server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)