### PR TITLE
test: review-lane activation smoke (throwaway — do not merge)

### DIFF
--- a/docs/.review-lane-smoke.md
+++ b/docs/.review-lane-smoke.md
@@ -1,0 +1,14 @@
+# Review-lane activation smoke test (throwaway — do NOT merge)
+
+Purpose: exercise the post-PR GitHub Action review lanes
+(`claude-security-review.yml`, `claude-code-review.yml`) to verify the
+`CLAUDE_CODE_OAUTH_TOKEN` org secret activates them.
+
+- **Before the secret:** the `security-review` / `code-review` checks show green but
+  their logs say `No CLAUDE_CODE_OAUTH_TOKEN … SKIPPED, not a clean signal` — a no-op.
+- **After the secret + a re-run:** the same checks actually invoke the reviewer over
+  this diff (logs show the review, not the SKIPPED warning).
+
+Tracking: activation UX + honest skip signal is #233 (epic #235).
+
+Close this PR after verifying — it is a smoke test, not a change to keep.


### PR DESCRIPTION
## Throwaway — smoke test for the review-lane activation (do NOT merge)

Opens a trivial diff to trigger the two post-PR Action lanes so you can verify the `CLAUDE_CODE_OAUTH_TOKEN` org secret activates them.

### How to test
1. **Look now** (before the secret): the `security-review` and `code-review` checks below will show ✓ **green**, but open their logs — you'll see `No CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY — … SKIPPED, not a clean signal`. That green is a **no-op** (the bug in #233).
2. **Add the org secret:**
   ```
   claude setup-token
   gh secret set CLAUDE_CODE_OAUTH_TOKEN --org 3D-Stories --visibility all
   ```
3. **Re-trigger the lanes** so they pick up the new secret (they don't retro-apply to the old run):
   - Actions tab → the `security-review` / `code-review` runs → **Re-run all jobs**, OR
   - `gh pr comment` / push any commit here to re-fire, OR simplest: `gh workflow run` isn't needed — just **Re-run** the two failed-to-review runs.
4. **Verify:** the re-run logs now show the reviewer actually running over this diff (no `SKIPPED` warning). That's activation confirmed.
5. **Close this PR** (do not merge) — it's only `docs/.review-lane-smoke.md`, a throwaway.

Tracking: #233 (honest skip signal + setup UX) · epic #235.
