### PR TITLE
feat(hooks): unify claude_docs resolution across all six resolver surfaces — v3.24.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.24.3",
+  "version": "3.24.4",
   "description": "6 SDLC workflow skills + 6 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -702,6 +702,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v3.24.4 (2026-07-07)
+- **claude_docs resolution unified across all six resolver surfaces (#262, epic #277).** `claudeDocsPath` resolution had drifted into three semantics: `wal-lib.sh` trusted an absolute path outside `$HOME`, the inline copies in `wal-stop`/`wal-suspend`/`wal-bind-guard` rejected it, and `session-start`/`security-guard.py` (two surfaces the review missed) trusted everything with no containment. Now ONE semantic — containment under `$HOME` or workspace-relative fallback — lives in `wal_resolve_claude_docs()` (plus a python mirror in `security-guard.py`); the four bash consumers source the lib, deleting ~90 duplicated lines. Structural tests pin the routing; red-before-green rejection tests cover bash + python; `docs/wal-guide.md` documents the semantic. Unblocks review children 3d and 4a. No workflow-spine change → no diagram REV. Suite 2283→2293.
+
 ### v3.24.3 (2026-07-07)
 - **render_summary no longer raises on a non-dict record (#261, epic #277).** `hooks/work_summary.py` read `verification_deferred` off the raw parameter while every sibling access routes through the `_as_dict`-coerced copy, so a list/str/int record raised `AttributeError` despite the function's "never raises" contract. One-line fix routes the read through the coerced copy; a parametrized reproduction test (list/str/int/None records) was red before the fix. No workflow-spine change → no diagram REV. Suite 2278→2283.
 

--- a/docs/wal-guide.md
+++ b/docs/wal-guide.md
@@ -17,6 +17,15 @@ The `claude_docs/` directory is resolved from the `claudeDocsPath` field in
 `.rawgentic_workspace.json`. If the field is absent, hooks fall back to
 `<workspace_root>/claude_docs/` for backward compatibility.
 
+Resolution lives in exactly two places (#262): `wal-lib.sh`'s
+`wal_resolve_claude_docs()` (bash source of truth — `wal-stop`, `wal-suspend`,
+`wal-bind-guard`, and `session-start` all source the lib rather than carrying
+inline copies) and a matching python mirror in `security-guard.py`. Both apply
+the same containment guard: every `claudeDocsPath` — tilde or absolute — must
+resolve under `$HOME`; a path outside `$HOME` is rejected with a warning and
+the workspace-relative fallback is used, so WAL/registry writers and readers
+can never be split across two directories.
+
 After migration (automatic on first startup with v2.20.0+), session data lives
 at `~/claude_docs/` and a symlink at the old workspace-relative location
 preserves backward compatibility.

--- a/hooks/security-guard.py
+++ b/hooks/security-guard.py
@@ -140,7 +140,16 @@ def _log_headless_guard_block(findings, rel_path, workspace_root, session_id=Non
                     ws_config = json.load(f)
                 cdp = ws_config.get("claudeDocsPath", "")
                 if cdp:
-                    claude_docs = os.path.expanduser(cdp)
+                    # Containment guard (#262): mirror wal-lib.sh's shared
+                    # semantic — every claudeDocsPath must resolve under $HOME,
+                    # else keep the workspace-relative fallback so the audit
+                    # log lands where the WAL readers look.
+                    home = os.path.realpath(os.path.expanduser("~"))
+                    resolved = os.path.realpath(os.path.expanduser(cdp))
+                    if resolved == home or resolved.startswith(home + os.sep):
+                        claude_docs = resolved
+                    else:
+                        _warn(f"claudeDocsPath outside $HOME rejected: {cdp}")
             except (json.JSONDecodeError, OSError):
                 pass
 

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -6,6 +6,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Shared resolution (#262): workspace find + claude_docs containment come from
+# wal-lib.sh — never inline a copy here.
+source "$SCRIPT_DIR/wal-lib.sh"
 
 # --- Shared utilities ---
 escape_for_json() {
@@ -51,28 +54,16 @@ fi
 CONTEXT_PARTS=()
 
 # Find workspace file (traverse up from CWD)
-WORKSPACE_FILE=""
-WS_ROOT=""
-_d="$CWD"
-_i=0
-while [ "$_i" -lt 5 ] && [ "$_d" != "/" ]; do
-    if [ -f "$_d/.rawgentic_workspace.json" ]; then
-        WORKSPACE_FILE="$_d/.rawgentic_workspace.json"
-        WS_ROOT="$_d"
-        break
-    fi
-    _d=$(cd "$_d/.." 2>/dev/null && pwd) || break
-    _i=$((_i + 1))
-done
+WAL_CWD="$CWD"
+wal_find_workspace || true
+WORKSPACE_FILE="$WAL_WORKSPACE_FILE"
+WS_ROOT="$WAL_WORKSPACE_ROOT"
 
-# --- Resolve claude_docs path ---
+# --- Resolve claude_docs path (shared containment semantics, #262) ---
 CLAUDE_DOCS=""
-[ -n "$WS_ROOT" ] && CLAUDE_DOCS="$WS_ROOT/claude_docs"
-if [ -n "$WORKSPACE_FILE" ] && command -v "$JQ" &>/dev/null; then
-    _cdp=$("$JQ" -r '.claudeDocsPath // ""' "$WORKSPACE_FILE" 2>/dev/null || true)
-    if [ -n "$_cdp" ]; then
-        CLAUDE_DOCS="${_cdp/#\~/$HOME}"
-    fi
+if [ -n "$WS_ROOT" ]; then
+    wal_resolve_claude_docs
+    CLAUDE_DOCS="$WAL_CLAUDE_DOCS"
 fi
 
 # =========================================================================

--- a/hooks/wal-bind-guard
+++ b/hooks/wal-bind-guard
@@ -9,33 +9,25 @@
 
 set -euo pipefail
 
-INPUT=$(cat)
+# Shared resolution (#262): stdin parse, workspace find, claude_docs
+# containment, and registry lookup come from wal-lib.sh — never inline a copy.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/wal-lib.sh"
 
-JQ="${HOME}/.local/bin/jq"
-[ -x "$JQ" ] || JQ="jq"
-command -v "$JQ" &>/dev/null || exit 0
-
-SESSION_ID=$(printf '%s' "$INPUT" | "$JQ" -r '.session_id // "unknown"')
-CWD=$(printf '%s' "$INPUT" | "$JQ" -r '.cwd // "."')
-TOOL_NAME=$(printf '%s' "$INPUT" | "$JQ" -r '.tool_name // ""')
+wal_read_stdin
+command -v "$WAL_JQ" &>/dev/null || exit 0
+wal_parse_fields
+INPUT="$WAL_RAW_INPUT"
+JQ="$WAL_JQ"
+SESSION_ID="$WAL_SESSION_ID"
+TOOL_NAME="$WAL_TOOL_NAME"
 
 [ "$SESSION_ID" = "unknown" ] && exit 0
 
 # --- Find workspace (traverse up to 5 levels) ---
-WORKSPACE_FILE=""
-WORKSPACE_ROOT=""
-_d="$CWD"
-_i=0
-while [ "$_i" -lt 5 ] && [ "$_d" != "/" ]; do
-    if [ -f "$_d/.rawgentic_workspace.json" ]; then
-        WORKSPACE_FILE="$_d/.rawgentic_workspace.json"
-        WORKSPACE_ROOT="$_d"
-        break
-    fi
-    _d=$(cd "$_d/.." 2>/dev/null && pwd) || break
-    _i=$((_i + 1))
-done
-[ -z "$WORKSPACE_FILE" ] && exit 0
+wal_find_workspace || exit 0
+WORKSPACE_FILE="$WAL_WORKSPACE_FILE"
+WORKSPACE_ROOT="$WAL_WORKSPACE_ROOT"
 
 # --- Helper: extract file path from tool input ---
 _get_file_path() {
@@ -63,26 +55,13 @@ _is_project_file() {
     return 1
 }
 
-# --- Resolve claude_docs path ---
-CLAUDE_DOCS="$WORKSPACE_ROOT/claude_docs"
-_cdp=$("$JQ" -r '.claudeDocsPath // ""' "$WORKSPACE_FILE" 2>/dev/null || true)
-if [ -n "$_cdp" ]; then
-    _cdp="${_cdp/#\~/$HOME}"
-    _resolved=$(realpath -m "$_cdp" 2>/dev/null || echo "$_cdp")
-    if [ "${_resolved#$HOME/}" != "$_resolved" ] || [ "$_resolved" = "$HOME" ]; then
-        CLAUDE_DOCS="$_resolved"
-    fi
-fi
+# --- Resolve claude_docs path (shared containment semantics) ---
+wal_resolve_claude_docs
+CLAUDE_DOCS="$WAL_CLAUDE_DOCS"
 
-# --- Resolve bound project from registry ---
-REGISTRY_FILE="$CLAUDE_DOCS/session_registry.jsonl"
-BOUND_PROJECT=""
-if [ -f "$REGISTRY_FILE" ]; then
-    REG_LINE=$(grep "$SESSION_ID" "$REGISTRY_FILE" 2>/dev/null | tail -1 || true)
-    if [ -n "$REG_LINE" ]; then
-        BOUND_PROJECT=$(printf '%s' "$REG_LINE" | "$JQ" -r '.project // ""' 2>/dev/null || true)
-    fi
-fi
+# --- Resolve bound project from registry (shared lookup) ---
+wal_resolve_project
+BOUND_PROJECT="$WAL_PROJECT"
 
 # --- Gate 1: Unbound session check ---
 if [ -z "$BOUND_PROJECT" ]; then

--- a/hooks/wal-lib.sh
+++ b/hooks/wal-lib.sh
@@ -73,23 +73,21 @@ wal_resolve_claude_docs() {
     local cdp
     cdp=$("$WAL_JQ" -r '.claudeDocsPath // ""' "$WAL_WORKSPACE_FILE" 2>/dev/null || true)
     if [ -n "$cdp" ]; then
-      local had_tilde=false
-      if [ "${cdp#\~}" != "$cdp" ]; then
-        had_tilde=true
-        cdp="${cdp/#\~/$HOME}"
-      fi
-      local resolved
+      cdp="${cdp/#\~/$HOME}"
+      local resolved home
       resolved=$(realpath -m "$cdp" 2>/dev/null || echo "$cdp")
-      if [ "$had_tilde" = true ]; then
-        # Tilde-expanded paths must stay under $HOME (path traversal guard)
-        if [ "${resolved#$HOME/}" != "$resolved" ] || [ "$resolved" = "$HOME" ]; then
-          WAL_CLAUDE_DOCS="$resolved"
-        else
-          echo "wal-lib: WARNING: claudeDocsPath traversal rejected: $cdp" >&2
-        fi
-      else
-        # Explicit absolute paths are trusted
+      # Containment guard (#262): EVERY claudeDocsPath — tilde or absolute —
+      # must resolve under $HOME, else the guards could read a different dir
+      # than the WAL/registry writers use. Outside $HOME → warn + keep the
+      # workspace-relative fallback. This is the single semantic all hooks
+      # share; do not reintroduce a per-hook copy. HOME is realpath'd so a
+      # symlinked HOME component compares equal — exact parity with the
+      # python mirror in security-guard.py.
+      home=$(realpath -m "$HOME" 2>/dev/null || echo "$HOME")
+      if [ "${resolved#$home/}" != "$resolved" ] || [ "$resolved" = "$home" ]; then
         WAL_CLAUDE_DOCS="$resolved"
+      else
+        echo "wal-lib: WARNING: claudeDocsPath outside \$HOME rejected: $cdp" >&2
       fi
     fi
   fi

--- a/hooks/wal-stop
+++ b/hooks/wal-stop
@@ -6,53 +6,30 @@
 _do_stop() {
     set -euo pipefail
 
-    INPUT=$(cat)
+    # Shared resolution (#262): workspace find, claude_docs containment, and
+    # registry lookup all come from wal-lib.sh — never inline a copy here.
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    source "$SCRIPT_DIR/wal-lib.sh"
 
-    JQ="${HOME}/.local/bin/jq"
-    [ -x "$JQ" ] || JQ="jq"
-    command -v "$JQ" &>/dev/null || exit 0
-
-    SESSION_ID=$(printf '%s' "$INPUT" | "$JQ" -r '.session_id // "unknown"')
-    CWD=$(printf '%s' "$INPUT" | "$JQ" -r '.cwd // "."')
+    wal_read_stdin
+    command -v "$WAL_JQ" &>/dev/null || exit 0
+    wal_parse_fields
+    JQ="$WAL_JQ"
+    SESSION_ID="$WAL_SESSION_ID"
 
     [ "$SESSION_ID" = "unknown" ] && exit 0
 
     # --- Guard clause: not a rawgentic session ---
-    WORKSPACE_FILE=""
-    WS_ROOT=""
-    _d="$CWD"
-    _i=0
-    while [ "$_i" -lt 5 ] && [ "$_d" != "/" ]; do
-        if [ -f "$_d/.rawgentic_workspace.json" ]; then
-            WORKSPACE_FILE="$_d/.rawgentic_workspace.json"
-            WS_ROOT="$_d"
-            break
-        fi
-        _d=$(cd "$_d/.." 2>/dev/null && pwd) || break
-        _i=$((_i + 1))
-    done
-    [ -z "$WORKSPACE_FILE" ] && exit 0
+    wal_find_workspace || exit 0
+    WORKSPACE_FILE="$WAL_WORKSPACE_FILE"
 
-    # --- Resolve claude_docs path ---
-    CLAUDE_DOCS="$WS_ROOT/claude_docs"
-    _cdp=$("$JQ" -r '.claudeDocsPath // ""' "$WORKSPACE_FILE" 2>/dev/null || true)
-    if [ -n "$_cdp" ]; then
-        _cdp="${_cdp/#\~/$HOME}"
-        _resolved=$(realpath -m "$_cdp" 2>/dev/null || echo "$_cdp")
-        if [ "${_resolved#$HOME/}" != "$_resolved" ] || [ "$_resolved" = "$HOME" ]; then
-            CLAUDE_DOCS="$_resolved"
-        fi
-    fi
+    # --- Resolve claude_docs path (shared containment semantics) ---
+    wal_resolve_claude_docs
+    CLAUDE_DOCS="$WAL_CLAUDE_DOCS"
 
     # --- Lookup project from registry ---
-    REGISTRY_FILE="$CLAUDE_DOCS/session_registry.jsonl"
-    PROJECT=""
-    if [ -f "$REGISTRY_FILE" ]; then
-        REG_LINE=$(grep "$SESSION_ID" "$REGISTRY_FILE" 2>/dev/null | tail -1 || true)
-        if [ -n "$REG_LINE" ]; then
-            PROJECT=$(printf '%s' "$REG_LINE" | "$JQ" -r '.project // ""')
-        fi
-    fi
+    wal_resolve_project
+    PROJECT="$WAL_PROJECT"
 
     # Fallback to active workspace project
     if [ -z "$PROJECT" ]; then

--- a/hooks/wal-suspend
+++ b/hooks/wal-suspend
@@ -17,38 +17,23 @@
 
 set -euo pipefail
 
+# Shared resolution (#262): workspace find + claude_docs containment come from
+# wal-lib.sh — never inline a copy here.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/wal-lib.sh"
 
-# --- Resolve jq ---
-JQ="${HOME}/.local/bin/jq"
-[ -x "$JQ" ] || JQ="jq"
+# --- Resolve jq (lib sets WAL_JQ) ---
+JQ="$WAL_JQ"
 command -v "$JQ" &>/dev/null || { echo "jq not found" >&2; exit 1; }
 
 # --- Find workspace root ---
-CWD="${PWD}"
-WS_ROOT=""
-_d="$CWD"
-_i=0
-while [ "$_i" -lt 5 ] && [ "$_d" != "/" ]; do
-    if [ -f "$_d/.rawgentic_workspace.json" ]; then
-        WS_ROOT="$_d"
-        break
-    fi
-    _d=$(cd "$_d/.." 2>/dev/null && pwd) || break
-    _i=$((_i + 1))
-done
-[ -z "$WS_ROOT" ] && { echo "No rawgentic workspace found" >&2; exit 1; }
+WAL_CWD="${PWD}"
+wal_find_workspace || { echo "No rawgentic workspace found" >&2; exit 1; }
+WS_ROOT="$WAL_WORKSPACE_ROOT"
 
-# --- Resolve claude_docs path ---
-CLAUDE_DOCS="$WS_ROOT/claude_docs"
-_cdp=$("$JQ" -r '.claudeDocsPath // ""' "$WS_ROOT/.rawgentic_workspace.json" 2>/dev/null || true)
-if [ -n "$_cdp" ]; then
-    _cdp="${_cdp/#\~/$HOME}"
-    _resolved=$(realpath -m "$_cdp" 2>/dev/null || echo "$_cdp")
-    if [ "${_resolved#$HOME/}" != "$_resolved" ] || [ "$_resolved" = "$HOME" ]; then
-        CLAUDE_DOCS="$_resolved"
-    fi
-fi
+# --- Resolve claude_docs path (shared containment semantics) ---
+wal_resolve_claude_docs
+CLAUDE_DOCS="$WAL_CLAUDE_DOCS"
 
 # --- Read session ID (with staleness check) ---
 SESSION_FILE="$CLAUDE_DOCS/.current_session_id"
@@ -63,15 +48,10 @@ if [ "$SESSION_FILE_AGE" -gt 86400 ]; then
     echo "WARNING: .current_session_id is >24h old (may be stale)" >&2
 fi
 
-# --- Resolve project from registry ---
-REGISTRY="$CLAUDE_DOCS/session_registry.jsonl"
-PROJECT=""
-if [ -f "$REGISTRY" ]; then
-    REG_LINE=$(grep "$SESSION_ID" "$REGISTRY" 2>/dev/null | tail -1 || true)
-    if [ -n "$REG_LINE" ]; then
-        PROJECT=$(printf '%s' "$REG_LINE" | "$JQ" -r '.project // ""')
-    fi
-fi
+# --- Resolve project from registry (shared lookup) ---
+WAL_SESSION_ID="$SESSION_ID"
+wal_resolve_project
+PROJECT="$WAL_PROJECT"
 
 # Fallback: first active project
 if [ -z "$PROJECT" ]; then

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.24.3",
+  "version": "3.24.4",
   "description": "6 SDLC workflow skills + 6 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -38,7 +38,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.24.3"
+    assert plugin["version"] == "3.24.4"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_session_binding.py
+++ b/tests/hooks/test_session_binding.py
@@ -133,3 +133,65 @@ def test_new_project_skill_uses_env_var_for_session_id():
     text = (SKILLS_DIR / "new-project" / "SKILL.md").read_text()
     assert "$CLAUDE_CODE_SESSION_ID" in text, \
         "new-project skill must source the session id from $CLAUDE_CODE_SESSION_ID"
+
+
+# --- security-guard claudeDocsPath containment (#262) --------------------------
+
+
+def test_log_rejects_claude_docs_path_outside_home(make_workspace, monkeypatch, tmp_path):
+    """#262 (C21 python mirror): an absolute claudeDocsPath OUTSIDE $HOME must be
+    rejected — the GUARD_BLOCK audit line falls back to the workspace-relative
+    claude_docs/ (where the WAL readers look), never the outside dir."""
+    mod = _load_security_guard()
+    ws = _two_project_ws(make_workspace)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    outside = tmp_path / "outside-docs"
+    outside.mkdir()
+    # Give the outside dir its own registry so the OLD (trusting) code would
+    # have resolved a project there and written the WAL outside.
+    (outside / "session_registry.jsonl").write_text(
+        json.dumps({"session_id": SID_B, "project": "projB",
+                    "project_path": "./projects/projB"}) + "\n")
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    ws_file = ws.root / ".rawgentic_workspace.json"
+    data = json.loads(ws_file.read_text())
+    data["claudeDocsPath"] = str(outside)
+    ws_file.write_text(json.dumps(data))
+
+    mod._log_headless_guard_block(
+        [{"name": "r"}], "foo.py", str(ws.root), session_id=SID_B)
+
+    assert not (outside / "wal").exists(), (
+        "outside-HOME claudeDocsPath must be rejected, not written to")
+    assert (ws.claude_docs / "wal" / "projB.jsonl").exists(), (
+        "audit line must land in the workspace-relative fallback")
+
+
+def test_log_accepts_claude_docs_path_under_home(make_workspace, monkeypatch, tmp_path):
+    """Companion: an absolute claudeDocsPath UNDER $HOME is honored."""
+    mod = _load_security_guard()
+    ws = _two_project_ws(make_workspace)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+
+    fake_home = tmp_path / "fakehome"
+    inside = fake_home / "my-docs"
+    inside.mkdir(parents=True)
+    (inside / "session_registry.jsonl").write_text(
+        json.dumps({"session_id": SID_B, "project": "projB",
+                    "project_path": "./projects/projB"}) + "\n")
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    ws_file = ws.root / ".rawgentic_workspace.json"
+    data = json.loads(ws_file.read_text())
+    data["claudeDocsPath"] = str(inside)
+    ws_file.write_text(json.dumps(data))
+
+    mod._log_headless_guard_block(
+        [{"name": "r"}], "foo.py", str(ws.root), session_id=SID_B)
+
+    assert (inside / "wal" / "projB.jsonl").exists(), (
+        "under-HOME claudeDocsPath must be honored")

--- a/tests/hooks/test_wal_lib.py
+++ b/tests/hooks/test_wal_lib.py
@@ -444,12 +444,28 @@ echo "$WAL_CLAUDE_DOCS"
         return stdout, stderr
 
     def test_reads_claude_docs_path_from_config(self, make_workspace, tmp_path):
-        """When claudeDocsPath is set, resolves to the expanded path."""
-        target = tmp_path / "fakehome" / "claude_docs"
+        """When claudeDocsPath is set (absolute, under $HOME), resolves to it."""
+        fake_home = tmp_path / "fakehome"
+        target = fake_home / "claude_docs"
         target.mkdir(parents=True)
         ws = make_workspace(claude_docs_path=str(target))
-        result, _ = self._resolve(ws)
+        result, _ = self._resolve(ws, home_dir=fake_home)
         assert result == str(target)
+
+    def test_absolute_outside_home_rejected(self, make_workspace, tmp_path):
+        """#262 (C21): an absolute claudeDocsPath OUTSIDE $HOME is rejected with
+        a warning and falls back to workspace-relative — the same containment
+        the sibling resolvers (wal-stop/wal-suspend/wal-bind-guard) always
+        applied. Before the unification the lib trusted it, so WAL/registry
+        writes could land where the guards never read."""
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        outside = tmp_path / "elsewhere" / "claude_docs"
+        outside.mkdir(parents=True)
+        ws = make_workspace(claude_docs_path=str(outside))
+        result, stderr = self._resolve(ws, home_dir=fake_home)
+        assert result == f"{ws.root}/claude_docs"
+        assert "rejected" in stderr.lower()
 
     def test_tilde_expansion(self, make_workspace, tmp_path):
         """Tilde in claudeDocsPath is expanded to $HOME."""
@@ -500,7 +516,7 @@ wal_init_file
 echo "$WAL_DIR"
 echo "$WAL_FILE"
 """
-        stdout, _, rc = _run_bash(script)
+        stdout, _, rc = _run_bash(script, env_override={"HOME": str(tmp_path / "fakehome")})
         assert rc == 0
         lines = stdout.strip().split("\n")
         assert lines[0] == str(target / "wal")
@@ -528,6 +544,35 @@ wal_resolve_claude_docs
 wal_resolve_project
 echo "$WAL_PROJECT"
 """
-        stdout, _, rc = _run_bash(script)
+        stdout, _, rc = _run_bash(script, env_override={"HOME": str(tmp_path / "fakehome")})
         assert rc == 0
         assert stdout == "testproj"
+
+
+class TestSharedResolutionRouting:
+    """#262: claudeDocsPath path RESOLUTION lives in exactly two places —
+    wal-lib.sh (bash source of truth) and security-guard.py (python mirror,
+    same containment semantic). Every bash consumer sources the lib instead of
+    carrying an inline copy; inline copies are what diverged (C7/C21)."""
+
+    CONSUMERS = ["wal-stop", "wal-suspend", "wal-bind-guard", "session-start"]
+    # These three had full inline resolver copies before #262 and have NO other
+    # legitimate claudeDocsPath use, so the string must be entirely absent.
+    # (session-start keeps two non-resolution uses: the migration presence
+    # check and the migration write — both act on the raw field, not a path.)
+    NO_INLINE = ["wal-stop", "wal-suspend", "wal-bind-guard"]
+
+    @pytest.mark.parametrize("script", CONSUMERS)
+    def test_consumer_sources_wal_lib(self, script):
+        text = (HOOKS_DIR / script).read_text()
+        assert 'source "$SCRIPT_DIR/wal-lib.sh"' in text, (
+            f"{script} must source wal-lib.sh for shared resolution")
+        assert "wal_resolve_claude_docs" in text, (
+            f"{script} must resolve claude_docs via the shared function")
+
+    @pytest.mark.parametrize("script", NO_INLINE)
+    def test_no_inline_claude_docs_parse(self, script):
+        text = (HOOKS_DIR / script).read_text()
+        assert "claudeDocsPath" not in text, (
+            f"{script} carries an inline claudeDocsPath parse — the divergent-"
+            f"copy pattern #262 removed; route through wal-lib.sh instead")


### PR DESCRIPTION
## Summary

Closes #262 (review children 3b = findings C7 + C21, epic #277): unifies `claudeDocsPath` resolution, which had drifted into **three semantics across six surfaces**:

| Surface | Old semantic |
|---|---|
| `wal-lib.sh` | tilde → under-HOME check; **absolute → trusted** |
| `wal-stop`, `wal-suspend`, `wal-bind-guard` (inline copies) | containment for all |
| `session-start`, `security-guard.py` (missed by the review) | **trusted everything, no containment** |

## Change

- `wal_resolve_claude_docs()` is now the single bash semantic: every `claudeDocsPath` (tilde or absolute) must resolve under `$HOME`, else warn + workspace-relative fallback.
- `wal-stop`, `wal-suspend`, `wal-bind-guard`, `session-start` source `wal-lib.sh` and call `wal_find_workspace` / `wal_resolve_claude_docs` / `wal_resolve_project` — ~90 duplicated lines deleted.
- `security-guard.py` carries a python mirror of the same containment (audit log lands where WAL readers look).
- `docs/wal-guide.md` documents the two-home rule (bash source of truth + python mirror).

Scope note: the issue named three resolvers; implementation found and folded in the two additional surfaces (`session-start`, `security-guard.py`) — within the issue's "one shared implementation all hooks route through" intent. No project sets `claudeDocsPath` today (verified in the review), so there is no live behavior change.

Unblocks #265 (3d) and #266 (4a).

## Reproduce-first evidence

- `test_wal_lib.py::TestWalResolveClaudeDocs::test_absolute_outside_home_rejected` — **red before** (lib trusted outside-HOME absolutes), green after.
- `test_session_binding.py::test_log_rejects_claude_docs_path_outside_home` — **red against origin/main `security-guard.py`** (verified by checkout-swap), green after.
- Structural pins: the four consumers must source the lib + call the shared resolver; the three former inline copies must not contain `claudeDocsPath` at all.

## Gates

- Full suite: **2293 passed, 0 failing** (main baseline 2283/0; +10 new tests)
- Both pylint lanes: 10.00/10
- Security scan: PASS; visible skips: `iac` (n/a), `sca` (osv-scanner: nothing to scan)
- Version ×3 → 3.24.4; README changelog entry (no spine change → no diagram REV; Suite 2283→2293)
- Code review (Step 11): 2 independent reviewers (routed model: opus) — results in comments below/PR discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
