### PR TITLE
feat(housekeeping): rawgentic:housekeeping skill for session-registry TTL pruning (#7)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "rawgentic",
-      "description": "6 SDLC workflow skills + 5 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, and dangerous pattern blocking with per-project exceptions.",
+      "description": "6 SDLC workflow skills + 6 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, and dangerous pattern blocking with per-project exceptions.",
       "source": "./",
       "strict": true,
       "skills": [
@@ -19,6 +19,7 @@
         "./skills/adversarial-review",
         "./skills/create-issue",
         "./skills/fix-bug",
+        "./skills/housekeeping",
         "./skills/implement-feature",
         "./skills/incident",
         "./skills/install-operating-charter",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rawgentic",
-  "version": "3.23.0",
-  "description": "6 SDLC workflow skills + 5 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, and dangerous pattern blocking with per-project exceptions.",
+  "version": "3.24.0",
+  "description": "6 SDLC workflow skills + 6 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",
     "url": "https://github.com/3D-Stories"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rawgentic
 
-**6 SDLC workflow skills + 5 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code**
+**6 SDLC workflow skills + 6 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-purple)](https://docs.anthropic.com/en/docs/claude-code)
@@ -11,9 +11,9 @@
 
 Claude Code is powerful but unstructured. Complex tasks — building features, fixing bugs, running security audits — need consistent quality gates, test-driven development, and deployment verification. Without guardrails, it's easy to skip code review, forget to run CI, or merge without testing.
 
-**Rawgentic** provides 14 skills organized in three layers (six little-used workflows were deprecated at v2.60.0 — #160 — and removed at v3.0.0; see `docs/upgrade-3.0.md`):
+**Rawgentic** provides 15 skills organized in three layers (six little-used workflows were deprecated at v2.60.0 — #160 — and removed at v3.0.0; see `docs/upgrade-3.0.md`):
 
-- **Workspace management** (5 skills) — Project registration, configuration, session binding, guard exception management, and opt-in operating-charter installation
+- **Workspace management** (6 skills) — Project registration, configuration, session binding, guard exception management, opt-in operating-charter installation, and session-registry housekeeping
 - **SDLC workflows** (6 skills) — Multi-step guided processes with quality gates, code review, CI verification, and deployment, plus a lightweight `interview` skill for pre-build requirements discovery
 - **Security & infrastructure** (1 skill + hooks) — Security pattern syncing, dangerous pattern blocking, per-project WAL logging, session binding enforcement, and cross-project file guards
 
@@ -158,6 +158,7 @@ Each add-on unlocks a specific capability. Rawgentic runs without them — you j
 | `/rawgentic:switch`         | Bind this session to a project, list projects, or deactivate. Checks for config staleness and prompts for missing `defaultProtectionLevel`. |
 | `/rawgentic:add-exception`  | Interactively add guard exceptions to `.rawgentic.json` when a WAL or security guard blocks a legitimate operation. |
 | `/rawgentic:install-operating-charter` | **Opt-in.** Install the rawgentic operating charter (quality/verification/honesty discipline) into a chosen `CLAUDE.md` via a one-line `@import`. Scope `{project | global | skip}`; never default, never silently writes global. |
+| `/rawgentic:housekeeping` | Prune stale entries from the append-only session registry older than a configurable TTL (default 30 days, `$RAWGENTIC_REGISTRY_TTL_DAYS`); fail-safe (keeps undatable lines), previews before writing. WAL rotation is handled automatically by session-start. |
 
 ### Planning
 
@@ -650,7 +651,7 @@ pytest tests/hooks/test_wal_guard.py -v
 
 **Impact measurement:** `scripts/wf2_impact_metrics.py` computes deterministic Tier-1 impact metrics (test growth, fail-closed coverage, dedup, diff volume) for a skill-extraction effort over a `--baseline`/`--head` git range. See [docs/measurements/2026-06-15-wf2-extraction-impact.md](docs/measurements/2026-06-15-wf2-extraction-impact.md) for the WF2 extraction analysis.
 
-Skills are tested via the `/skill-creator` eval pipeline (9/14 skills have evals.json files in their `skills/<skill>-workspace/evals/` directories; the lightweight `add-exception`, `install-operating-charter`, `interview`, `scan`, and `sync-security-patterns` skills have none, and `peer-consult` ships an empty stub — `skills/peer-consult/evals.json` — pending eval authoring).
+Skills are tested via the `/skill-creator` eval pipeline (9/15 skills have evals.json files in their `skills/<skill>-workspace/evals/` directories; the lightweight `add-exception`, `housekeeping`, `install-operating-charter`, `interview`, `scan`, and `sync-security-patterns` skills have none, and `peer-consult` ships an empty stub — `skills/peer-consult/evals.json` — pending eval authoring).
 
 **Workspace directories:** Some skills have a corresponding `*-workspace/` directory (e.g., `skills/setup-workspace/`) used for internal skill iteration and evaluation. These contain `evals/`, `iteration-N/`, and `skill-snapshot/` subdirectories. They are **excluded from marketplace installs** via the `skills` whitelist in `marketplace.json`. If you add a new workspace directory, never name a file `SKILL.md` inside it — the marketplace validator scans for that filename recursively and will reject duplicates.
 
@@ -700,6 +701,9 @@ For major changes, please open an issue first to discuss the approach.
 
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
+
+### v3.24.0 (2026-07-06)
+- **`rawgentic:housekeeping` skill — session-registry TTL pruning (#7, epic #247, rescoped).** `claude_docs/session_registry.jsonl` is append-only and gains one entry per bound session forever (session-start dedups by `session_id` but never prunes by age). New opt-in `/rawgentic:housekeeping` skill prunes entries whose `started` timestamp is older than a configurable TTL (default 30 days, `$RAWGENTIC_REGISTRY_TTL_DAYS`) and reports `kept / removed / undatable-kept`. **Fail-safe:** a malformed or undatable line is KEPT (a prune tool must never silently drop data it can't age); it previews before writing and only rewrites when something was removed. Logic is a tested helper `hooks/registry_prune.py` (pure `prune_registry` + CLI); the skill is a thin orchestrator. **Rescoped (#7's 2026-07-06 note):** the WAL half is dropped — session-start already rotates any WAL >5000 lines to a 7-day window, so WAL growth is already capped; only registry pruning was the real gap. 15th skill (marketplace entry + codex symlink + skill-count guards). `tests/hooks/test_registry_prune.py` +13. Not a workflow-spine change → no diagram REV. Suite 2265→2278.
 
 ### v3.23.0 (2026-07-06)
 - **Workflow diagram: station drill-down as a modal overlay (#227, epic #247).** Drilling into a station used to hash-navigate to a **full-page** detail view (the overview grid was replaced). Now clicking a station opens its drill-down in a native `<dialog>` (`showModal()`) **over the dimmed, still-rendered overview** — the reader keeps their place in the spine. Deep-links + back/forward preserved (the hash still carries `#/wf2/<ver>/s/<id>`; loading it opens the overview with the modal already open); Esc, a close button, and backdrop click all route back to `#/wf2/<ver>`; prev/next station nav works inside the modal; `<dialog>` supplies focus-trap + focus-restore + `::backdrop`, with `prefers-reduced-motion` honored. Built with the existing DOM-builder — **no `innerHTML`** — single self-contained CSP-safe file, both themes. **Verified live in a headless browser** (modal opens over the overview, deep-link, Esc/close/backdrop, prev/next, focus-in-modal, zero JS console errors); a cross-version edge case surfaced during that verification (stale close-handler) was fixed. Step-11 review added three more live-only fixes: the `body.modal-open` scroll-lock is now actually toggled (it was dead CSS — the overview scrolled behind the modal, defeating "keep your place"), the backdrop-close is guarded on a press that *started* on the backdrop (a scrollbar/text-drag no longer closes it), and focus lands on the close button after a prev/next content swap. `tests/test_workflow_diagram.py` +1 pins the modal (all existing guards — station coverage, no-innerHTML, snapshots, newest-rev — still pass). Overview visual unchanged → no README snapshot regen; interaction-only change → no diagram REV. Suite 2264→2265.

--- a/docs/wal-guide.md
+++ b/docs/wal-guide.md
@@ -117,6 +117,26 @@ The handler uses `fcntl.flock()` for concurrent safety, atomic writes via
 `tempfile` + `os.replace()`, and validates project names against
 `^[a-zA-Z0-9_-]+$`.
 
+## Session Registry Housekeeping (`/rawgentic:housekeeping`, #7)
+
+`claude_docs/session_registry.jsonl` is append-only — session-start dedups by
+`session_id` (keeping the latest) but never prunes by age, so it accumulates one
+entry per bound session forever. The opt-in **`/rawgentic:housekeeping`** skill (via
+the tested `hooks/registry_prune.py`) prunes entries whose `started` timestamp is
+older than a TTL:
+
+- **Threshold:** default **30 days**, configurable via `--ttl-days` or the
+  `RAWGENTIC_REGISTRY_TTL_DAYS` env var (a missing / non-int / `< 1` value falls back
+  to 30 — never prunes with a bogus TTL).
+- **Fail-safe:** a malformed line, or one with no datable `started`, is **kept** — the
+  prune never silently drops data it can't age. Blank lines are dropped.
+- **Reports** `kept / removed / undatable-kept`, previews with `--dry-run`, and only
+  rewrites the file when something was actually removed.
+
+WAL files are **not** pruned by this skill — they are already capped by the >5000-line
+rotation above (#7 rescope: WAL growth was already bounded; registry pruning was the
+real gap).
+
 ## WAL Guard (`hooks/wal-guard`)
 
 The WAL Guard is a separate PreToolUse hook (matcher: Bash) that blocks dangerous

--- a/hooks/registry_prune.py
+++ b/hooks/registry_prune.py
@@ -1,0 +1,133 @@
+"""Prune stale entries from a session registry (#7 — housekeeping).
+
+`claude_docs/session_registry.jsonl` grows one entry per session forever
+(session-start dedups by session_id but never prunes by age). This prunes entries
+whose `started` timestamp is older than a configurable TTL (default 30 days,
+env `RAWGENTIC_REGISTRY_TTL_DAYS`). Fail-safe: a line that can't be parsed or has no
+datable `started` is KEPT — a prune tool must never silently drop data it can't age.
+
+Pure core (`prune_registry`) + a CLI the `rawgentic:housekeeping` skill shells out to.
+WAL cleanup is out of scope: session-start already rotates any WAL >5000 lines.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+DEFAULT_TTL_DAYS = 30
+TTL_ENV = "RAWGENTIC_REGISTRY_TTL_DAYS"
+
+
+def ttl_days(env: dict | None = None) -> int:
+    """Resolve the TTL in days from the environment. Fail-safe: a missing, non-int,
+    or < 1 value falls back to the 30-day default (never prunes with a bogus TTL)."""
+    raw = (env if env is not None else os.environ).get(TTL_ENV)
+    if raw is None:
+        return DEFAULT_TTL_DAYS
+    try:
+        v = int(str(raw).strip())
+    except (ValueError, TypeError):
+        return DEFAULT_TTL_DAYS
+    return v if v >= 1 else DEFAULT_TTL_DAYS
+
+
+def _parse_started(obj) -> datetime | None:
+    """Return a tz-aware UTC datetime for the entry's `started`, or None if undatable."""
+    if not isinstance(obj, dict):
+        return None
+    s = obj.get("started")
+    if not isinstance(s, str) or not s.strip():
+        return None
+    try:
+        dt = datetime.fromisoformat(s.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+def prune_registry(text: str, now: datetime, ttl: int = DEFAULT_TTL_DAYS) -> tuple[str, dict]:
+    """Pure prune. Given the registry TEXT, a tz-aware `now`, and a TTL in days, return
+    `(new_text, stats)` with `stats = {kept, removed, undatable}`. An entry is REMOVED only
+    when its `started` parses AND is strictly older than `now - ttl`. Blank lines are
+    dropped; malformed / undatable lines are KEPT (counted in `undatable`, also in `kept`)."""
+    cutoff = now - timedelta(days=ttl)
+    kept_lines: list[str] = []
+    removed = 0
+    undatable = 0
+    for line in text.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        try:
+            obj = json.loads(s)
+        except (json.JSONDecodeError, ValueError):
+            kept_lines.append(s)
+            undatable += 1
+            continue
+        dt = _parse_started(obj)
+        if dt is None:
+            kept_lines.append(s)
+            undatable += 1
+            continue
+        if dt < cutoff:
+            removed += 1
+            continue
+        kept_lines.append(s)
+    new_text = ("\n".join(kept_lines) + "\n") if kept_lines else ""
+    return new_text, {"kept": len(kept_lines), "removed": removed, "undatable": undatable}
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="registry_prune",
+                                description="Prune stale session-registry entries (#7).")
+    p.add_argument("--registry", required=True, help="path to session_registry.jsonl")
+    p.add_argument("--ttl-days", type=int, default=None,
+                   help=f"override the TTL (else ${TTL_ENV} or {DEFAULT_TTL_DAYS})")
+    p.add_argument("--now", default=None, help="ISO timestamp override (testing)")
+    p.add_argument("--dry-run", action="store_true", help="report only; do not rewrite")
+    a = p.parse_args(argv)
+
+    ttl = a.ttl_days if a.ttl_days is not None else ttl_days()
+    if ttl < 1:
+        print("--ttl-days must be >= 1", file=sys.stderr)
+        return 2
+    if a.now:
+        try:
+            now = datetime.fromisoformat(a.now.replace("Z", "+00:00"))
+        except ValueError:
+            print(f"--now is not an ISO timestamp: {a.now}", file=sys.stderr)
+            return 2
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = datetime.now(timezone.utc)
+
+    try:
+        with open(a.registry, "r", encoding="utf-8") as f:
+            text = f.read()
+    except FileNotFoundError:
+        print(f"registry not found: {a.registry} (nothing to prune)")
+        return 0
+    except OSError as exc:
+        print(f"cannot read registry {a.registry}: {exc}", file=sys.stderr)
+        return 2
+
+    new_text, stats = prune_registry(text, now, ttl)
+    print(f"session-registry prune (ttl={ttl}d): kept {stats['kept']}, "
+          f"removed {stats['removed']}, undatable-kept {stats['undatable']}")
+    if a.dry_run:
+        print("(dry-run — no changes written)")
+    elif stats["removed"] > 0:
+        with open(a.registry, "w", encoding="utf-8") as f:
+            f.write(new_text)
+        print(f"rewrote {a.registry}")
+    else:
+        print("nothing to remove — registry unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/registry_prune.py
+++ b/hooks/registry_prune.py
@@ -15,6 +15,7 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 from datetime import datetime, timedelta, timezone
 
 DEFAULT_TTL_DAYS = 30
@@ -46,6 +47,30 @@ def _parse_started(obj) -> datetime | None:
     except ValueError:
         return None
     return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+def _atomic_write(path: str, text: str) -> None:
+    """Write `text` to `path` via a temp file + os.replace so a crash never leaves the
+    registry truncated/half-written (mirrors hooks/notes-size-handler.py's discipline).
+    ponytail: os.replace closes the truncate-corruption window. Residual ceiling (NOT
+    closed here): the registry's appenders are bash `printf ... >>` in skills/switch +
+    skills/new-project, which take no lock — so a session that BINDS in the window between
+    this prune's read and its os.replace can be dropped (its line went to the old inode).
+    Accepted for #7: opt-in manual tool, rarely run concurrently with a bind, and the lost
+    datum is a low-value registry line ("no correctness impact"); fully closing it needs
+    cooperative locking added to those two bash append sites — out of this issue's scope."""
+    d = os.path.dirname(os.path.abspath(path)) or "."
+    fd, tmp = tempfile.mkstemp(dir=d, prefix=".registry_prune.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def prune_registry(text: str, now: datetime, ttl: int = DEFAULT_TTL_DAYS) -> tuple[str, dict]:
@@ -121,8 +146,7 @@ def main(argv: list[str] | None = None) -> int:
     if a.dry_run:
         print("(dry-run — no changes written)")
     elif stats["removed"] > 0:
-        with open(a.registry, "w", encoding="utf-8") as f:
-            f.write(new_text)
+        _atomic_write(a.registry, new_text)   # temp + os.replace — never truncate-in-place
         print(f"rewrote {a.registry}")
     else:
         print("nothing to remove — registry unchanged")

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rawgentic",
-  "version": "3.23.0",
-  "description": "6 SDLC workflow skills + 5 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, and dangerous pattern blocking with per-project exceptions.",
+  "version": "3.24.0",
+  "description": "6 SDLC workflow skills + 6 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",
     "url": "https://github.com/3D-Stories"

--- a/plugins/rawgentic/skills/housekeeping
+++ b/plugins/rawgentic/skills/housekeeping
@@ -1,0 +1,1 @@
+../../../skills/housekeeping

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: rawgentic:housekeeping
+description: Prune stale entries from the session registry (claude_docs/session_registry.jsonl), which grows one entry per session forever. Use when the user asks to clean up / prune / trim the session registry or workspace housekeeping. Removes entries older than a configurable TTL (default 30 days) and reports what was cleaned. WAL files are NOT pruned here — session-start already rotates any WAL over 5000 lines.
+argument-hint: optional — "dry-run" to preview, or a TTL in days (e.g. "60")
+---
+
+<role>
+You run workspace housekeeping. Right now that means one thing: pruning the append-only
+**session registry** so it doesn't accumulate stale entries forever. You are a thin
+orchestrator — the prune logic is tested code in `hooks/registry_prune.py`; you resolve the
+registry path, run the CLI, and report. You do NOT touch WAL files: `hooks/session-start`
+already rotates any WAL over 5000 lines to a 7-day window, so the WAL is auto-capped (#7).
+</role>
+
+# Housekeeping — `/rawgentic:housekeeping`
+
+## What this prunes
+
+`claude_docs/session_registry.jsonl` gains one line per bound session and is never pruned
+by age (session-start dedups by `session_id` but keeps every distinct session forever).
+This removes entries whose `started` timestamp is older than the TTL. **Fail-safe:** a line
+that can't be parsed or has no datable `started` is KEPT — housekeeping never silently
+drops data it can't age.
+
+## Step 1: Resolve the registry path
+
+Find the workspace root (the directory containing `.rawgentic_workspace.json`); the registry
+is `<workspace-root>/claude_docs/session_registry.jsonl`. Honor an external
+`claudeDocsPath` in the workspace file if set (same resolution `hooks/session-start` uses).
+If the file doesn't exist, there is nothing to prune — report that and stop.
+
+## Step 2: Parse the argument
+
+- `dry-run` (or "preview") → pass `--dry-run` (report only, write nothing).
+- a bare number → pass it as `--ttl-days <n>` (overrides the default/env TTL).
+- nothing → default TTL (30 days, or `$RAWGENTIC_REGISTRY_TTL_DAYS`).
+
+## Step 3: Preview, then prune
+
+Show the user what WOULD change first (safe by default), then apply:
+
+```bash
+# preview
+python3 hooks/registry_prune.py --registry <abs-registry-path> --dry-run
+# then, if the user is happy (or the run is non-interactive), apply:
+python3 hooks/registry_prune.py --registry <abs-registry-path> [--ttl-days <n>]
+```
+
+The CLI reports `kept N, removed N, undatable-kept N` and only rewrites the file when it
+actually removed something. TTL is configurable: `--ttl-days` > `$RAWGENTIC_REGISTRY_TTL_DAYS`
+> default 30; a TTL below 1 is rejected (exit 2) rather than pruning everything.
+
+Exit codes: `0` success (incl. nothing-to-prune / missing file), `2` usage error (bad TTL
+or unreadable registry).
+
+## Step 4: Report
+
+Relay the CLI's summary line plainly: how many entries were kept, removed, and kept-because-
+undatable, and whether the file was rewritten. Note that WAL rotation is handled
+automatically by session-start and is out of scope for this skill.

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -38,7 +38,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.23.0"
+    assert plugin["version"] == "3.24.0"
 
 
 def test_descriptions_consistent_count():
@@ -56,10 +56,10 @@ def test_readme_count_strings_updated():
     readme = (REPO_ROOT / "README.md").read_text()
     assert "6 SDLC workflow skills" in readme
     assert "12 SDLC workflow skills" not in readme
-    assert "provides 14 skills" in readme
+    assert "provides 15 skills" in readme
     assert "All 7 config-driven skills" in readme
-    assert "9/14 skills have evals.json" in readme
-    assert "5 workspace management" in readme  # #113 — README count must match plugin/marketplace descriptions
+    assert "9/15 skills have evals.json" in readme
+    assert "6 workspace management" in readme  # #113 — README count must match plugin/marketplace descriptions
 
 
 def test_readme_changelog_has_no_spliced_headings():

--- a/tests/hooks/test_registry_prune.py
+++ b/tests/hooks/test_registry_prune.py
@@ -91,6 +91,8 @@ def test_cli_prunes_and_rewrites(tmp_path):
     assert r.returncode == 0, r.stderr
     lines = [l for l in reg.read_text().splitlines() if l.strip()]
     assert len(lines) == 1 and "new" in lines[0]
+    # atomic write via os.replace leaves no stray temp file behind
+    assert not list(tmp_path.glob(".registry_prune.*.tmp"))
 
 def test_cli_dry_run_does_not_write(tmp_path):
     reg = tmp_path / "r.jsonl"

--- a/tests/hooks/test_registry_prune.py
+++ b/tests/hooks/test_registry_prune.py
@@ -1,0 +1,110 @@
+"""Tests for hooks/registry_prune.py — session-registry TTL pruning (#7)."""
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+import registry_prune as rp  # noqa: E402
+
+CLI = HOOKS_DIR / "registry_prune.py"
+NOW = datetime(2026, 7, 6, tzinfo=timezone.utc)
+
+
+def _entry(sid, started):
+    return json.dumps({"session_id": sid, "project": "p", "project_path": "./p",
+                       "started": started, "cwd": "/w"})
+
+
+# --- ttl_days env resolution ------------------------------------------------
+
+def test_ttl_default():
+    assert rp.ttl_days({}) == 30
+
+def test_ttl_env_override():
+    assert rp.ttl_days({"RAWGENTIC_REGISTRY_TTL_DAYS": "7"}) == 7
+
+def test_ttl_env_invalid_falls_back():
+    assert rp.ttl_days({"RAWGENTIC_REGISTRY_TTL_DAYS": "abc"}) == 30
+    assert rp.ttl_days({"RAWGENTIC_REGISTRY_TTL_DAYS": "0"}) == 30
+    assert rp.ttl_days({"RAWGENTIC_REGISTRY_TTL_DAYS": "-5"}) == 30
+
+
+# --- prune_registry (pure) --------------------------------------------------
+
+def test_removes_old_keeps_recent():
+    text = "\n".join([
+        _entry("old", "2026-05-01T00:00:00Z"),   # 66 days before NOW → removed
+        _entry("recent", "2026-07-01T00:00:00Z"), # 5 days → kept
+    ]) + "\n"
+    out, stats = rp.prune_registry(text, NOW, 30)
+    assert stats == {"kept": 1, "removed": 1, "undatable": 0}
+    assert "recent" in out and "old" not in out
+
+def test_boundary_just_inside_ttl_kept():
+    text = _entry("edge", "2026-06-10T00:00:00Z") + "\n"  # 26 days → within 30 → kept
+    out, stats = rp.prune_registry(text, NOW, 30)
+    assert stats["removed"] == 0 and stats["kept"] == 1
+
+def test_undatable_lines_kept_failsafe():
+    text = "\n".join([
+        "{ not json",                                  # malformed
+        json.dumps({"session_id": "x"}),               # no started
+        json.dumps({"session_id": "y", "started": 42}),# non-str started
+        _entry("z", "2020-01-01T00:00:00Z"),           # ancient → removed
+    ]) + "\n"
+    out, stats = rp.prune_registry(text, NOW, 30)
+    assert stats["removed"] == 1
+    assert stats["undatable"] == 3
+    assert stats["kept"] == 3  # the 3 undatable survive
+    assert "z" not in out
+
+def test_blank_lines_dropped_not_counted():
+    text = _entry("a", "2026-07-05T00:00:00Z") + "\n\n\n"
+    out, stats = rp.prune_registry(text, NOW, 30)
+    assert stats["kept"] == 1
+    assert out == _entry("a", "2026-07-05T00:00:00Z") + "\n"
+
+def test_empty_text():
+    out, stats = rp.prune_registry("", NOW, 30)
+    assert out == "" and stats == {"kept": 0, "removed": 0, "undatable": 0}
+
+def test_naive_timestamp_treated_as_utc():
+    text = _entry("naive", "2026-05-01T00:00:00") + "\n"  # no Z → UTC → 66d → removed
+    _out, stats = rp.prune_registry(text, NOW, 30)
+    assert stats["removed"] == 1
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _run(*args):
+    return subprocess.run([sys.executable, str(CLI), *args], capture_output=True, text=True)
+
+def test_cli_prunes_and_rewrites(tmp_path):
+    reg = tmp_path / "session_registry.jsonl"
+    reg.write_text(_entry("old", "2026-01-01T00:00:00Z") + "\n"
+                   + _entry("new", "2026-07-05T00:00:00Z") + "\n", encoding="utf-8")
+    r = _run("--registry", str(reg), "--now", "2026-07-06T00:00:00Z")
+    assert r.returncode == 0, r.stderr
+    lines = [l for l in reg.read_text().splitlines() if l.strip()]
+    assert len(lines) == 1 and "new" in lines[0]
+
+def test_cli_dry_run_does_not_write(tmp_path):
+    reg = tmp_path / "r.jsonl"
+    body = _entry("old", "2026-01-01T00:00:00Z") + "\n"
+    reg.write_text(body, encoding="utf-8")
+    r = _run("--registry", str(reg), "--now", "2026-07-06T00:00:00Z", "--dry-run")
+    assert r.returncode == 0 and "dry-run" in r.stdout
+    assert reg.read_text() == body  # unchanged
+
+def test_cli_missing_registry_is_noop(tmp_path):
+    r = _run("--registry", str(tmp_path / "nope.jsonl"))
+    assert r.returncode == 0 and "nothing to prune" in r.stdout
+
+def test_cli_rejects_bad_ttl(tmp_path):
+    reg = tmp_path / "r.jsonl"; reg.write_text("", encoding="utf-8")
+    r = _run("--registry", str(reg), "--ttl-days", "0")
+    assert r.returncode == 2

--- a/tests/test_v3_removals.py
+++ b/tests/test_v3_removals.py
@@ -43,7 +43,7 @@ def test_marketplace_whitelist_has_no_removed_skills():
     mp = json.loads((REPO_ROOT / ".claude-plugin" / "marketplace.json").read_text())
     listed = {Path(rel).name for rel in mp["plugins"][0]["skills"]}
     assert not listed & set(REMOVED), f"whitelist still carries: {listed & set(REMOVED)}"
-    assert len(listed) == 14
+    assert len(listed) == 15
 
 
 def test_descriptions_no_longer_mention_stubs():


### PR DESCRIPTION
## Summary

Implements #7 (epic #247, **rescoped**, FINAL child): a `rawgentic:housekeeping` skill that prunes stale entries from the append-only session registry. `claude_docs/session_registry.jsonl` gains one line per bound session forever (session-start dedups by `session_id` but never prunes by age).

Per the issue's **2026-07-06 rescope**: the WAL half is dropped — session-start already rotates any WAL >5000 lines to a 7-day window, so WAL growth is already capped; **registry pruning was the only real gap**.

## Changes

- **`hooks/registry_prune.py`** — pure `prune_registry(text, now, ttl)` + a CLI. Prunes entries whose `started` is strictly older than `now - ttl`. **Fail-safe:** a malformed line, or one with no datable `started`, is **kept** (a prune must never silently drop data it can't age); blank lines dropped. Reports `kept / removed / undatable-kept`. **Atomic write** (tempfile + `os.replace`) so a crash can't truncate the registry.
- **`skills/housekeeping/SKILL.md`** — thin orchestrator: resolve the registry path → preview (`--dry-run`) → apply → report. TTL: `--ttl-days` > `$RAWGENTIC_REGISTRY_TTL_DAYS` > default 30 (a `<1` value is rejected, never prunes-all).
- 15th skill: marketplace entry + codex symlink + all skill-count guards (15 skills / 6 workspace management / 9-of-15 evals). `docs/wal-guide.md` documents the pass.

## Acceptance criteria (rescoped)

- [x] `rawgentic:housekeeping` prunes `session_registry.jsonl` entries older than a configurable TTL (default 30d) and reports what was removed
- [x] WAL archival out of scope (rotation already caps growth) — noted
- [x] Tests cover the prune + TTL + CLI

## Review

- **Step 11 (Opus reviewer):** 1 Medium, 0 Critical/High. **F1a fixed** — the write was `open("w")` truncate-in-place (crash → empty registry); now tempfile + `os.replace`. **F1b** — a concurrent bash `>>` bind during the read→write window can be lost; `os.replace` can't save it (needs locking the two bash append sites), so it's documented as an accepted ceiling at the write site (opt-in tool, rarely concurrent with a bind, low-value registry line). Fail-safe/TTL/boundary/timezone/registration all verified correct.
- **Step 11.5 security scan:** PASS (visible skips: IaC N/A, SCA nothing-to-scan).

## Tests

`pytest tests/` — **2278 passed, 0 failed** (branch baseline 2265; +13 `test_registry_prune.py`; 0 regressions). pylint lane clean.

Version 3.23.0 → **3.24.0** (minor / feat) ×3 surfaces. No diagram REV — not a workflow-spine change.

> Advisory `code-review`/`security-review` lanes may be red on the Claude Code Action OAuth outage (advisory per `docs/ci-review-lanes.md`). `test` + `lint` are the hard signals.

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
