### PR TITLE
docs(memory): document memory source of truth; close #206 (v3.11.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "description": "6 SDLC workflow skills + 4 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ The `docs/` directory contains detailed design documentation for contributors:
   - [Model Routing + Peer Consult (WF13) design](docs/design/2026-07-03-model-routing-and-peer-consult-design.md) ([visual](docs/design/2026-07-03-model-routing-and-peer-consult-design.html))
   - [Model Routing + Peer Consult plan](docs/plans/2026-07-03-model-routing-and-peer-consult.md)
   - [Dual Memory Backend (draft)](docs/superpowers/specs/2026-04-08-dual-memory-backend-design.md)
+- **[Memory Source of Truth](docs/memory-source-of-truth.md)** — which store is authoritative (CLAUDE.md, session notes, curated auto-memory) vs. the mempalace recall replica, and how mempalace is fed (PreCompact fork + WF2 Step 10); the #206 no-bulk-migration determination
 - **Planning documents** (in `docs/planning/`):
   - [Workflow Modernization Review (2026-07)](docs/planning/2026-07-04-workflow-modernization-review.md) ([visual](docs/planning/2026-07-04-workflow-modernization-review.html)) — 12-AC findings: model-routing topology verdict, /goal + multi-issue design, skill restructure, plugin dispositions, deprecation audit
   - [Workflow Modernization Roadmap](docs/planning/2026-07-04-workflow-modernization-roadmap.md) — 4 milestones (M1 instrument → M2 restructure/v3.0.0 → M3 multi-issue → M4 headless); issues filed under epics #167–#170
@@ -696,6 +697,9 @@ For major changes, please open an issue first to discuss the approach.
 
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
+
+### v3.11.3 (2026-07-05)
+- **Document the memory source of truth (#206).** After the reflexion removal (#205) moved Step 10 memorize to mempalace, investigation found the anticipated memory migration had already happened organically — the PreCompact fork and WF2 Step 10 replicate curated facts into the `rawgentic` mempalace wing, and the curated auto-memory dir is already loaded into every session. New `docs/memory-source-of-truth.md` records the authoritative-store split and why **no bulk migration** was warranted (a copy would create a dual source of truth with no back-sync). No code, no workflow-spine change → no diagram REV bump.
 
 ### v3.11.2 (2026-07-05)
 - **Workflow diagram is live on GitHub Pages.** Site is up at <https://3d-stories.github.io/rawgentic/>; added `docs/index.html` so the site root redirects to the diagram, and updated the README caption to link the live URL (was "when enabled"). No workflow-spine change → no diagram REV bump.

--- a/docs/memory-source-of-truth.md
+++ b/docs/memory-source-of-truth.md
@@ -1,0 +1,65 @@
+# Memory Source of Truth
+
+Where rawgentic's "memories" live after the reflexion removal (#205) and the
+memory-migration investigation (#206), and which store is authoritative for what.
+
+Background architecture (dated draft): `docs/superpowers/specs/2026-04-08-dual-memory-backend-design.md`.
+
+## The three stores
+
+| Store | Location | Role | Authoritative for |
+|---|---|---|---|
+| **Project contract** | `CLAUDE.md` (workspace root + each `projects/<name>/CLAUDE.md`) | Operating instructions loaded verbatim every session | **Yes** — instructions, conventions, pre-PR checklist |
+| **Session notes** | `claude_docs/session_notes/<project>.md` (+ WAL, registry) | Per-project workflow progress across compaction/resume | **Yes** — in-flight run state |
+| **Curated auto-memory** | `~/.claude/projects/<workspace>/memory/` (`MEMORY.md` index + per-fact files) | Durable curated facts, loaded into every session via the `MEMORY.md` system-reminder | **Yes** — durable cross-session facts |
+| **mempalace** | memory server, `MEMORY_SERVER_URL=http://10.0.17.205:8420` | Semantic-search + knowledge-graph **replica**, queried during workflow runs | **No** — a recall index fed by the stores above |
+
+The first three are **in-repo / in-`~/.claude`, human-readable, git- or file-backed,
+and are the source of truth**. mempalace is a **downstream recall replica**: it makes
+those facts semantically searchable during a workflow run. It is never edited by hand
+as a primary; it is populated by the pipes below.
+
+## How mempalace gets populated (why no bulk migration is needed)
+
+Three pipes keep mempalace current automatically — this is why #206 closed as a
+*documentation* task, not a data move:
+
+1. **PreCompact fork.** The mempalace PreCompact hook saves each session (a diary
+   drawer + gotcha drawers) into the project's mempalace wing before context compacts.
+   Since rawgentic sessions run for weeks with frequent compaction, this is the
+   primary ingest trigger (the design spec's key finding: `wal-stop` rarely fires).
+2. **WF2 Step 10 (memorize).** Post-#205, Step 10 curates each run's insights into
+   mempalace via `mempalace_kg_add` / `mempalace_add_drawer`, scoped to the project;
+   it falls back to `CLAUDE.md` / the memory dir only if mempalace is unreachable.
+3. **One-time restage.** A 2026-04-15 restage loaded the repos' `docs/` markdown into
+   mempalace (the bulk of the `rawgentic` wing).
+
+WF2 Step 2 (Layer-3 recall) reads mempalace back — `mempalace_search` +
+`mempalace_kg_query` — so durable facts surface at design time.
+
+## The #206 determination (no bulk migration)
+
+Investigation (2026-07-05) found the migration the issue anticipated had **already
+happened organically** once #205's Step-10-to-mempalace change shipped:
+
+- Recent curated facts are already present in the `rawgentic` mempalace wing
+  (verified by direct query — e.g. the GitHub-Pages/`.nojekyll` gotcha and the
+  full session diary, created via the PreCompact fork; `driver_lib` version facts).
+- The curated auto-memory dir is already loaded into **every** session via the
+  `MEMORY.md` system-reminder, so it is queryable through the interface actually used.
+
+A **bulk copy** of the auto-memory dir into mempalace was rejected because:
+
+- It would create a **dual source of truth with no back-sync** — mempalace cannot
+  write corrections back to the `MEMORY.md` files, so a fact edited in one store
+  goes stale in the other (drift).
+- #206's scope explicitly excludes other projects' memories, but the auto-memory
+  dir is cross-project.
+- The recall value is already delivered by the three pipes above.
+
+**Rule going forward:** write durable facts to the authoritative store (a `CLAUDE.md`
+instruction, or a `MEMORY.md` per-fact file). Let the pipes replicate them into
+mempalace. Treat mempalace as read-mostly for recall; never hand-edit it as a
+primary. When a fact changes, update the in-repo / `~/.claude` source; if a stale
+mempalace drawer needs correcting, use `mempalace_kg_invalidate` /
+`mempalace_delete_by_source` rather than editing in place.

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "description": "6 SDLC workflow skills + 4 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -38,7 +38,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.11.2"
+    assert plugin["version"] == "3.11.3"
 
 
 def test_descriptions_consistent_count():


### PR DESCRIPTION
## What & why

Closes #206 (conditional follow-up to #205). The issue asked whether rawgentic "memories" should be migrated into mempalace once #205 moved WF2 Step 10 memorize to the memory server. **Investigation-first outcome: no bulk migration warranted — closed with a documentation deliverable.**

### AC coverage
- **AC1 (inventory + classify):** three stores — `CLAUDE.md` (contract), `claude_docs/session_notes/` (run state), curated auto-memory dir (`~/.claude/.../memory/`, MEMORY.md + 199 files). All classified **LEAVE authoritative in-repo/`~/.claude`**; mempalace is a downstream recall replica.
- **AC2 (migrate if warranted):** **negative determination.** Verified by direct mempalace query that curated rawgentic facts already flow into the `rawgentic` wing via the **PreCompact fork** + **Step 10 memorize** (e.g. the GitHub-Pages/`.nojekyll` gotcha and the 2026-07-05 session diary are already present). A bulk copy would create a **dual source of truth with no back-sync** (drift), and #206's scope excludes other projects while the auto-memory dir is cross-project.
- **AC3 (document source of truth):** new `docs/memory-source-of-truth.md`.

## Changes
- `docs/memory-source-of-truth.md` (new) — authoritative-store split + how mempalace is fed + the no-migration rationale and the going-forward rule.
- `README.md` — Design Documentation link + Changelog v3.11.3.
- Version 3.11.2 → 3.11.3 (`.claude-plugin/plugin.json`, `plugins/rawgentic/.codex-plugin/plugin.json`, version-pin test).

## Pre-PR checklist
1. ✅ Version bumped (patch — docs)
2. ✅ README updated (incl. Changelog)
3. ✅ docs/ updated (new file)
4. ✅ Workflow diagram — **no edit** (docs-only, no workflow-spine change; deliberate). Newest rev 3.10.0 ≤ plugin 3.11.3, `test_diagram_newest_rev_matches_plugin_version` passes.
5. ✅ Tests — **2035 passed, 0 failed** (unchanged baseline; docs-only, no new tests)

Closes #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)