### PR TITLE
fix(wal): init WAL_FILE lazily in wal-guard deny so headless blocks audit — v3.24.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.24.4",
+  "version": "3.24.5",
   "description": "6 SDLC workflow skills + 6 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -702,6 +702,9 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v3.24.5 (2026-07-07)
+- **Headless guard blocks are auditable again (#263, epic #277).** `wal-guard`'s `deny()` promised a GUARD_BLOCK audit line in headless mode but gated it on `WAL_FILE`, which nothing ever initialized (`wal_init_file` was never called) — the audit path was dead code, so blocks under bypassPermissions left no WAL trace. Fix initializes `WAL_FILE` lazily inside `deny()` (denies are rare; the hot allow-path pays no mkdir), best-effort so an init failure can never break the deny decision. Red-before-green test asserts a headless deny appends the GUARD_BLOCK line; a companion pins interactive denies staying silent. No workflow-spine change → no diagram REV. Suite 2293→2295.
+
 ### v3.24.4 (2026-07-07)
 - **claude_docs resolution unified across all six resolver surfaces (#262, epic #277).** `claudeDocsPath` resolution had drifted into three semantics: `wal-lib.sh` trusted an absolute path outside `$HOME`, the inline copies in `wal-stop`/`wal-suspend`/`wal-bind-guard` rejected it, and `session-start`/`security-guard.py` (two surfaces the review missed) trusted everything with no containment. Now ONE semantic — containment under `$HOME` or workspace-relative fallback — lives in `wal_resolve_claude_docs()` (plus a python mirror in `security-guard.py`); the four bash consumers source the lib, deleting ~90 duplicated lines. Structural tests pin the routing; red-before-green rejection tests cover bash + python; `docs/wal-guide.md` documents the semantic. Unblocks review children 3d and 4a. No workflow-spine change → no diagram REV. Suite 2283→2293.
 

--- a/hooks/wal-guard
+++ b/hooks/wal-guard
@@ -37,6 +37,12 @@ Run this command manually in your terminal if you need to proceed."
 
   # Headless mode audit: log guard blocks to WAL for visibility
   # In bypassPermissions mode, guards are the last defense — blocks MUST be auditable
+  # #263: WAL_FILE is initialized lazily HERE (denies are rare) so the hot
+  # allow-path pays no mkdir. Best-effort — an init failure must never break
+  # the deny itself (audit skipped, decision still returned).
+  if [ "${RAWGENTIC_HEADLESS:-}" = "1" ] && [ -z "${WAL_FILE:-}" ]; then
+    wal_init_file 2>/dev/null || true
+  fi
   if [ "${RAWGENTIC_HEADLESS:-}" = "1" ] && [ -n "${WAL_FILE:-}" ]; then
     local ts
     ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.24.4",
+  "version": "3.24.5",
   "description": "6 SDLC workflow skills + 6 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -38,7 +38,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.24.4"
+    assert plugin["version"] == "3.24.5"
 
 
 def test_descriptions_consistent_count():

--- a/tests/hooks/test_wal_guard.py
+++ b/tests/hooks/test_wal_guard.py
@@ -518,3 +518,72 @@ class TestHeadlessSSHBlock:
         _, parsed = _run_guard_headless("ssh deploy@host", make_workspace)
         reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
         assert "headlessAllowSSH" in reason
+
+
+class TestHeadlessGuardBlockAudit:
+    """#263 (C20): a headless deny must append a GUARD_BLOCK audit line to the
+    per-project WAL. Before the fix, deny() gated on WAL_FILE but nothing ever
+    called wal_init_file — the audit path was dead code and blocks in
+    bypassPermissions mode left no trace."""
+
+    def _deny_and_read_wal(self, make_workspace, command="ssh deploy@host"):
+        session_id = "headless-audit-sess"
+        ws = make_workspace(
+            projects=[{
+                "name": "testproj", "path": "./projects/testproj",
+                "active": True, "configured": True,
+            }],
+            registry_entries=[{
+                "session_id": session_id, "project": "testproj",
+                "project_path": "./projects/testproj",
+            }],
+            project_configs={"testproj": {"protectionLevel": "strict"}},
+        )
+        payload = {
+            "tool_input": {"command": command}, "tool_name": "Bash",
+            "session_id": session_id, "tool_use_id": "tu-a", "cwd": str(ws.root),
+        }
+        stdout, _stderr, _rc = run_hook(
+            HOOK, payload, cwd=ws.root, env_override={"RAWGENTIC_HEADLESS": "1"})
+        parsed = parse_hook_output(stdout)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+        wal_file = ws.claude_docs / "wal" / "testproj.jsonl"
+        return ws, wal_file
+
+    def test_headless_deny_appends_guard_block(self, make_workspace):
+        _, wal_file = self._deny_and_read_wal(make_workspace)
+        assert wal_file.exists(), "headless deny must create the per-project WAL"
+        entries = [json.loads(l) for l in wal_file.read_text().splitlines() if l.strip()]
+        blocks = [e for e in entries if e.get("phase") == "GUARD_BLOCK"]
+        assert blocks, "headless deny must append a GUARD_BLOCK audit line"
+        entry = blocks[-1]
+        assert entry["guard"] == "wal-guard"
+        assert entry["session"] == "headless-audit-sess"
+        assert "ssh" in entry["command"]
+
+    def test_non_headless_deny_writes_no_audit(self, make_workspace):
+        """Companion: without RAWGENTIC_HEADLESS the deny stays silent (audit is
+        a headless-only contract)."""
+        session_id = "interactive-sess"
+        ws = make_workspace(
+            projects=[{
+                "name": "testproj", "path": "./projects/testproj",
+                "active": True, "configured": True,
+            }],
+            registry_entries=[{
+                "session_id": session_id, "project": "testproj",
+                "project_path": "./projects/testproj",
+            }],
+            project_configs={"testproj": {"protectionLevel": "strict"}},
+        )
+        payload = {
+            "tool_input": {"command": "ssh deploy@prod-1"}, "tool_name": "Bash",
+            "session_id": session_id, "tool_use_id": "tu-b", "cwd": str(ws.root),
+        }
+        stdout, _stderr, _rc = run_hook(HOOK, payload, cwd=ws.root)
+        parsed = parse_hook_output(stdout)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+        wal_file = ws.claude_docs / "wal" / "testproj.jsonl"
+        if wal_file.exists():
+            entries = [json.loads(l) for l in wal_file.read_text().splitlines() if l.strip()]
+            assert not [e for e in entries if e.get("phase") == "GUARD_BLOCK"]


### PR DESCRIPTION
## Summary

Closes #263 (review finding C20, epic #277): `wal-guard`'s `deny()` promised a headless GUARD_BLOCK audit line but gated it on `WAL_FILE`, which nothing ever initialized — `wal_init_file` (its sole assigner) was never called in this hook. The audit path was dead code: guard blocks under bypassPermissions left no WAL trace.

## Fix

Lazy init inside `deny()` itself: when headless and `WAL_FILE` is empty, call `wal_init_file 2>/dev/null || true`, then the existing append. Denies are rare, so the hot allow-path pays **zero** added cost (no mkdir per Bash call — deliberate, this hook is on EPIC 4's hot-path list). Best-effort: an init failure can never break the deny decision (verified empirically by a reviewer with an uncreatable WAL dir — deny JSON still printed, exit 0).

## Reproduce-first evidence

- `TestHeadlessGuardBlockAudit::test_headless_deny_appends_guard_block` — **red before the fix** (reviewer re-verified by swapping in `origin/main:hooks/wal-guard`: FAILED), green after. Pins `phase`, `guard:"wal-guard"`, `session`, and command content, so no other writer can satisfy it.
- Companion `test_non_headless_deny_writes_no_audit` pins interactive denies staying silent (passes both before and after — behavior preserved).

## Gates

- Full suite: **2295 passed, 0 failing** (main baseline 2293/0; +2 new tests)
- Both pylint lanes: 10.00/10
- Security scan: PASS; visible skips: `iac` (n/a), `sca` (osv-scanner: nothing to scan)
- Version ×3 → 3.24.5; README changelog entry (no spine change → no diagram REV; Suite 2293→2295)
- Code review (Step 9): 2 independent reviewers (routed model: opus) — both NO FINDINGS; schema checked against WAL readers (session-start recovery only parses INTENT — extra GUARD_BLOCK lines are harmless); no overlap with security-guard.py's audit (different tool matchers, `guard` field disambiguates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
