### PR TITLE
docs(memory): mempalace is the authoritative read/write memory store (v3.11.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.11.3",
+  "version": "3.11.4",
   "description": "6 SDLC workflow skills + 4 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ The `docs/` directory contains detailed design documentation for contributors:
   - [Model Routing + Peer Consult (WF13) design](docs/design/2026-07-03-model-routing-and-peer-consult-design.md) ([visual](docs/design/2026-07-03-model-routing-and-peer-consult-design.html))
   - [Model Routing + Peer Consult plan](docs/plans/2026-07-03-model-routing-and-peer-consult.md)
   - [Dual Memory Backend (draft)](docs/superpowers/specs/2026-04-08-dual-memory-backend-design.md)
-- **[Memory Source of Truth](docs/memory-source-of-truth.md)** — which store is authoritative (CLAUDE.md, session notes, curated auto-memory) vs. the mempalace recall replica, and how mempalace is fed (PreCompact fork + WF2 Step 10); the #206 no-bulk-migration determination
+- **[Memory Source of Truth](docs/memory-source-of-truth.md)** — **mempalace is the authoritative read/write memory store** for durable facts/decisions/gotchas; `CLAUDE.md` (contract) and session notes/WAL stay in-repo because the tooling reads them directly; the auto-memory dir is a secondary bootstrap mirror. How mempalace is fed (PreCompact fork + WF2 Step 10) and worked with (CRUD tools + recall protocol).
 - **Planning documents** (in `docs/planning/`):
   - [Workflow Modernization Review (2026-07)](docs/planning/2026-07-04-workflow-modernization-review.md) ([visual](docs/planning/2026-07-04-workflow-modernization-review.html)) — 12-AC findings: model-routing topology verdict, /goal + multi-issue design, skill restructure, plugin dispositions, deprecation audit
   - [Workflow Modernization Roadmap](docs/planning/2026-07-04-workflow-modernization-roadmap.md) — 4 milestones (M1 instrument → M2 restructure/v3.0.0 → M3 multi-issue → M4 headless); issues filed under epics #167–#170
@@ -697,6 +697,9 @@ For major changes, please open an issue first to discuss the approach.
 
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
+
+### v3.11.4 (2026-07-05)
+- **Memory policy: mempalace is the authoritative read/write memory store.** Owner direction supersedes the v3.11.3 "recall replica, read-mostly" framing. Durable memory (facts, decisions, gotchas, session insights) is written to, corrected in, and read from mempalace as the primary; `CLAUDE.md` (operating contract) and `session_notes`/WAL stay in-repo only because the tooling reads those files directly (and still flow into mempalace via the PreCompact fork); the `~/.claude/.../memory/` auto-memory dir is now a secondary bootstrap mirror. `docs/memory-source-of-truth.md` rewritten accordingly. Docs-only, no workflow-spine change → no diagram REV bump.
 
 ### v3.11.3 (2026-07-05)
 - **Document the memory source of truth (#206).** After the reflexion removal (#205) moved Step 10 memorize to mempalace, investigation found the anticipated memory migration had already happened organically — the PreCompact fork and WF2 Step 10 replicate curated facts into the `rawgentic` mempalace wing, and the curated auto-memory dir is already loaded into every session. New `docs/memory-source-of-truth.md` records the authoritative-store split and why **no bulk migration** was warranted (a copy would create a dual source of truth with no back-sync). No code, no workflow-spine change → no diagram REV bump.

--- a/docs/memory-source-of-truth.md
+++ b/docs/memory-source-of-truth.md
@@ -1,65 +1,58 @@
 # Memory Source of Truth
 
-Where rawgentic's "memories" live after the reflexion removal (#205) and the
-memory-migration investigation (#206), and which store is authoritative for what.
+**Policy:** **mempalace is the authoritative, read/write memory store**
+(`MEMORY_SERVER_URL=http://10.0.17.205:8420`) for durable *memory* — facts,
+decisions, gotchas, and session insights. Write to it, correct it in place, and read
+from it as the primary. Two in-repo stores stay authoritative only for their own
+**non-memory** roles, because the tooling reads those files directly (see below).
 
 Background architecture (dated draft): `docs/superpowers/specs/2026-04-08-dual-memory-backend-design.md`.
 
-## The three stores
+## The stores and their roles
 
 | Store | Location | Role | Authoritative for |
 |---|---|---|---|
-| **Project contract** | `CLAUDE.md` (workspace root + each `projects/<name>/CLAUDE.md`) | Operating instructions loaded verbatim every session | **Yes** — instructions, conventions, pre-PR checklist |
-| **Session notes** | `claude_docs/session_notes/<project>.md` (+ WAL, registry) | Per-project workflow progress across compaction/resume | **Yes** — in-flight run state |
-| **Curated auto-memory** | `~/.claude/projects/<workspace>/memory/` (`MEMORY.md` index + per-fact files) | Durable curated facts, loaded into every session via the `MEMORY.md` system-reminder | **Yes** — durable cross-session facts |
-| **mempalace** | memory server, `MEMORY_SERVER_URL=http://10.0.17.205:8420` | Semantic-search + knowledge-graph **replica**, queried during workflow runs | **No** — a recall index fed by the stores above |
+| **mempalace** | memory server (`http://10.0.17.205:8420`) | **Authoritative read/write memory** — semantic search + knowledge graph, full CRUD | **Durable memory: facts, decisions, gotchas, session insights** |
+| Project contract | `CLAUDE.md` (workspace root + each `projects/<name>/CLAUDE.md`) | Operating instructions loaded **verbatim by Claude Code every session** | Instructions / conventions / pre-PR checklist — **not** episodic memory |
+| Session notes / WAL | `claude_docs/session_notes/<project>.md`, WAL, registry | In-flight run-state read **directly by the resume/context hooks** | Current run state (also ingested into mempalace) |
+| Auto-memory dir | `~/.claude/projects/<workspace>/memory/` (`MEMORY.md` + files) | **Legacy** Claude Code native auto-memory; secondary bootstrap mirror auto-loaded via the `MEMORY.md` system-reminder | — superseded by mempalace as the memory authority |
 
-The first three are **in-repo / in-`~/.claude`, human-readable, git- or file-backed,
-and are the source of truth**. mempalace is a **downstream recall replica**: it makes
-those facts semantically searchable during a workflow run. It is never edited by hand
-as a primary; it is populated by the pipes below.
+## Working with authoritative memory (mempalace)
 
-## How mempalace gets populated (why no bulk migration is needed)
+- **Write** durable memory directly to mempalace:
+  - `mempalace_kg_add` — a fact / decision (knowledge-graph triple)
+  - `mempalace_add_drawer` — a note / gotcha
+  - `mempalace_diary_write` — a session record
+- **Correct / delete in place** — mempalace is the authority, so edit it directly; there
+  is no replica to reconcile:
+  - `mempalace_update_drawer`, `mempalace_kg_invalidate`, `mempalace_delete_by_source`
+- **Read** via the mempalace recall protocol: `mempalace_status` on wake-up;
+  `mempalace_search` + `mempalace_kg_query` before acting on any prior fact (WF2 Step 2
+  Layer-3 recall). Never guess a stored fact — query first.
+- **Automatic ingest still feeds it:** the PreCompact fork (session diary + gotcha
+  drawers) and WF2 Step 10 memorize keep new insights flowing in without manual steps.
 
-Three pipes keep mempalace current automatically — this is why #206 closed as a
-*documentation* task, not a data move:
+## Why the two in-repo stores can't move
 
-1. **PreCompact fork.** The mempalace PreCompact hook saves each session (a diary
-   drawer + gotcha drawers) into the project's mempalace wing before context compacts.
-   Since rawgentic sessions run for weeks with frequent compaction, this is the
-   primary ingest trigger (the design spec's key finding: `wal-stop` rarely fires).
-2. **WF2 Step 10 (memorize).** Post-#205, Step 10 curates each run's insights into
-   mempalace via `mempalace_kg_add` / `mempalace_add_drawer`, scoped to the project;
-   it falls back to `CLAUDE.md` / the memory dir only if mempalace is unreachable.
-3. **One-time restage.** A 2026-04-15 restage loaded the repos' `docs/` markdown into
-   mempalace (the bulk of the `rawgentic` wing).
+These are constraints of the tooling, not carve-outs from the policy:
 
-WF2 Step 2 (Layer-3 recall) reads mempalace back — `mempalace_search` +
-`mempalace_kg_query` — so durable facts surface at design time.
+- **`CLAUDE.md`** — Claude Code loads its instructions from the file at session start; it
+  does not read mempalace for the contract. The contract must live in-repo, git-tracked.
+  It is instructions, not memory.
+- **Session notes / WAL** — the resume and context-injection hooks read these local files
+  directly to reconstruct state after a compaction; they cannot be served from mempalace.
+  They are additionally ingested into mempalace via the PreCompact fork.
 
-## The #206 determination (no bulk migration)
+## The auto-memory dir is now secondary
 
-Investigation (2026-07-05) found the migration the issue anticipated had **already
-happened organically** once #205's Step-10-to-mempalace change shipped:
+`~/.claude/projects/<workspace>/memory/` (the `MEMORY.md` index + per-fact files) still
+auto-loads into every session via the system-reminder, which makes it a useful bootstrap.
+But **mempalace is the memory authority**: write new durable facts to mempalace and correct
+them there. The auto-memory files are a human-readable mirror/bootstrap, not the source of
+truth for memory.
 
-- Recent curated facts are already present in the `rawgentic` mempalace wing
-  (verified by direct query — e.g. the GitHub-Pages/`.nojekyll` gotcha and the
-  full session diary, created via the PreCompact fork; `driver_lib` version facts).
-- The curated auto-memory dir is already loaded into **every** session via the
-  `MEMORY.md` system-reminder, so it is queryable through the interface actually used.
+## History
 
-A **bulk copy** of the auto-memory dir into mempalace was rejected because:
-
-- It would create a **dual source of truth with no back-sync** — mempalace cannot
-  write corrections back to the `MEMORY.md` files, so a fact edited in one store
-  goes stale in the other (drift).
-- #206's scope explicitly excludes other projects' memories, but the auto-memory
-  dir is cross-project.
-- The recall value is already delivered by the three pipes above.
-
-**Rule going forward:** write durable facts to the authoritative store (a `CLAUDE.md`
-instruction, or a `MEMORY.md` per-fact file). Let the pipes replicate them into
-mempalace. Treat mempalace as read-mostly for recall; never hand-edit it as a
-primary. When a fact changes, update the in-repo / `~/.claude` source; if a stale
-mempalace drawer needs correcting, use `mempalace_kg_invalidate` /
-`mempalace_delete_by_source` rather than editing in place.
+#206 (2026-07-05, PR #219) first closed this as "mempalace = recall replica, read-mostly,
+in-repo stores authoritative." **Owner corrected the same day: mempalace is the
+authoritative read/write memory store.** This document supersedes that earlier framing.

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.11.3",
+  "version": "3.11.4",
   "description": "6 SDLC workflow skills + 4 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -38,7 +38,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.11.3"
+    assert plugin["version"] == "3.11.4"
 
 
 def test_descriptions_consistent_count():


### PR DESCRIPTION
## What & why

Owner direction: **mempalace is the authoritative read/write memory store.** This supersedes the v3.11.3 (#206 / PR #219) framing of mempalace as a read-mostly recall replica with the in-repo stores authoritative.

Durable *memory* — facts, decisions, gotchas, session insights — is now written to, corrected in, and read from mempalace as the primary. The "no back-sync → drift" objection from #206 dissolves: with mempalace as the single authority you edit it directly (`mempalace_update_drawer` / `mempalace_kg_invalidate` / `mempalace_delete_by_source`); there is no replica to reconcile.

Two in-repo stores stay **only because the tooling reads those files directly** (a constraint, not a carve-out):
- `CLAUDE.md` — operating contract loaded verbatim by Claude Code at session start (instructions, not memory).
- `claude_docs/session_notes` + WAL — in-flight run-state read by the resume/context hooks; also ingested into mempalace via the PreCompact fork.

The `~/.claude/.../memory/` auto-memory dir (MEMORY.md + files) is now a secondary bootstrap mirror.

## Changes
- `docs/memory-source-of-truth.md` — rewritten to the new policy (roles table, CRUD tools, recall protocol, why the two in-repo stores can't move, history note recording the same-day correction).
- `README.md` — Design Documentation description + Changelog v3.11.4.
- Version 3.11.3 → 3.11.4 (`.claude-plugin/plugin.json`, `plugins/rawgentic/.codex-plugin/plugin.json`, version-pin test).

## Dogfooded
The decision is filed **in mempalace** (rawgentic/decisions drawer + a `rawgentic memory → authoritative_store_is → mempalace (read/write)` KG triple) and recall-verified (top hit, similarity 0.78).

## Pre-PR checklist
1. ✅ Version bumped (patch — docs)
2. ✅ README updated (incl. Changelog)
3. ✅ docs/ updated
4. ✅ Workflow diagram — no edit (docs-only, no workflow-spine change; deliberate). Newest rev 3.10.0 ≤ plugin 3.11.4.
5. ✅ Tests — **2035 passed, 0 failed** (unchanged baseline)

Refs #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)