### PR TITLE
docs(pages): site root redirect to the diagram + live-URL caption — v3.11.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "6 SDLC workflow skills + 4 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ budgets drawn as return arcs. Click through to the interactive version.
   </picture>
 </a>
 
-*Snapshot of the WF2 sheet. The [interactive diagram](docs/workflow-diagram.html) covers
-WF1 / WF2 / WF3 / WF5 with per-station detail and version history — see
-[docs/workflow-diagram.md](docs/workflow-diagram.md) for the update recipe (it renders
-live via GitHub Pages when enabled for `main` + `/docs`).*
+*Snapshot of the WF2 sheet. The interactive diagram is **live** at
+**[3d-stories.github.io/rawgentic](https://3d-stories.github.io/rawgentic/)** (also
+[in-repo](docs/workflow-diagram.html)) — it covers WF1 / WF2 / WF3 / WF5 with per-station
+detail and version history. See [docs/workflow-diagram.md](docs/workflow-diagram.md) for
+the update recipe.*
 
 ---
 
@@ -695,6 +696,9 @@ For major changes, please open an issue first to discuss the approach.
 
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
+
+### v3.11.2 (2026-07-05)
+- **Workflow diagram is live on GitHub Pages.** Site is up at <https://3d-stories.github.io/rawgentic/>; added `docs/index.html` so the site root redirects to the diagram, and updated the README caption to link the live URL (was "when enabled"). No workflow-spine change → no diagram REV bump.
 
 ### v3.11.1 (2026-07-05)
 - **Fix GitHub Pages build (`docs/.nojekyll`).** The Pages site (main + `/docs`) failed to build under the legacy Jekyll processor because several committed docs contain `{{ }}` sequences Jekyll parses as Liquid. Adding `docs/.nojekyll` disables Jekyll so the hand-authored static HTML/markdown (incl. `workflow-diagram.html`) is served verbatim. No workflow-spine change → no diagram REV bump.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>rawgentic — Official Workflow Diagram</title>
+<meta http-equiv="refresh" content="0; url=./workflow-diagram.html">
+<link rel="canonical" href="./workflow-diagram.html">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<p>Redirecting to the <a href="./workflow-diagram.html">rawgentic official workflow diagram</a>&hellip;</p>

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "6 SDLC workflow skills + 4 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -38,7 +38,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.11.1"
+    assert plugin["version"] == "3.11.2"
 
 
 def test_descriptions_consistent_count():


### PR DESCRIPTION
## Summary
Now that GitHub Pages is live (https://3d-stories.github.io/rawgentic/workflow-diagram.html):
- **`docs/index.html`** — the site root (`/`) previously 404'd (no index); it now redirects to `workflow-diagram.html` so the bare Pages URL lands on the diagram (the showcase-seed entry point).
- **README caption** — updated from "renders live … when enabled" to link the live URL directly (the prior wording is now stale).

No workflow-spine change → no diagram REV bump (deliberate, Pre-PR Checklist item 4).

## Verification
- Full suite: **2035 passed / 0 failed**.
- Live diagram already confirmed: HTTP 200, `content-type: text/html; charset=utf-8`, served bytes byte-identical to committed `docs/workflow-diagram.html` (title correct, 4 embedded fonts, DATA present).
- Post-merge: I'll confirm the root URL redirects (200 at `/` after the Pages rebuild).

- Branch protection: none — gates enforced by CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)