### PR TITLE
fix(work_summary): render_summary never raises on non-dict record — v3.24.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.24.2",
+  "version": "3.24.3",
   "description": "6 SDLC workflow skills + 6 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -702,6 +702,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v3.24.3 (2026-07-07)
+- **render_summary no longer raises on a non-dict record (#261, epic #277).** `hooks/work_summary.py` read `verification_deferred` off the raw parameter while every sibling access routes through the `_as_dict`-coerced copy, so a list/str/int record raised `AttributeError` despite the function's "never raises" contract. One-line fix routes the read through the coerced copy; a parametrized reproduction test (list/str/int/None records) was red before the fix. No workflow-spine change → no diagram REV. Suite 2278→2283.
+
 ### v3.24.2 (2026-07-07)
 - **Unified harness + code review deliverable committed (docs).** `docs/reviews/2026-07-07-harness-and-code-review.md` and its rendered `.html` added: 28 confirmed findings (6 harness H-A…H-F, 22 code C1…C22, each independently re-verified), severity summary, a proposed 6-epic / 25-child work breakdown with dependency edges and acceptance criteria, a post-publication QA-pass record (cross-map complete both directions, 5 findings re-verified first-hand, suite re-run 2278/0), a discard log, and named coverage gaps. Review-only PR — no code changed. No workflow-spine change → no diagram REV. Suite 2278→2278.
 

--- a/hooks/work_summary.py
+++ b/hooks/work_summary.py
@@ -575,7 +575,7 @@ def render_summary(record) -> str:
     usage = _as_dict(r.get("usage"))
     if usage:
         lines.append(_render_usage_line(usage))
-    deferred = record.get("verification_deferred")
+    deferred = r.get("verification_deferred")
     if isinstance(deferred, list) and deferred:
         lines.append("- Verification deferred (must be checked on target):")
         for d in deferred:

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.24.2",
+  "version": "3.24.3",
   "description": "6 SDLC workflow skills + 6 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -38,7 +38,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.24.2"
+    assert plugin["version"] == "3.24.3"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_work_summary.py
+++ b/tests/hooks/test_work_summary.py
@@ -561,6 +561,21 @@ class TestRenderSummary:
         text = render_summary(bad)
         assert isinstance(text, str) and text
 
+    @pytest.mark.parametrize("nondict", [
+        [],                    # a record file holding a JSON array
+        ["a", "b"],
+        "not-a-record",
+        42,
+        None,
+    ])
+    def test_never_raises_on_nondict_record(self, nondict):
+        """#261: the docstring promises "never raises on a ... non-dict record",
+        but the verification_deferred read went through the RAW param instead of
+        the _as_dict-coerced copy, so a list/str/int record raised AttributeError."""
+        from work_summary import render_summary
+        text = render_summary(nondict)
+        assert isinstance(text, str) and text
+
 
 # --- resolve_store_path ----------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #261 (review finding C1, epic #277): `render_summary()` in `hooks/work_summary.py` promises in its docstring to "never raise on a partial/invalid/non-dict record", but line 578 read `verification_deferred` off the RAW parameter while every sibling access routes through the `_as_dict`-coerced copy — so a list/str/int/None record raised `AttributeError` on the rc=1 unvalidated render path (live trigger: a record file holding a JSON array/scalar).

## Root cause & fix

- Root cause: `hooks/work_summary.py:578` — `record.get(...)` bypassed `r = _as_dict(record)` (line 510).
- Fix: one line, `deferred = r.get("verification_deferred")`. Behavior identical for dict records (`_as_dict` returns the same object for dicts). Both callers (`render_summary(raw)` rc=1 path and normalized path) route through the shared function.

## Reproduce-first evidence

- New parametrized test `TestRenderSummary::test_never_raises_on_nondict_record` (list / list-of-str / str / int / None): **5 failed before the fix** (AttributeError), all green after.

## Gates

- Full suite: **2283 passed, 0 failing** (baseline 2278/0; +5 = the new reproduction params)
- Both pylint lanes: 10.00/10
- Security scan: PASS; visible skips: `iac` (n/a), `sca` (osv-scanner: nothing to scan)
- Version ×3 → 3.24.3; README changelog entry with diagram decision (no spine change → no REV) + Suite 2278→2283
- Code review (Step 9): 2 independent reviewers (routed model: opus) — both NO FINDINGS; failure-lens reviewer empirically confirmed red-before-green per param against origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
