### PR TITLE
docs(reviews): WF14 M1+M2 aggregate + nine per-run assessments

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.35.0",
+  "version": "3.35.1",
   "description": "8 SDLC workflow skills + 7 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/docs/reviews/2026-07-11-wf14-m1-m2-aggregate.html
+++ b/docs/reviews/2026-07-11-wf14-m1-m2-aggregate.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 aggregate — saystory M1+M2 campaign</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+
+:root{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+@media(prefers-color-scheme:dark){:root{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}}
+:root[data-theme=dark]{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}
+:root[data-theme=light]{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+.score{font:11.5px/1.4 ui-monospace,Menlo,Consolas,monospace;font-weight:700;background:var(--code);color:var(--accent);border-radius:5px;padding:1px 6px}
+.sev{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 7px;border-radius:999px;text-transform:uppercase;white-space:nowrap}
+.sev-critical{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.sev-high{color:var(--sev-high);background:var(--sev-high-bg)}
+.sev-medium{color:var(--sev-med);background:var(--sev-med-bg)}
+.sev-low{color:var(--sev-low);background:var(--sev-low-bg)}
+.req{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 6px;border-radius:5px;color:var(--req-c);background:var(--req-c-bg)}
+.req-must-not,.req-should-not{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.req-may{color:var(--ink-3);background:var(--code)}
+
+.tpl-report blockquote{background:var(--code);border-left-color:var(--accent)}
+.tpl-report tbody tr:nth-child(even){background:var(--code)}
+</style>
+</head>
+<body class="tpl-report">
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-11 07:32 MDT</div>
+<h1>WF14 aggregate — saystory M1+M2 campaign</h1>
+
+</header>
+<main>
+<h1>WF14 aggregate — saystory M1+M2 overnight campaign (9 WF2 runs, 2026-07-10 → 07-11)</h1>
+<p>One roll-up of the nine per-issue WF14 assessments from the saystory M1–M5 overnight run&#x27;s first two milestones (epics #171 M1, #172 M2). Individual reports (committed alongside this aggregate) are authoritative for per-run evidence; this document is the cross-run view: score trends, systemic patterns, and what got routed where. Rubric v2 throughout (M1 reports predate the fixed summary block; scores extracted from their dimension sections). All adversarial/WF14 layers ran on gpt-5.6-sol per the owner directive of 2026-07-10.</p>
+<h2>Scoreboard</h2>
+<table>
+<thead><tr><th>Run</th><th>Lane</th><th>PRs</th><th>Fidelity</th><th>Gates</th><th>Clarity</th><th>Dispatch</th><th>Telemetry</th><th>Cost</th></tr></thead>
+<tbody>
+<tr><td>#164 runbook reconcile (M1)</td><td>trivial-D1</td><td>#177</td><td>5</td><td>unscored</td><td>5</td><td>unscored</td><td>3</td><td>3</td></tr>
+<tr><td>#165 dispatch extraction (M1)</td><td>full</td><td>#178</td><td>4</td><td>5</td><td>3</td><td>3</td><td>3</td><td>3</td></tr>
+<tr><td>#69 paste-spacing port (M1)</td><td>small-standard</td><td>#179</td><td>4</td><td>5</td><td>4</td><td>4</td><td>3</td><td>3</td></tr>
+<tr><td>#157 Parrot text (M1)</td><td>trivial-D1</td><td>#180</td><td>5</td><td>unscored</td><td>5</td><td>unscored</td><td>3</td><td>3</td></tr>
+<tr><td>#166 P2 mac skeleton (M2)</td><td>full</td><td>#181</td><td>5</td><td>5</td><td>4</td><td>5</td><td>3</td><td>3</td></tr>
+<tr><td>#167 P3 platform adapter (M2)</td><td>full ×2PR</td><td>#182+#183</td><td>4</td><td>4</td><td>3</td><td>3</td><td>3</td><td>2</td></tr>
+<tr><td>#168 P4 model pipeline (M2)</td><td>full ×2PR</td><td>#186+#189</td><td>3</td><td>5</td><td>4</td><td>4</td><td>2</td><td>3</td></tr>
+<tr><td>#156 input-monitoring recovery (M2)</td><td>small-standard</td><td>#188</td><td>4</td><td>5</td><td>4</td><td>5</td><td>2</td><td>4</td></tr>
+<tr><td>#162 cleanup-stage feedback (M2)</td><td>full</td><td>#190</td><td>4</td><td>5</td><td>5</td><td>5</td><td>3</td><td>4</td></tr>
+</tbody>
+</table>
+<p>Campaign outcome: 9/9 issues merged (11 PRs), v0.2.39 → v0.2.48, zero regressions against recorded baselines at every merge, both epics&#x27; code scope complete (owner-gated remainders: M2 UAT round, #154, #163).</p>
+<h2>The five cross-run patterns</h2>
+<p><strong>1. Gates score <span class="score">5/5</span> whenever scoreable — and the catches were real, not ceremony.</strong> Every scoreable run names at least one pre-merge catch with the finding text quoted. The campaign&#x27;s three best: (a) #168 design pass-2 H4 — the double-llama test-bundle link hazard, which produced the R6 symbol-localization mechanism; (b) #162 Step-11 adversarial — a Critical in the DESIGN&#x27;S OWN stage sequencing (&quot;running&quot; emitted before the load it labels), caught after two 8a lenses had verified the faithful implementation as clean: the strongest specimen yet that the adversarial layer catches the spec where compliance lenses structurally cannot; (c) #156 design F0 — the recovery notice would have rendered inside a hidden window; <code>notifyOs</code> surfacing became the fix&#x27;s actual user value.</p>
+<p><strong>2. The mac-preflight rule flipped CI economics mid-campaign.</strong> #167 took 4 mac-lane fix loops and #168 PR-A took 6 (each loop 15–40 min) — all authored-blind Swift/ld details a target-host run would have caught. After the owner&#x27;s challenge (~07:30Z 2026-07-11), the rule &quot;full build-macos-ffi.sh + swift test on the mac host before ANY mac-lane push&quot; went live: #168 PR-B, #156-adjacent runs, and #162 went <strong>3-for-3 mac-lane-green on the first CI attempt</strong>. Cost scores rise accordingly (#167 $2 → #162 $4). Promotion of this rule into WF2 prose is the campaign&#x27;s top process recommendation (routed: #391-class checklist thread; also named in the #168 report&#x27;s finding 3).</p>
+<p><strong>3. Telemetry is the chronically weakest dimension (2–3, never higher).</strong> Three independent causes, all routed: (a) usage capture unavailable — standing known-limitation, #329/#330; (b) orchestrator schema stumbles when assembling records by hand (#168: <code>type</code> vs <code>subagent_type</code>; #156: invented reviewer_kind enum) — the validator caught both loudly, the read-the-schema-first lesson landed by #162 (first-summarize valid); (c) gate-count semantics under the #340 rule need per-pass bookkeeping discipline (one in-store correction, #168). No new telemetry issues filed — every negative was either already tracked or assessor-caused.</p>
+<p><strong>4. The adversarial disposition ledger (#393) stays the top plugin friction — with new nuance.</strong> Re-litigation cost: #167 PR-A 3/4 findings, #168 PR-A 3/4 and PR-B 2/4 declined against settled evidence; but #162&#x27;s two engine passes produced ONLY fresh findings (including the campaign&#x27;s best catch). The fix must inject dispositions without dampening fresh-finding aggression — the #162 data point is the design constraint. Recurrence ≥4 runs; friction memory saved (<code>wf2-adversarial-needs-disposition-ledger-168</code>, mempalace).</p>
+<p><strong>5. Cross-project WF14 mechanics still need the #372 re-bind dance.</strong> Every report write into the rawgentic tree from the saystory-bound session required the documented registry re-bind workaround (3× this session). #372 remains open; the cost is small but per-report.</p>
+<h2>Environment ledger (not machinery, named for completeness)</h2>
+<p>Two same-day disk-full incidents (mac host at 276MiB free — owner freed 137G; WSL root 100% — spent worktree targets + a 13G incremental cache reclaimed), one usage-window stall recovered by the tick machinery (#69, M1), reviewer session-limit deaths with re-dispatch (#167), <code>gh pr edit</code> projectCards failure (PATCH workaround), stale mergeable races after fresh pushes. All carried in the workspace env-gotcha notes.</p>
+<h2>Routed (cumulative, deduplicated)</h2>
+<ul>
+<li>Filed during M1: rawgentic#371 (worktree spawn layout), rawgentic#372 (WF14</li>
+</ul>
+<p>  path-binding vs bind-guard). Linked during M2: rawgentic#393 (disposition   ledger — recurrence evidence added, not refiled).</p>
+<ul>
+<li>Friction memories: M1 reviewer-dead-threshold; M2 disposition-ledger</li>
+</ul>
+<p>  (<code>drawer_rawgentic_process-conventions_d151e29eadde94aa69115328</code>).</p>
+<ul>
+<li>Process recommendation for WF2 prose (not yet filed, #391-class thread): the</li>
+</ul>
+<p>  mac-preflight/target-host proxy rule (pattern 2) and the Step-9-folds-into-   Step-11 marker question (3 occurrences).</p>
+<ul>
+<li>Telemetry: nothing new filed — #329/#330/#333 cover the field.</li>
+</ul>
+<h2>Owner-gated remainders (unchanged by this aggregate)</h2>
+<p>M2 exit UAT round (install, re-grant, hotkey→dictation→paste through the rust core, #156 recovery UI, #162 stage pill), #154 (mic prompt, pre-milestone tccutil repro is the owner&#x27;s), #163 (Developer-ID cert, Apple-side).</p>
+
+</main>
+<footer>Last updated: 2026-07-11 07:32 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/2026-07-11-wf14-m1-m2-aggregate.md
+++ b/docs/reviews/2026-07-11-wf14-m1-m2-aggregate.md
@@ -1,0 +1,99 @@
+# WF14 aggregate — saystory M1+M2 overnight campaign (9 WF2 runs, 2026-07-10 → 07-11)
+
+One roll-up of the nine per-issue WF14 assessments from the saystory M1–M5 overnight
+run's first two milestones (epics #171 M1, #172 M2). Individual reports (committed
+alongside this aggregate) are authoritative for per-run evidence; this document is
+the cross-run view: score trends, systemic patterns, and what got routed where.
+Rubric v2 throughout (M1 reports predate the fixed summary block; scores extracted
+from their dimension sections). All adversarial/WF14 layers ran on gpt-5.6-sol per
+the owner directive of 2026-07-10.
+
+## Scoreboard
+
+| Run | Lane | PRs | Fidelity | Gates | Clarity | Dispatch | Telemetry | Cost |
+|---|---|---|---|---|---|---|---|---|
+| #164 runbook reconcile (M1) | trivial-D1 | #177 | 5 | unscored | 5 | unscored | 3 | 3 |
+| #165 dispatch extraction (M1) | full | #178 | 4 | 5 | 3 | 3 | 3 | 3 |
+| #69 paste-spacing port (M1) | small-standard | #179 | 4 | 5 | 4 | 4 | 3 | 3 |
+| #157 Parrot text (M1) | trivial-D1 | #180 | 5 | unscored | 5 | unscored | 3 | 3 |
+| #166 P2 mac skeleton (M2) | full | #181 | 5 | 5 | 4 | 5 | 3 | 3 |
+| #167 P3 platform adapter (M2) | full ×2PR | #182+#183 | 4 | 4 | 3 | 3 | 3 | 2 |
+| #168 P4 model pipeline (M2) | full ×2PR | #186+#189 | 3 | 5 | 4 | 4 | 2 | 3 |
+| #156 input-monitoring recovery (M2) | small-standard | #188 | 4 | 5 | 4 | 5 | 2 | 4 |
+| #162 cleanup-stage feedback (M2) | full | #190 | 4 | 5 | 5 | 5 | 3 | 4 |
+
+Campaign outcome: 9/9 issues merged (11 PRs), v0.2.39 → v0.2.48, zero regressions
+against recorded baselines at every merge, both epics' code scope complete
+(owner-gated remainders: M2 UAT round, #154, #163).
+
+## The five cross-run patterns
+
+**1. Gates score 5/5 whenever scoreable — and the catches were real, not ceremony.**
+Every scoreable run names at least one pre-merge catch with the finding text quoted.
+The campaign's three best: (a) #168 design pass-2 H4 — the double-llama test-bundle
+link hazard, which produced the R6 symbol-localization mechanism; (b) #162 Step-11
+adversarial — a Critical in the DESIGN'S OWN stage sequencing ("running" emitted
+before the load it labels), caught after two 8a lenses had verified the faithful
+implementation as clean: the strongest specimen yet that the adversarial layer
+catches the spec where compliance lenses structurally cannot; (c) #156 design F0 —
+the recovery notice would have rendered inside a hidden window; `notifyOs`
+surfacing became the fix's actual user value.
+
+**2. The mac-preflight rule flipped CI economics mid-campaign.** #167 took 4 mac-lane
+fix loops and #168 PR-A took 6 (each loop 15–40 min) — all authored-blind Swift/ld
+details a target-host run would have caught. After the owner's challenge (~07:30Z
+2026-07-11), the rule "full build-macos-ffi.sh + swift test on the mac host before
+ANY mac-lane push" went live: #168 PR-B, #156-adjacent runs, and #162 went
+**3-for-3 mac-lane-green on the first CI attempt**. Cost scores rise accordingly
+(#167 $2 → #162 $4). Promotion of this rule into WF2 prose is the campaign's top
+process recommendation (routed: #391-class checklist thread; also named in the #168
+report's finding 3).
+
+**3. Telemetry is the chronically weakest dimension (2–3, never higher).** Three
+independent causes, all routed: (a) usage capture unavailable — standing
+known-limitation, #329/#330; (b) orchestrator schema stumbles when assembling
+records by hand (#168: `type` vs `subagent_type`; #156: invented reviewer_kind
+enum) — the validator caught both loudly, the read-the-schema-first lesson landed
+by #162 (first-summarize valid); (c) gate-count semantics under the #340 rule need
+per-pass bookkeeping discipline (one in-store correction, #168). No new telemetry
+issues filed — every negative was either already tracked or assessor-caused.
+
+**4. The adversarial disposition ledger (#393) stays the top plugin friction —
+with new nuance.** Re-litigation cost: #167 PR-A 3/4 findings, #168 PR-A 3/4 and
+PR-B 2/4 declined against settled evidence; but #162's two engine passes produced
+ONLY fresh findings (including the campaign's best catch). The fix must inject
+dispositions without dampening fresh-finding aggression — the #162 data point is
+the design constraint. Recurrence ≥4 runs; friction memory saved
+(`wf2-adversarial-needs-disposition-ledger-168`, mempalace).
+
+**5. Cross-project WF14 mechanics still need the #372 re-bind dance.** Every report
+write into the rawgentic tree from the saystory-bound session required the
+documented registry re-bind workaround (3× this session). #372 remains open; the
+cost is small but per-report.
+
+## Environment ledger (not machinery, named for completeness)
+
+Two same-day disk-full incidents (mac host at 276MiB free — owner freed 137G; WSL
+root 100% — spent worktree targets + a 13G incremental cache reclaimed), one
+usage-window stall recovered by the tick machinery (#69, M1), reviewer
+session-limit deaths with re-dispatch (#167), `gh pr edit` projectCards failure
+(PATCH workaround), stale mergeable races after fresh pushes. All carried in the
+workspace env-gotcha notes.
+
+## Routed (cumulative, deduplicated)
+
+- Filed during M1: rawgentic#371 (worktree spawn layout), rawgentic#372 (WF14
+  path-binding vs bind-guard). Linked during M2: rawgentic#393 (disposition
+  ledger — recurrence evidence added, not refiled).
+- Friction memories: M1 reviewer-dead-threshold; M2 disposition-ledger
+  (`drawer_rawgentic_process-conventions_d151e29eadde94aa69115328`).
+- Process recommendation for WF2 prose (not yet filed, #391-class thread): the
+  mac-preflight/target-host proxy rule (pattern 2) and the Step-9-folds-into-
+  Step-11 marker question (3 occurrences).
+- Telemetry: nothing new filed — #329/#330/#333 cover the field.
+
+## Owner-gated remainders (unchanged by this aggregate)
+
+M2 exit UAT round (install, re-grant, hotkey→dictation→paste through the rust
+core, #156 recovery UI, #162 stage pill), #154 (mic prompt, pre-milestone tccutil
+repro is the owner's), #163 (Developer-ID cert, Apple-side).

--- a/docs/reviews/run-feedback-wf2-156-2026-07-11.html
+++ b/docs/reviews/run-feedback-wf2-156-2026-07-11.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 run-feedback — WF2 #156</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+
+:root{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+@media(prefers-color-scheme:dark){:root{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}}
+:root[data-theme=dark]{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}
+:root[data-theme=light]{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+.score{font:11.5px/1.4 ui-monospace,Menlo,Consolas,monospace;font-weight:700;background:var(--code);color:var(--accent);border-radius:5px;padding:1px 6px}
+.sev{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 7px;border-radius:999px;text-transform:uppercase;white-space:nowrap}
+.sev-critical{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.sev-high{color:var(--sev-high);background:var(--sev-high-bg)}
+.sev-medium{color:var(--sev-med);background:var(--sev-med-bg)}
+.sev-low{color:var(--sev-low);background:var(--sev-low-bg)}
+.req{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 6px;border-radius:5px;color:var(--req-c);background:var(--req-c-bg)}
+.req-must-not,.req-should-not{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.req-may{color:var(--ink-3);background:var(--code)}
+
+.tpl-report blockquote{background:var(--code);border-left-color:var(--accent)}
+.tpl-report tbody tr:nth-child(even){background:var(--code)}
+</style>
+</head>
+<body class="tpl-report">
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-11 06:03 MDT</div>
+<h1>WF14 run-feedback — WF2 #156</h1>
+
+</header>
+<main>
+<h1>WF14 run-feedback — WF2 #156 (saystory, small-standard lane, PR #188)</h1>
+<p>Assessed under rubric v2 (2026-07-10, #377). Plugin version loaded: 3.35.0 (cache). Record: explicit (<code>claude_docs/.rawgentic-156-record.json</code>), persisted to the saystory store (24th line) — schema-valid on SECOND summarize (reviewer_kind enum; see telemetry). Adversarial layers used gpt-5.6-sol per owner directive.</p>
+<h2>At a glance</h2>
+<p><strong>A clean, cheap, gate-productive small-lane run: the collapsed design note plus two adversarial passes and one reviewer produced four adopted improvements on a 69-line frontend fix, with zero CI loops on substance — the only churn was a predictable cross-PR design-log merge conflict and two enum/schema stumbles by the orchestrator.</strong></p>
+<ul>
+<li><strong>Fidelity <span class="score">4/5</span></strong> — small-standard collapsed-steps lane; all executed steps</li>
+</ul>
+<p>  marked (1, 2, 3-5 collapsed, 4-gate, 8-12, 14, 16); the collapse itself is the   lane&#x27;s documented shape.</p>
+<ul>
+<li><strong>Gates <span class="score">5/5</span></strong> — real catches, named below (notifyOs surfacing High; row-synthesis</li>
+</ul>
+<p>  edge; once-per-session notification guard).</p>
+<ul>
+<li><strong>Clarity <span class="score">4/5</span></strong> — one interpreted contract: the engine rejects sidecar paths</li>
+</ul>
+<p>  outside the project root (clear error, no prose warning; same as #168&#x27;s run).</p>
+<ul>
+<li><strong>Dispatch <span class="score">5/5</span></strong> — one reviewer dispatch, opus as routed, non-vacuous, first try.</li>
+<li><strong>Telemetry <span class="score">2/5</span></strong> — record rejected on first summarize (<code>codex_adversarial</code> not in</li>
+</ul>
+<p>  the reviewer_kind enum — the assessor invented a value instead of reading the   documented set); validator loud and correct.</p>
+<ul>
+<li><strong>Cost <span class="score">4/5</span></strong> — lane choice fit the change (no full 3-agent design gate, no</li>
+</ul>
+<p>  implementer dispatch — orchestrator-implemented inline); heaviest-least-value   step: the second full workspace suite run after the merge-conflict resolution   whose only rust delta was version numbers (defensible under the semantic-conflict   rule, but it re-proved an unchanged surface).</p>
+<p><strong>Best catch:</strong> design-pass F0 (High, gpt-5.6-sol): &quot;the only notification is rendered inside the Settings section... hotkey failure can remain visibly silent&quot; — adopted as the <code>notifyOs</code> surfacing, which is the issue&#x27;s actual user-facing value. Runner-up: diff-pass row-synthesis (the protocol compat-shim omits the Input Monitoring row while state is Unknown — the recovery row could vanish exactly when needed).</p>
+<p><strong>Worst friction:</strong> reviewer_kind enum invention (orchestrator error — the enum is documented in run-record.md; second occurrence of a schema stumble in one session after #168&#x27;s <code>subagent_type</code>). Pattern noted in the friction memory lineage, not refiled.</p>
+<p><strong>Routed:</strong> 0 defects filed; no new friction memory (the #168 memory of this session already carries the disposition-ledger lesson; the schema stumbles are orchestrator errors, not plugin faults — the validator worked both times); clean-run line below.</p>
+<h2>Evidence ledger (selected)</h2>
+<ul>
+<li>Steps 1-2 markers (previous leg) + Steps 3-5 collapsed note + 4-gate dispositions</li>
+</ul>
+<p>  + 8-12 markers + merge/audit — <strong>confirmed</strong> (session_notes.md markers, quoted in   the run&#x27;s section).</p>
+<ul>
+<li>Design adversarial r1: 4 findings, F0/F3 adopted, F1/F2 declined-with-evidence —</li>
+</ul>
+<p>  <strong>confirmed</strong> (dispositions in claude_docs/wf2-156-design-note.md + marker).</p>
+<ul>
+<li>Step 11: opus reviewer 0 C/H/M + 2 Lows (1 adopted, 1 declined-deliberate); engine</li>
+</ul>
+<p>  diff pass 3 findings (1 adopted, 2 declined with proofs) — <strong>confirmed</strong> (agent   result + findings JSON).</p>
+<ul>
+<li>Gates on merge: typecheck 0, ws 407/0 twice (pre-PR and post-conflict-resolution),</li>
+</ul>
+<p>  drift-guard 1/1, scan PASS — <strong>confirmed</strong> (runner outputs read).</p>
+<ul>
+<li>Merge held until #168 PR-B for version monotonicity; design-log append-append</li>
+</ul>
+<p>  conflict resolved keep-both; stale DIRTY mergeable race observed then cleared —   <strong>confirmed</strong>.</p>
+<h2>Telemetry audit</h2>
+<table>
+<thead><tr><th>field</th><th>recorded</th><th>session evidence</th><th>verdict</th></tr></thead>
+<tbody>
+<tr><td>workflow/issue/lane</td><td>implement-feature / 156 / small-standard</td><td>matches</td><td>match</td></tr>
+<tr><td>tests</td><td>0 added / 407 passing</td><td>typecheck-only frontend change; ws 407/0 runner output</td><td>match (no JS harness exists — known repo shape)</td></tr>
+<tr><td>gates[]</td><td>4/4, 0/0, <span class="score">5/5</span></td><td>dispositions + markers</td><td>match</td></tr>
+<tr><td>loop_backs</td><td>0/3</td><td>no loop-back consumed</td><td>match</td></tr>
+<tr><td>outcome</td><td>PR 188 merged, ci passed</td><td>merge SHA 5d24fab</td><td>match</td></tr>
+<tr><td>security_scan</td><td>ran, iac skip</td><td>scan output</td><td>match</td></tr>
+<tr><td>usage</td><td>unavailable</td><td>session-level only</td><td>known-limitation</td></tr>
+<tr><td>dispatches[]</td><td>1 reviewer</td><td>agent result</td><td>match; first summarize rejected reviewer_kind enum (orchestrator-invented value)</td></tr>
+</tbody>
+</table>
+<p>Verdicts: match 7 · known-limitation 1 · mismatch 0.</p>
+<h2>Findings and classes</h2>
+<p>1. <strong>ORCHESTRATOR ERROR</strong> — invented <code>codex_adversarial</code> reviewer_kind (documented    enum: builtin_code_review/codex/hand_rolled_multi/inline/reflexion). Validator    caught it. Second schema stumble this session — the read-the-schema-first lesson    is the orchestrator&#x27;s, not the plugin&#x27;s. 2. <strong>ENVIRONMENT/GH</strong> — <code>gh pr edit</code> fails on the projectCards GraphQL deprecation    (body edits must go through <code>gh api PATCH</code>); and mergeable/mergeState reads race    fresh pushes (a stale DIRTY after the conflict-resolution push). Both are gh/API    behaviors; the workspace env-gotcha notes now carry them. 3. <strong>WORKING AS DESIGNED</strong> — merge-order hold for version monotonicity and the    keep-both design-log conflict resolution followed the documented conventions    exactly; the small-standard lane&#x27;s collapsed steps kept cost proportional.</p>
+<h2>Summary block</h2>
+<pre><code>WF RUN ASSESSMENT — WF2 @ v3.35.0 (issue #156, PR #188, lane small-standard) · rubric v2
+Fidelity 4/5 · Gates 5/5 · Clarity 4/5 · Dispatch 5/5 · Telemetry 2/5 · Cost 4/5
+Mode: full · Record: claude_docs/.rawgentic-156-record.json (persisted)
+Best catch: design F0 — silent hotkey failure needs notifyOs surfacing (adopted)
+Worst friction: orchestrator-invented reviewer_kind enum value (own goal; validator correct)
+Telemetry verdicts: match 7 / mismatch 0 / missing-in-record 0 / missing-in-session 0 / unverifiable 0 / known-limitation 1
+Defects filed: none | Telemetry filed: none | Not filed (cap): 0 | Friction memorized: none (covered by this session&#x27;s #168 memory) | Clean run: yes (machinery)
+Report: projects/rawgentic/docs/reviews/run-feedback-wf2-156-2026-07-11.md
+Inferred (unconfirmed) claims: none</code></pre>
+
+</main>
+<footer>Last updated: 2026-07-11 06:03 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/run-feedback-wf2-156-2026-07-11.md
+++ b/docs/reviews/run-feedback-wf2-156-2026-07-11.md
@@ -1,0 +1,105 @@
+# WF14 run-feedback — WF2 #156 (saystory, small-standard lane, PR #188)
+
+Assessed under rubric v2 (2026-07-10, #377). Plugin version loaded: 3.35.0 (cache).
+Record: explicit (`claude_docs/.rawgentic-156-record.json`), persisted to the saystory
+store (24th line) — schema-valid on SECOND summarize (reviewer_kind enum; see
+telemetry). Adversarial layers used gpt-5.6-sol per owner directive.
+
+## At a glance
+
+**A clean, cheap, gate-productive small-lane run: the collapsed design note plus two
+adversarial passes and one reviewer produced four adopted improvements on a 69-line
+frontend fix, with zero CI loops on substance — the only churn was a predictable
+cross-PR design-log merge conflict and two enum/schema stumbles by the orchestrator.**
+
+- **Fidelity 4/5** — small-standard collapsed-steps lane; all executed steps
+  marked (1, 2, 3-5 collapsed, 4-gate, 8-12, 14, 16); the collapse itself is the
+  lane's documented shape.
+- **Gates 5/5** — real catches, named below (notifyOs surfacing High; row-synthesis
+  edge; once-per-session notification guard).
+- **Clarity 4/5** — one interpreted contract: the engine rejects sidecar paths
+  outside the project root (clear error, no prose warning; same as #168's run).
+- **Dispatch 5/5** — one reviewer dispatch, opus as routed, non-vacuous, first try.
+- **Telemetry 2/5** — record rejected on first summarize (`codex_adversarial` not in
+  the reviewer_kind enum — the assessor invented a value instead of reading the
+  documented set); validator loud and correct.
+- **Cost 4/5** — lane choice fit the change (no full 3-agent design gate, no
+  implementer dispatch — orchestrator-implemented inline); heaviest-least-value
+  step: the second full workspace suite run after the merge-conflict resolution
+  whose only rust delta was version numbers (defensible under the semantic-conflict
+  rule, but it re-proved an unchanged surface).
+
+**Best catch:** design-pass F0 (High, gpt-5.6-sol): "the only notification is
+rendered inside the Settings section... hotkey failure can remain visibly silent" —
+adopted as the `notifyOs` surfacing, which is the issue's actual user-facing value.
+Runner-up: diff-pass row-synthesis (the protocol compat-shim omits the Input
+Monitoring row while state is Unknown — the recovery row could vanish exactly when
+needed).
+
+**Worst friction:** reviewer_kind enum invention (orchestrator error — the enum is
+documented in run-record.md; second occurrence of a schema stumble in one session
+after #168's `subagent_type`). Pattern noted in the friction memory lineage, not
+refiled.
+
+**Routed:** 0 defects filed; no new friction memory (the #168 memory of this session
+already carries the disposition-ledger lesson; the schema stumbles are orchestrator
+errors, not plugin faults — the validator worked both times); clean-run line below.
+
+## Evidence ledger (selected)
+
+- Steps 1-2 markers (previous leg) + Steps 3-5 collapsed note + 4-gate dispositions
+  + 8-12 markers + merge/audit — **confirmed** (session_notes.md markers, quoted in
+  the run's section).
+- Design adversarial r1: 4 findings, F0/F3 adopted, F1/F2 declined-with-evidence —
+  **confirmed** (dispositions in claude_docs/wf2-156-design-note.md + marker).
+- Step 11: opus reviewer 0 C/H/M + 2 Lows (1 adopted, 1 declined-deliberate); engine
+  diff pass 3 findings (1 adopted, 2 declined with proofs) — **confirmed** (agent
+  result + findings JSON).
+- Gates on merge: typecheck 0, ws 407/0 twice (pre-PR and post-conflict-resolution),
+  drift-guard 1/1, scan PASS — **confirmed** (runner outputs read).
+- Merge held until #168 PR-B for version monotonicity; design-log append-append
+  conflict resolved keep-both; stale DIRTY mergeable race observed then cleared —
+  **confirmed**.
+
+## Telemetry audit
+
+| field | recorded | session evidence | verdict |
+|---|---|---|---|
+| workflow/issue/lane | implement-feature / 156 / small-standard | matches | match |
+| tests | 0 added / 407 passing | typecheck-only frontend change; ws 407/0 runner output | match (no JS harness exists — known repo shape) |
+| gates[] | 4/4, 0/0, 5/5 | dispositions + markers | match |
+| loop_backs | 0/3 | no loop-back consumed | match |
+| outcome | PR 188 merged, ci passed | merge SHA 5d24fab | match |
+| security_scan | ran, iac skip | scan output | match |
+| usage | unavailable | session-level only | known-limitation |
+| dispatches[] | 1 reviewer | agent result | match; first summarize rejected reviewer_kind enum (orchestrator-invented value) |
+
+Verdicts: match 7 · known-limitation 1 · mismatch 0.
+
+## Findings and classes
+
+1. **ORCHESTRATOR ERROR** — invented `codex_adversarial` reviewer_kind (documented
+   enum: builtin_code_review/codex/hand_rolled_multi/inline/reflexion). Validator
+   caught it. Second schema stumble this session — the read-the-schema-first lesson
+   is the orchestrator's, not the plugin's.
+2. **ENVIRONMENT/GH** — `gh pr edit` fails on the projectCards GraphQL deprecation
+   (body edits must go through `gh api PATCH`); and mergeable/mergeState reads race
+   fresh pushes (a stale DIRTY after the conflict-resolution push). Both are gh/API
+   behaviors; the workspace env-gotcha notes now carry them.
+3. **WORKING AS DESIGNED** — merge-order hold for version monotonicity and the
+   keep-both design-log conflict resolution followed the documented conventions
+   exactly; the small-standard lane's collapsed steps kept cost proportional.
+
+## Summary block
+
+```
+WF RUN ASSESSMENT — WF2 @ v3.35.0 (issue #156, PR #188, lane small-standard) · rubric v2
+Fidelity 4/5 · Gates 5/5 · Clarity 4/5 · Dispatch 5/5 · Telemetry 2/5 · Cost 4/5
+Mode: full · Record: claude_docs/.rawgentic-156-record.json (persisted)
+Best catch: design F0 — silent hotkey failure needs notifyOs surfacing (adopted)
+Worst friction: orchestrator-invented reviewer_kind enum value (own goal; validator correct)
+Telemetry verdicts: match 7 / mismatch 0 / missing-in-record 0 / missing-in-session 0 / unverifiable 0 / known-limitation 1
+Defects filed: none | Telemetry filed: none | Not filed (cap): 0 | Friction memorized: none (covered by this session's #168 memory) | Clean run: yes (machinery)
+Report: projects/rawgentic/docs/reviews/run-feedback-wf2-156-2026-07-11.md
+Inferred (unconfirmed) claims: none
+```

--- a/docs/reviews/run-feedback-wf2-157-2026-07-10.html
+++ b/docs/reviews/run-feedback-wf2-157-2026-07-10.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 run-feedback — WF2 #157</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+</style>
+</head>
+<body>
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-10 08:12 MDT</div>
+<h1>WF14 run-feedback — WF2 #157</h1>
+
+</header>
+<main>
+<h1>WF14 run-feedback — WF2 #157 (saystory, PR #180) · 2026-07-10 · rubric v1</h1>
+<p><strong>Run under assessment:</strong> WF2 invocation for saystory #157 (user-visible &quot;Parrot&quot; text rebrand) that took the <strong>trivial-work exit</strong> at Step 2. <strong>Plugin version loaded:</strong> 3.29.0 (cache); main: 3.32.1. <strong>Record:</strong> explicit (saystory store, issue-157 line, rc 0 on summarize). <strong>Session notes:</strong> saystory <code>claude_docs/session_notes.md</code> (Steps 1/1b/2 markers + trivial-suggestion advisory, first-party — assessor ran the run).</p>
+<h2>What the run did (confirmed)</h2>
+<p>Steps 1–2 in full. The Step-2 audit did the issue&#x27;s real work: classified every remaining &quot;Parrot&quot; occurrence — 7 brand-context template lines (replace), 2 README fork-lineage attributions (keep per AC2), and the whole docs/ tree (all historical records / identifiers / non-user-facing — keep per AC3, list shipped in the PR body). Net mechanical change 2 files / 7 lines → trivial exit (D5, owner-contract recommended fork). Exit hygiene: branch, one commit, PR #180 with the full audit list, merge on green, epic tick, run-record rc 0. One environment note: the PR&#x27;s CI ran FULL builds — <code>.github/ISSUE_TEMPLATE/*.yml</code> is evidently not in the path-classifier&#x27;s docs-skip allowlist, so a 7-line template change cost ~35 min of queued heavy builds (fail-safe direction by design: &quot;a wasted build is cheap&quot;).</p>
+<h2>Dimension scores</h2>
+<p>1. <strong>Fidelity 5/5</strong> (confirmed) — executed steps marked; sanctioned exit; decision    logged. 2. <strong>Gates unscored</strong> — none ran (sanctioned exit); the audit judgment (keep vs    replace) was the run&#x27;s substance and shipped transparently in the PR body. 3. <strong>Clarity 5/5</strong> (confirmed) — no improvisation. 4. <strong>Dispatch unscored</strong> — zero dispatches. 5. <strong>Telemetry 3/5</strong> (confirmed; valid first summarize; usage known-limitation;    all other fields match). 6. <strong>Cost 3/5</strong> (capped: usage session-level; the exit itself minimized    orchestration cost — the only real cost was the classifier-forced full CI,    which is saystory repo config, not plugin machinery).</p>
+<h2>Findings</h2>
+<p><strong>F1 — ENVIRONMENT (saystory repo config, noted for the owner, not a plugin issue): <code>.github/ISSUE_TEMPLATE/</code> absent from the path-aware classifier&#x27;s docs-skip set</strong> (<code>scripts/ci/classify-paths.sh</code> in saystory) — a pure template change ran ~43 min of platform builds. Fail-safe direction is correct policy; adding the template dir to the skip set is a one-line saystory follow-up, owner&#x27;s call. Routed: noted in the M1 wrap comment, not filed against the plugin.</p>
+<h2>Telemetry audit</h2>
+<table>
+<thead><tr><th>field</th><th>recorded</th><th>session evidence</th><th>verdict</th></tr></thead>
+<tbody>
+<tr><td>workflow/version/issue</td><td>implement-feature / 3.29.0 / 157</td><td>cache + markers</td><td>match</td></tr>
+<tr><td>changes</td><td>2 files, +7/−7, 1 commit</td><td>PR #180 stat</td><td>match</td></tr>
+<tr><td>tests / gates / scan / loop_backs</td><td>0-added·nulls / [] / ran:false / 0-3</td><td>sanctioned exit, no suites (docs), none run</td><td>match</td></tr>
+<tr><td>outcome</td><td>PR 180, merged, ci passed</td><td>878c602 + all-lanes-pass</td><td>match</td></tr>
+<tr><td>usage</td><td>session-cumulative</td><td>capture semantics</td><td>known-limitation</td></tr>
+<tr><td>dispatches[]</td><td>absent</td><td>zero dispatch activity</td><td>correct omission</td></tr>
+<tr><td>goal_guard</td><td>deferred</td><td>run-level /goal</td><td>match</td></tr>
+</tbody>
+</table>
+<p>Verdicts: match 8 · known-limitation 1.</p>
+<h2>Routing</h2>
+<p>Clean run for the plugin: nothing filed, nothing memorized (F1 is assessed-project environment, routed via the epic wrap comment).</p>
+<p>Inferred (unconfirmed) claims: none.</p>
+
+</main>
+<footer>Last updated: 2026-07-10 08:12 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/run-feedback-wf2-157-2026-07-10.md
+++ b/docs/reviews/run-feedback-wf2-157-2026-07-10.md
@@ -1,0 +1,65 @@
+# WF14 run-feedback — WF2 #157 (saystory, PR #180) · 2026-07-10 · rubric v1
+
+**Run under assessment:** WF2 invocation for saystory #157 (user-visible "Parrot"
+text rebrand) that took the **trivial-work exit** at Step 2. **Plugin version
+loaded:** 3.29.0 (cache); main: 3.32.1. **Record:** explicit (saystory store,
+issue-157 line, rc 0 on summarize). **Session notes:** saystory
+`claude_docs/session_notes.md` (Steps 1/1b/2 markers + trivial-suggestion advisory,
+first-party — assessor ran the run).
+
+## What the run did (confirmed)
+
+Steps 1–2 in full. The Step-2 audit did the issue's real work: classified every
+remaining "Parrot" occurrence — 7 brand-context template lines (replace), 2 README
+fork-lineage attributions (keep per AC2), and the whole docs/ tree (all historical
+records / identifiers / non-user-facing — keep per AC3, list shipped in the PR
+body). Net mechanical change 2 files / 7 lines → trivial exit (D5, owner-contract
+recommended fork). Exit hygiene: branch, one commit, PR #180 with the full audit
+list, merge on green, epic tick, run-record rc 0. One environment note: the PR's CI
+ran FULL builds — `.github/ISSUE_TEMPLATE/*.yml` is evidently not in the
+path-classifier's docs-skip allowlist, so a 7-line template change cost ~35 min of
+queued heavy builds (fail-safe direction by design: "a wasted build is cheap").
+
+## Dimension scores
+
+1. **Fidelity 5/5** (confirmed) — executed steps marked; sanctioned exit; decision
+   logged.
+2. **Gates unscored** — none ran (sanctioned exit); the audit judgment (keep vs
+   replace) was the run's substance and shipped transparently in the PR body.
+3. **Clarity 5/5** (confirmed) — no improvisation.
+4. **Dispatch unscored** — zero dispatches.
+5. **Telemetry 3/5** (confirmed; valid first summarize; usage known-limitation;
+   all other fields match).
+6. **Cost 3/5** (capped: usage session-level; the exit itself minimized
+   orchestration cost — the only real cost was the classifier-forced full CI,
+   which is saystory repo config, not plugin machinery).
+
+## Findings
+
+**F1 — ENVIRONMENT (saystory repo config, noted for the owner, not a plugin
+issue): `.github/ISSUE_TEMPLATE/` absent from the path-aware classifier's docs-skip
+set** (`scripts/ci/classify-paths.sh` in saystory) — a pure template change ran
+~43 min of platform builds. Fail-safe direction is correct policy; adding the
+template dir to the skip set is a one-line saystory follow-up, owner's call.
+Routed: noted in the M1 wrap comment, not filed against the plugin.
+
+## Telemetry audit
+
+| field | recorded | session evidence | verdict |
+|---|---|---|---|
+| workflow/version/issue | implement-feature / 3.29.0 / 157 | cache + markers | match |
+| changes | 2 files, +7/−7, 1 commit | PR #180 stat | match |
+| tests / gates / scan / loop_backs | 0-added·nulls / [] / ran:false / 0-3 | sanctioned exit, no suites (docs), none run | match |
+| outcome | PR 180, merged, ci passed | 878c602 + all-lanes-pass | match |
+| usage | session-cumulative | capture semantics | known-limitation |
+| dispatches[] | absent | zero dispatch activity | correct omission |
+| goal_guard | deferred | run-level /goal | match |
+
+Verdicts: match 8 · known-limitation 1.
+
+## Routing
+
+Clean run for the plugin: nothing filed, nothing memorized (F1 is assessed-project
+environment, routed via the epic wrap comment).
+
+Inferred (unconfirmed) claims: none.

--- a/docs/reviews/run-feedback-wf2-162-2026-07-11.html
+++ b/docs/reviews/run-feedback-wf2-162-2026-07-11.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 run-feedback — WF2 #162</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+
+:root{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+@media(prefers-color-scheme:dark){:root{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}}
+:root[data-theme=dark]{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}
+:root[data-theme=light]{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+.score{font:11.5px/1.4 ui-monospace,Menlo,Consolas,monospace;font-weight:700;background:var(--code);color:var(--accent);border-radius:5px;padding:1px 6px}
+.sev{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 7px;border-radius:999px;text-transform:uppercase;white-space:nowrap}
+.sev-critical{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.sev-high{color:var(--sev-high);background:var(--sev-high-bg)}
+.sev-medium{color:var(--sev-med);background:var(--sev-med-bg)}
+.sev-low{color:var(--sev-low);background:var(--sev-low-bg)}
+.req{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 6px;border-radius:5px;color:var(--req-c);background:var(--req-c-bg)}
+.req-must-not,.req-should-not{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.req-may{color:var(--ink-3);background:var(--code)}
+
+.tpl-report blockquote{background:var(--code);border-left-color:var(--accent)}
+.tpl-report tbody tr:nth-child(even){background:var(--code)}
+</style>
+</head>
+<body class="tpl-report">
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-11 07:29 MDT</div>
+<h1>WF14 run-feedback — WF2 #162</h1>
+
+</header>
+<main>
+<h1>WF14 run-feedback — WF2 #162 (saystory, standard lane, PR #190)</h1>
+<p>Assessed under rubric v2 (2026-07-10, #377). Plugin version loaded: 3.35.0 (cache). Record: explicit (<code>claude_docs/.rawgentic-162-record.json</code>), persisted to the saystory store (25th line) — <strong>schema-valid on FIRST summarize</strong> (the session&#x27;s two earlier schema stumbles didn&#x27;t recur). Adversarial layers used gpt-5.6-sol per owner directive.</p>
+<h2>At a glance</h2>
+<p><strong>The run where the layered-gate design proved itself: two independent 8a lenses verified a faithful implementation of a design whose stage sequencing was itself wrong, and the Step-11 adversarial diff caught that Critical (plus a real cache race) before any push — zero CI fix loops, mac lane green first try, and every gate artifact carried its evidence.</strong></p>
+<ul>
+<li><strong>Fidelity <span class="score">4/5</span></strong> — full-spine steps marked (1-5 incl. gated design, 8, 8a, 11,</li>
+</ul>
+<p>  11.5, 12, 14, 16); Step 9 again folded into the 8a whole-diff task-mapping rather   than marked separately (same pattern as #168 PR-B — see friction lineage).</p>
+<ul>
+<li><strong>Gates <span class="score">5/5</span></strong> — the assessment&#x27;s centerpiece, named below.</li>
+<li><strong>Clarity <span class="score">5/5</span></strong> — zero improvisation this run: every engine/tool invocation ran</li>
+</ul>
+<p>  as learned earlier in the session (sidecar path in-project, rc read unpiped,   schema enums from the doc).</p>
+<ul>
+<li><strong>Dispatch <span class="score">5/5</span></strong> — 3 dispatches (1 implementer worktree, 2 reviewers), all opus</li>
+</ul>
+<p>  as routed, non-vacuous, first try; implementer&#x27;s flagged doubt (is hotkey_worker   mac&#x27;s live path?) retired by the orchestrator with a code citation   (socket.rs:169) instead of being trusted or ignored.</p>
+<ul>
+<li><strong>Telemetry <span class="score">3/5</span></strong> — valid first summarize; usage still session-level</li>
+</ul>
+<p>  (known-limitation); tests.added assembled from two suites (stated).</p>
+<ul>
+<li><strong>Cost <span class="score">4/5</span></strong> — proportional: one implementer + 2 reviewers + 2 engine passes for</li>
+</ul>
+<p>  a 700-line cross-crate change; heaviest-least-value step: the second full   workspace suite run between 8a-fixes and adversarial-fixes (defensible, but the   intermediate run proved surfaces the final run re-proved 20 minutes later).</p>
+<p><strong>Best catch:</strong> Step-11 adversarial (gpt-5.6-sol), Critical — &quot;On a cold cache miss, <code>loading-model</code> is immediately followed by <code>running</code> before <code>cleanup()</code> begins. Because <code>cleanup()</code> itself performs the model load, the overlay switches to &#x27;Cleaning up…&#x27; for the entire slow load&quot; — a flaw in the DESIGN&#x27;S OWN sequencing (D-162-3 as written), faithfully implemented and passed by both 8a lenses. Fixed by warming explicitly between the stages (the trait surface already existed). This is the strongest same-session evidence yet that the adversarial layer catches what compliance-oriented lenses structurally cannot: the spec itself. Runner-up (High): <code>SingleSlotModelCache</code> two-key insert race (both platforms) — red-proven reentrancy test now pins the RAM invariant.</p>
+<p><strong>Worst friction:</strong> none new — the recurring items (Step-9 marker absorption; adversarial disposition ledger #393) both reappeared in known shapes; #393&#x27;s re-litigation cost this run was ZERO findings (both engine passes produced only fresh findings), a favorable data point for the pending fix&#x27;s priority calculus.</p>
+<p><strong>Routed:</strong> 0 defects filed; no new friction memory (both patterns already carried: #393 + this session&#x27;s #168 memory); orchestrator-error note below.</p>
+<h2>Evidence ledger (selected)</h2>
+<ul>
+<li>Design gate 1 pass, 5 findings dispositioned (4 adopted incl. the send-failure</li>
+</ul>
+<p>  safety net that Step 11 later CORRECTED in mechanism — the sidecar window-hide,   not a frontend re-render — an honest two-stage refinement, both recorded) —   <strong>confirmed</strong> (design-note dispositions + markers).</p>
+<ul>
+<li>T1 red-first: taps disabled → 3 sequencing tests red; cache race: retain</li>
+</ul>
+<p>  disabled → panic &quot;two models were resident&quot; — <strong>confirmed</strong> (runner outputs read   in-session).</p>
+<ul>
+<li>Gates: ws 416/0 (+9), linux 70/0 (+4), typecheck 0, drift-guard 1/1, scan PASS,</li>
+</ul>
+<p>  mac preflight 84/1/0 ×2 — <strong>confirmed</strong> (final runner outputs).</p>
+<ul>
+<li>PR #190 merged 50bf91b; mac lane green FIRST CI run (preflight rule now 3-for-3</li>
+</ul>
+<p>  since adoption); audit clean (#162 closed, #154/#172 untouched) — <strong>confirmed</strong>.</p>
+<ul>
+<li>ORCHESTRATOR ERROR (owned): during the red-proof, <code>git checkout --</code> restored the</li>
+</ul>
+<p>  committed file and silently wiped the UNCOMMITTED fix+test (reapplied from   context). Lesson: red-prove by sed-out/sed-back, never a checkout restore over   uncommitted work. No plugin prose invited it.</p>
+<h2>Telemetry audit</h2>
+<table>
+<thead><tr><th>field</th><th>recorded</th><th>session evidence</th><th>verdict</th></tr></thead>
+<tbody>
+<tr><td>workflow/issue/lane</td><td>implement-feature / 162 / full</td><td>matches</td><td>match</td></tr>
+<tr><td>tests</td><td>13 added / 486 passing</td><td>ws 416 + linux 70 (two suites, stated)</td><td>match (assembly method stated)</td></tr>
+<tr><td>gates[]</td><td><span class="score">5/5</span>, 2/2, 2/2</td><td>dispositions + markers</td><td>match</td></tr>
+<tr><td>loop_backs</td><td>0/3</td><td>none consumed</td><td>match</td></tr>
+<tr><td>outcome</td><td>PR 190 merged, ci passed</td><td>merge SHA 50bf91b</td><td>match</td></tr>
+<tr><td>security_scan</td><td>ran, iac skip</td><td>scan output</td><td>match</td></tr>
+<tr><td>usage</td><td>unavailable</td><td>session-level</td><td>known-limitation</td></tr>
+<tr><td>dispatches[]</td><td>3</td><td>agent results</td><td>match (first-summarize valid)</td></tr>
+</tbody>
+</table>
+<p>Verdicts: match 7 · known-limitation 1 · mismatch 0.</p>
+<h2>Findings and classes</h2>
+<p>1. <strong>WORKING AS DESIGNED (highlight)</strong> — the redundant-lens architecture: 8a    verifies implementation-vs-spec, adversarial attacks the spec. #162 is the    clean specimen: both 8a lenses CLEAN on code that faithfully implemented a    wrong sequence; the adversarial pass alone caught it. Feed to #393&#x27;s issue as    supporting evidence that the disposition ledger must NOT dampen fresh-finding    aggression. 2. <strong>PLUGIN FRICTION (recurrent, low)</strong> — Step 9&#x27;s identity keeps dissolving into    Step 11&#x27;s whole-diff task-mapping on multi-task runs (3rd occurrence: #168    PR-B, #162). Either the prose should bless the fold (Step 11 subsumes 9 when    the same reviewer maps the whole diff) or demand the marker. Below filing    threshold individually; noted for the #391-class checklist thread. 3. <strong>ORCHESTRATOR ERROR</strong> — the checkout-over-uncommitted-work slip (owned,    recovered, lesson recorded).</p>
+<h2>Summary block</h2>
+<pre><code>WF RUN ASSESSMENT — WF2 @ v3.35.0 (issue #162, PR #190, lane full) · rubric v2
+Fidelity 4/5 · Gates 5/5 · Clarity 5/5 · Dispatch 5/5 · Telemetry 3/5 · Cost 4/5
+Mode: full · Record: claude_docs/.rawgentic-162-record.json (persisted, first-summarize valid)
+Best catch: adversarial Critical — the design&#x27;s own stage sequencing billed the load to &quot;Cleaning up…&quot;
+Worst friction: none new (known lineages: Step-9 fold, #393 disposition ledger)
+Telemetry verdicts: match 7 / mismatch 0 / missing-in-record 0 / missing-in-session 0 / unverifiable 0 / known-limitation 1
+Defects filed: none | Telemetry filed: none | Not filed (cap): 0 | Friction memorized: none (covered) | Clean run: yes (machinery)
+Report: projects/rawgentic/docs/reviews/run-feedback-wf2-162-2026-07-11.md
+Inferred (unconfirmed) claims: none</code></pre>
+
+</main>
+<footer>Last updated: 2026-07-11 07:29 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/run-feedback-wf2-162-2026-07-11.md
+++ b/docs/reviews/run-feedback-wf2-162-2026-07-11.md
@@ -1,0 +1,114 @@
+# WF14 run-feedback — WF2 #162 (saystory, standard lane, PR #190)
+
+Assessed under rubric v2 (2026-07-10, #377). Plugin version loaded: 3.35.0 (cache).
+Record: explicit (`claude_docs/.rawgentic-162-record.json`), persisted to the saystory
+store (25th line) — **schema-valid on FIRST summarize** (the session's two earlier
+schema stumbles didn't recur). Adversarial layers used gpt-5.6-sol per owner directive.
+
+## At a glance
+
+**The run where the layered-gate design proved itself: two independent 8a lenses
+verified a faithful implementation of a design whose stage sequencing was itself
+wrong, and the Step-11 adversarial diff caught that Critical (plus a real cache
+race) before any push — zero CI fix loops, mac lane green first try, and every gate
+artifact carried its evidence.**
+
+- **Fidelity 4/5** — full-spine steps marked (1-5 incl. gated design, 8, 8a, 11,
+  11.5, 12, 14, 16); Step 9 again folded into the 8a whole-diff task-mapping rather
+  than marked separately (same pattern as #168 PR-B — see friction lineage).
+- **Gates 5/5** — the assessment's centerpiece, named below.
+- **Clarity 5/5** — zero improvisation this run: every engine/tool invocation ran
+  as learned earlier in the session (sidecar path in-project, rc read unpiped,
+  schema enums from the doc).
+- **Dispatch 5/5** — 3 dispatches (1 implementer worktree, 2 reviewers), all opus
+  as routed, non-vacuous, first try; implementer's flagged doubt (is hotkey_worker
+  mac's live path?) retired by the orchestrator with a code citation
+  (socket.rs:169) instead of being trusted or ignored.
+- **Telemetry 3/5** — valid first summarize; usage still session-level
+  (known-limitation); tests.added assembled from two suites (stated).
+- **Cost 4/5** — proportional: one implementer + 2 reviewers + 2 engine passes for
+  a 700-line cross-crate change; heaviest-least-value step: the second full
+  workspace suite run between 8a-fixes and adversarial-fixes (defensible, but the
+  intermediate run proved surfaces the final run re-proved 20 minutes later).
+
+**Best catch:** Step-11 adversarial (gpt-5.6-sol), Critical — "On a cold cache miss,
+`loading-model` is immediately followed by `running` before `cleanup()` begins.
+Because `cleanup()` itself performs the model load, the overlay switches to
+'Cleaning up…' for the entire slow load" — a flaw in the DESIGN'S OWN sequencing
+(D-162-3 as written), faithfully implemented and passed by both 8a lenses. Fixed by
+warming explicitly between the stages (the trait surface already existed). This is
+the strongest same-session evidence yet that the adversarial layer catches what
+compliance-oriented lenses structurally cannot: the spec itself.
+Runner-up (High): `SingleSlotModelCache` two-key insert race (both platforms) —
+red-proven reentrancy test now pins the RAM invariant.
+
+**Worst friction:** none new — the recurring items (Step-9 marker absorption;
+adversarial disposition ledger #393) both reappeared in known shapes; #393's
+re-litigation cost this run was ZERO findings (both engine passes produced only
+fresh findings), a favorable data point for the pending fix's priority calculus.
+
+**Routed:** 0 defects filed; no new friction memory (both patterns already carried:
+#393 + this session's #168 memory); orchestrator-error note below.
+
+## Evidence ledger (selected)
+
+- Design gate 1 pass, 5 findings dispositioned (4 adopted incl. the send-failure
+  safety net that Step 11 later CORRECTED in mechanism — the sidecar window-hide,
+  not a frontend re-render — an honest two-stage refinement, both recorded) —
+  **confirmed** (design-note dispositions + markers).
+- T1 red-first: taps disabled → 3 sequencing tests red; cache race: retain
+  disabled → panic "two models were resident" — **confirmed** (runner outputs read
+  in-session).
+- Gates: ws 416/0 (+9), linux 70/0 (+4), typecheck 0, drift-guard 1/1, scan PASS,
+  mac preflight 84/1/0 ×2 — **confirmed** (final runner outputs).
+- PR #190 merged 50bf91b; mac lane green FIRST CI run (preflight rule now 3-for-3
+  since adoption); audit clean (#162 closed, #154/#172 untouched) — **confirmed**.
+- ORCHESTRATOR ERROR (owned): during the red-proof, `git checkout --` restored the
+  committed file and silently wiped the UNCOMMITTED fix+test (reapplied from
+  context). Lesson: red-prove by sed-out/sed-back, never a checkout restore over
+  uncommitted work. No plugin prose invited it.
+
+## Telemetry audit
+
+| field | recorded | session evidence | verdict |
+|---|---|---|---|
+| workflow/issue/lane | implement-feature / 162 / full | matches | match |
+| tests | 13 added / 486 passing | ws 416 + linux 70 (two suites, stated) | match (assembly method stated) |
+| gates[] | 5/5, 2/2, 2/2 | dispositions + markers | match |
+| loop_backs | 0/3 | none consumed | match |
+| outcome | PR 190 merged, ci passed | merge SHA 50bf91b | match |
+| security_scan | ran, iac skip | scan output | match |
+| usage | unavailable | session-level | known-limitation |
+| dispatches[] | 3 | agent results | match (first-summarize valid) |
+
+Verdicts: match 7 · known-limitation 1 · mismatch 0.
+
+## Findings and classes
+
+1. **WORKING AS DESIGNED (highlight)** — the redundant-lens architecture: 8a
+   verifies implementation-vs-spec, adversarial attacks the spec. #162 is the
+   clean specimen: both 8a lenses CLEAN on code that faithfully implemented a
+   wrong sequence; the adversarial pass alone caught it. Feed to #393's issue as
+   supporting evidence that the disposition ledger must NOT dampen fresh-finding
+   aggression.
+2. **PLUGIN FRICTION (recurrent, low)** — Step 9's identity keeps dissolving into
+   Step 11's whole-diff task-mapping on multi-task runs (3rd occurrence: #168
+   PR-B, #162). Either the prose should bless the fold (Step 11 subsumes 9 when
+   the same reviewer maps the whole diff) or demand the marker. Below filing
+   threshold individually; noted for the #391-class checklist thread.
+3. **ORCHESTRATOR ERROR** — the checkout-over-uncommitted-work slip (owned,
+   recovered, lesson recorded).
+
+## Summary block
+
+```
+WF RUN ASSESSMENT — WF2 @ v3.35.0 (issue #162, PR #190, lane full) · rubric v2
+Fidelity 4/5 · Gates 5/5 · Clarity 5/5 · Dispatch 5/5 · Telemetry 3/5 · Cost 4/5
+Mode: full · Record: claude_docs/.rawgentic-162-record.json (persisted, first-summarize valid)
+Best catch: adversarial Critical — the design's own stage sequencing billed the load to "Cleaning up…"
+Worst friction: none new (known lineages: Step-9 fold, #393 disposition ledger)
+Telemetry verdicts: match 7 / mismatch 0 / missing-in-record 0 / missing-in-session 0 / unverifiable 0 / known-limitation 1
+Defects filed: none | Telemetry filed: none | Not filed (cap): 0 | Friction memorized: none (covered) | Clean run: yes (machinery)
+Report: projects/rawgentic/docs/reviews/run-feedback-wf2-162-2026-07-11.md
+Inferred (unconfirmed) claims: none
+```

--- a/docs/reviews/run-feedback-wf2-164-2026-07-10.html
+++ b/docs/reviews/run-feedback-wf2-164-2026-07-10.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 run-feedback — WF2 #164</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+</style>
+</head>
+<body>
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-10 08:05 MDT</div>
+<h1>WF14 run-feedback — WF2 #164</h1>
+
+</header>
+<main>
+<h1>WF14 run-feedback — WF2 #164 (saystory, PR #177) · 2026-07-10 · rubric v1</h1>
+<p><strong>Run under assessment:</strong> WF2 invocation for saystory #164 (macOS CI lane) that took the sanctioned <strong>trivial-work exit</strong> at Step 2 — the subject is the trivial-exit machinery + the record it emitted. <strong>Plugin version loaded:</strong> 3.29.0 (cache); main: 3.32.1. <strong>Record:</strong> explicit (saystory store, issue-164 line; <code>validate_record</code> on main&#x27;s validator → valid). <strong>Session notes:</strong> saystory <code>claude_docs/session_notes.md</code>, markers for Steps 1/1b/2 + the trivial-suggestion advisory + a <code>WF2 #164: COMPLETE via trivial-work exit</code> close line (all quoted in ledger; assessor ran the run — first-party evidence).</p>
+<h2>What the run did (confirmed)</h2>
+<p>Steps 1–2 executed in full (capabilities derive, issue fetch, branch-protection probe, live AC verification against CI runs/API/release evidence). The Step-2 audit found ACs 1–3 already shipped by prior PRs — the remaining scope was a 1-file docs reconcile, classified trivial (<code>lane_decision</code> → tier=trivial). The trivial-exit suggestion was AUTO-TAKEN citing the owner&#x27;s overnight contract (&quot;take the workflow&#x27;s RECOMMENDED option at every suggested fork&quot;) — logged as run-decision D1. Exit hygiene per the trivial-exit prose: branch off fresh origin/main, single commit, PR #177 (docs-only, no bump per convention), CI classifier skip exercised as the gate, squash-merge, post-merge auto-close audit, epic checkbox tick, run-record emitted with <code>complexity: &quot;trivial&quot;</code> (rc 0).</p>
+<h2>Dimension scores</h2>
+<p>1. <strong>Fidelity 5/5</strong> (confirmed). Every executed step marked; the exit is the ONE    sanctioned no-gate path and its suggestion marker + decision log are present; no    mandatory step was entered then skipped. 2. <strong>Gates unscored</strong> — no gates ran, by design of the taken exit; AC verification    was live-evidence-based (CI run 29077807637 macOS job success, protection API,    v0.2.39 dmg) rather than gate-based. Stated, not scored. 3. <strong>Clarity 5/5</strong> (confirmed). The <code>&lt;trivial-work-check&gt;</code> prose executed without    improvisation; the optional-run-record sentence (&quot;If you do emit a run-record,    set <code>complexity: &quot;trivial&quot;</code>&quot;) was followed as written. 4. <strong>Dispatch unscored</strong> — zero dispatches in this run. 5. <strong>Telemetry 3/5</strong> (confirmed; anchor: valid first summarize + ≥1    known-limitation). Record valid on first summarize; all audited fields match;    <code>usage</code> session-cumulative (standing known-limitation). <code>gates: []</code> accepted by    the validator — the trivial-exit record shape works. 6. <strong>Cost 3/5</strong> (capped: usage session-level; would otherwise anchor at 5 — the    trivial exit demonstrably minimized cost: zero subagents, one commit, for a    4-AC issue whose real remainder was a 25-line docs reconcile).</p>
+<h2>Findings</h2>
+<p><strong>F1 — WORKING AS DESIGNED (noted, no action): autonomous-interactive fork resolution rests on the owner contract, not the skill.</strong> The trivial-check&#x27;s only autonomous guidance is the headless annotation (&quot;[Headless: AUTO-RESOLVE — continue the full workflow…]&quot;) — conservative auto-continue, NOT take-the-exit. This run auto-took the exit under the owner&#x27;s explicit standing contract, which outranks skill defaults (documented precedence). Correct behavior; the gap (goal-driven autonomous non-headless runs have no skill-level fork guidance) is real but the precedence hierarchy already resolves it. Not filed, not memorized — the #165 assessment&#x27;s friction memory covers this session&#x27;s one memorization slot pattern, and this finding is not actionable beyond what precedence already defines.</p>
+<p><strong>F2 — MACHINERY VALIDATION (positive data point):</strong> a WF2 issue can arrive ALREADY-IMPLEMENTED (filed by a WF5 review unaware of same-day merges); Step 2&#x27;s live-evidence analysis caught it and the trivial exit turned a would-be redundant full spine into a 25-line honest reconcile. The check earned its place.</p>
+<h2>Telemetry audit</h2>
+<table>
+<thead><tr><th>field</th><th>recorded</th><th>session evidence</th><th>verdict</th></tr></thead>
+<tbody>
+<tr><td>workflow/version/issue</td><td>implement-feature / 3.29.0 / 164</td><td>cache + markers</td><td>match</td></tr>
+<tr><td>changes</td><td>1 file, +18/−14, 1 commit</td><td>PR #177 diff stat</td><td>match</td></tr>
+<tr><td>tests</td><td>0 added, null/null</td><td>docs-only, no suite run (honest nulls)</td><td>match</td></tr>
+<tr><td>gates[]</td><td>[]</td><td>no gates ran (sanctioned exit)</td><td>match</td></tr>
+<tr><td>security_scan</td><td>ran:false, skipped:[]</td><td>scan not run (exit skips it, sanctioned)</td><td>match</td></tr>
+<tr><td>loop_backs</td><td>0/3</td><td>no counters file</td><td>match</td></tr>
+<tr><td>outcome</td><td>PR 177, merged, ci passed</td><td>merge 61c4da6, classifier pass + skipped-as-success</td><td>match</td></tr>
+<tr><td>usage</td><td>session-cumulative</td><td>capture semantics</td><td>known-limitation</td></tr>
+<tr><td>dispatches[]</td><td>absent</td><td>zero dispatch activity in session</td><td>correct omission (not missing-in-record)</td></tr>
+<tr><td>goal_guard</td><td>deferred</td><td>run-level /goal active, logged</td><td>match</td></tr>
+</tbody>
+</table>
+<p>Verdicts: match 9 · known-limitation 1.</p>
+<h2>Routing</h2>
+<p>Clean run: nothing filed, nothing memorized. (F1 is working-as-designed; F2 is a positive data point.)</p>
+<p>Inferred (unconfirmed) claims: none — first-party evidence throughout.</p>
+
+</main>
+<footer>Last updated: 2026-07-10 08:05 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/run-feedback-wf2-164-2026-07-10.md
+++ b/docs/reviews/run-feedback-wf2-164-2026-07-10.md
@@ -1,0 +1,85 @@
+# WF14 run-feedback — WF2 #164 (saystory, PR #177) · 2026-07-10 · rubric v1
+
+**Run under assessment:** WF2 invocation for saystory #164 (macOS CI lane) that took
+the sanctioned **trivial-work exit** at Step 2 — the subject is the trivial-exit
+machinery + the record it emitted. **Plugin version loaded:** 3.29.0 (cache); main:
+3.32.1. **Record:** explicit (saystory store, issue-164 line; `validate_record` on
+main's validator → valid). **Session notes:** saystory
+`claude_docs/session_notes.md`, markers for Steps 1/1b/2 + the trivial-suggestion
+advisory + a `WF2 #164: COMPLETE via trivial-work exit` close line (all quoted in
+ledger; assessor ran the run — first-party evidence).
+
+## What the run did (confirmed)
+
+Steps 1–2 executed in full (capabilities derive, issue fetch, branch-protection
+probe, live AC verification against CI runs/API/release evidence). The Step-2 audit
+found ACs 1–3 already shipped by prior PRs — the remaining scope was a 1-file docs
+reconcile, classified trivial (`lane_decision` → tier=trivial). The trivial-exit
+suggestion was AUTO-TAKEN citing the owner's overnight contract ("take the
+workflow's RECOMMENDED option at every suggested fork") — logged as run-decision D1.
+Exit hygiene per the trivial-exit prose: branch off fresh origin/main, single
+commit, PR #177 (docs-only, no bump per convention), CI classifier skip exercised as
+the gate, squash-merge, post-merge auto-close audit, epic checkbox tick, run-record
+emitted with `complexity: "trivial"` (rc 0).
+
+## Dimension scores
+
+1. **Fidelity 5/5** (confirmed). Every executed step marked; the exit is the ONE
+   sanctioned no-gate path and its suggestion marker + decision log are present; no
+   mandatory step was entered then skipped.
+2. **Gates unscored** — no gates ran, by design of the taken exit; AC verification
+   was live-evidence-based (CI run 29077807637 macOS job success, protection API,
+   v0.2.39 dmg) rather than gate-based. Stated, not scored.
+3. **Clarity 5/5** (confirmed). The `<trivial-work-check>` prose executed without
+   improvisation; the optional-run-record sentence ("If you do emit a run-record,
+   set `complexity: "trivial"`") was followed as written.
+4. **Dispatch unscored** — zero dispatches in this run.
+5. **Telemetry 3/5** (confirmed; anchor: valid first summarize + ≥1
+   known-limitation). Record valid on first summarize; all audited fields match;
+   `usage` session-cumulative (standing known-limitation). `gates: []` accepted by
+   the validator — the trivial-exit record shape works.
+6. **Cost 3/5** (capped: usage session-level; would otherwise anchor at 5 — the
+   trivial exit demonstrably minimized cost: zero subagents, one commit, for a
+   4-AC issue whose real remainder was a 25-line docs reconcile).
+
+## Findings
+
+**F1 — WORKING AS DESIGNED (noted, no action): autonomous-interactive fork
+resolution rests on the owner contract, not the skill.** The trivial-check's only
+autonomous guidance is the headless annotation ("[Headless: AUTO-RESOLVE — continue
+the full workflow…]") — conservative auto-continue, NOT take-the-exit. This run
+auto-took the exit under the owner's explicit standing contract, which outranks
+skill defaults (documented precedence). Correct behavior; the gap (goal-driven
+autonomous non-headless runs have no skill-level fork guidance) is real but the
+precedence hierarchy already resolves it. Not filed, not memorized — the #165
+assessment's friction memory covers this session's one memorization slot pattern,
+and this finding is not actionable beyond what precedence already defines.
+
+**F2 — MACHINERY VALIDATION (positive data point):** a WF2 issue can arrive
+ALREADY-IMPLEMENTED (filed by a WF5 review unaware of same-day merges); Step 2's
+live-evidence analysis caught it and the trivial exit turned a would-be redundant
+full spine into a 25-line honest reconcile. The check earned its place.
+
+## Telemetry audit
+
+| field | recorded | session evidence | verdict |
+|---|---|---|---|
+| workflow/version/issue | implement-feature / 3.29.0 / 164 | cache + markers | match |
+| changes | 1 file, +18/−14, 1 commit | PR #177 diff stat | match |
+| tests | 0 added, null/null | docs-only, no suite run (honest nulls) | match |
+| gates[] | [] | no gates ran (sanctioned exit) | match |
+| security_scan | ran:false, skipped:[] | scan not run (exit skips it, sanctioned) | match |
+| loop_backs | 0/3 | no counters file | match |
+| outcome | PR 177, merged, ci passed | merge 61c4da6, classifier pass + skipped-as-success | match |
+| usage | session-cumulative | capture semantics | known-limitation |
+| dispatches[] | absent | zero dispatch activity in session | correct omission (not missing-in-record) |
+| goal_guard | deferred | run-level /goal active, logged | match |
+
+Verdicts: match 9 · known-limitation 1.
+
+## Routing
+
+Clean run: nothing filed, nothing memorized. (F1 is working-as-designed; F2 is a
+positive data point.)
+
+Inferred (unconfirmed) claims: none — first-party evidence throughout.

--- a/docs/reviews/run-feedback-wf2-165-2026-07-10.html
+++ b/docs/reviews/run-feedback-wf2-165-2026-07-10.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 run-feedback — WF2 #165</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+</style>
+</head>
+<body>
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-10 08:00 MDT</div>
+<h1>WF14 run-feedback — WF2 #165</h1>
+
+</header>
+<main>
+<h1>WF14 run-feedback — WF2 #165 (saystory, PR #178) · 2026-07-10 · rubric v1</h1>
+<p><strong>Run under assessment:</strong> WF2 implement-feature, saystory issue #165 (shared parrot-core-dispatch crate + Linux migration), full spine, merged. <strong>Plugin version loaded:</strong> 3.29.0 (cache <code>~/.claude/plugins/cache/rawgentic/rawgentic/3.29.0/</code>); current main: 3.32.1 — every filed defect re-verified on main. <strong>Record:</strong> explicit (<code>projects/saystory/docs/measurements/run_records.jsonl</code>, issue-165 line), <code>validate_record</code> (main&#x27;s validator) → valid, empty error list. <strong>Session notes:</strong> <code>projects/saystory/claude_docs/session_notes.md</code> (21 <code>### WF2 Step … #165</code> markers accepted; all keyed per #341 slots). Assessor = the same session that ran the workflow — evidence is first-party; the RUN&#x27;s cross-model layer was gpt-5.6-sol (design/plan/diff adversarial), but this ASSESSMENT is same-model rubric scoring (WF14 has no cross-model slot; stated per the owner&#x27;s gpt-5.6-sol directive).</p>
+<h2>Dimension scores</h2>
+<p>1. <strong>Fidelity 4/5</strong> (confirmed). All 12 mandatory markers present + Step 6 ran +    Step 15 skip condition met (no deployment). Ding: Step 2 item 10    (probe-parallelism) was NOT executed — notes say &quot;Parallelism: worktree assumed    per session precedent&quot; — an asserted, unevidenced condition; and the assumption    was WRONG at dispatch time (see F1). 2. <strong>Gates 5/5</strong> (confirmed). Real pre-implementation catch, finding text quoted in    notes: the design note claimed captureShortcut wire tokens &quot;pushToTalk&quot;/    &quot;handsFree&quot;; BOTH the Step-4 self-review (High, 0.8) and the gpt-5.6-sol    adversarial pass independently caught that the real tokens are    &quot;pushToTalkShortcut&quot;/&quot;handsFreeShortcut&quot; (shortcut_capture.rs:41-42) — an    implementer following the note would have broken every captureShortcut RPC with    green suites (the arm was unpinned). Peer consult also materially reshaped the    seam (narrow ServiceInitializer over the drafted PlatformHost). 3. <strong>Clarity 3/5</strong> (confirmed instances). Interpreted sentences: (a) Step 4 item 7    says dispatch <code>/rawgentic:adversarial-review &lt;design-doc-path&gt;</code> — the saystory    CLAUDE.md precedence note sanctions the raw engine instead; harmonizing prose    would remove the fork. (b) Step 11 defines dead-return (vacuous) detection but    no hung-dispatch ELAPSED-TIME threshold — the orchestrator invented &quot;17 min =    dead&quot; and was wrong (the dispatch returned healthy at 22 min). (c) engine    <code>--findings-json</code> must live under project root — discovered via exit-2 error,    not prose (one wasted dispatch). 4. <strong>Dispatch 3/5</strong> (confirmed). 14 dispatches; all ultimately resolved or visibly    substituted. Two blemishes: (a) rawgentic-implementer worktree spawn FAILED    outright (F1) → documented generic fallback used, serial; (b) the A2    presumed-dead relaunch — the original returned ok at 22 min, the relaunch was    TaskStopped; one wasted dispatch (~90k subagent tokens), no vacuous result    trusted. 5. <strong>Telemetry 3/5</strong> (confirmed). Record valid on first summarize; gates[] counts    match the persisted at-close dedup notes (#340 rule); loop_backs 1/3 matches the    counters file; outcome/scan/changes match. Negatives: <code>dispatches[]</code> carries 13    entries vs 14 session DISPATCH lines — the A2 episode was mis-emitted by the    orchestrator (premature <code>outcome=dead</code> for a dispatch that later returned ok,    plus a <code>retried</code> line; the #330 rules prescribe ONE line — orchestrator error,    owned). <code>usage</code> is session-cumulative (standing known-limitation). 6. <strong>Cost 3/5</strong> (capped at 3: usage is session-level). Full spine justified (new    crate = architecture change; lane correctly ineligible). Heaviest-least-value    step this run: the A2 relaunch (pure waste — caused by the missing    dead-threshold guidance, F2).</p>
+<h2>Findings</h2>
+<p><strong>F1 — PLUGIN DEFECT (filed): probe-parallelism measures the wrong repo for Agent-tool worktree spawning.</strong> Step 2 item 10 probes <code>--repo-root &quot;$(git rev-parse --show-toplevel)&quot;</code> (the PROJECT repo — <code>skills/implement-feature/references/steps.md:454</code> on main), but the Agent tool creates the <code>rawgentic:rawgentic-implementer</code> worktree (frontmatter <code>isolation: worktree</code>, <code>agents/rawgentic-implementer.md</code> on main) against the SESSION primary working directory. In the plugin&#x27;s flagship layout — a rawgentic WORKSPACE root that is NOT a git repo containing project repos — the probe returns <code>worktree</code> while every implementer dispatch dies at spawn. Live error this session, quoted: &quot;Cannot create agent worktree: not in a git repository and no WorktreeCreate hooks are configured.&quot; The documented <code>serial-only</code> graceful fallback never engages because the probe never says serial-only. Confirmed at 3.29.0 (live) and unchanged on main 3.32.1 (both files verified). Impact: silent loss of worktree isolation + one failed dispatch per run until the orchestrator improvises the generic fallback (this run did, logged).</p>
+<p><strong>F5 — PLUGIN DEFECT (filed): WF14&#x27;s cross-project report path collides with wal-bind-guard.</strong> WF14 SKILL.md path-binding (main, <code>skills/run-feedback/SKILL.md:60</code>: &quot;reports never land in the assessed project&#x27;s tree&quot;) REQUIRES writing under <code>projects/rawgentic/docs/reviews/</code> from a session bound to the assessed project; <code>hooks/wal-bind-guard</code> (main) denies exactly that write (&quot;File path belongs to a different project than the bound one&quot; — PreToolUse deny observed live this session). Two plugin components mandate contradictory behavior; the only non-bypass resolution is a temporary registry re-bind (used here, then reverted), which no prose documents. Confirmed at 3.29.0 (live deny) and both surfaces present on main 3.32.1.</p>
+<p><strong>F2 — PLUGIN FRICTION (memorized, not filed): no hung-dispatch deadline for reviewer agents.</strong> Step 11 item 2 / Step 8a item 7 define vacuous-return and error-retry handling, but no elapsed-time threshold for a silent healthy-but-slow dispatch. Gap sentence (Step 11 item 2): &quot;A reviewer return that is vacuous (no findings AND no substantive content) is a DEAD dispatch&quot; — nothing addresses not-yet-returned. Observed cost: one wasted opus relaunch killed after the original returned at 22 min. Measured this session: opus reviewers running cargo gates take 12–22 min.</p>
+<p><strong>F3 — ORCHESTRATOR ERROR (owned, no routing): premature <code>outcome=dead</code> DISPATCH line</strong> for A2 (returned ok later) — the #330 single-line retry rule misapplied; the record&#x27;s <code>dispatches[]</code> inherited the distortion (13 vs 14 lines). The prose did not invite the misread; no plugin feedback.</p>
+<p><strong>F4 — WORKING AS DESIGNED: adversarial design review raced the peer-consult synthesis</strong> (reviewed the pre-synthesis draft; its findings against the superseded PlatformHost section arrived pre-resolved). The Step-4 concurrency tradeoff note covers the loop-back case; the peer-synthesis race is an adjacent bounded cost of the same accepted overlap. No action.</p>
+<h2>Telemetry audit</h2>
+<table>
+<thead><tr><th>field</th><th>recorded</th><th>session evidence</th><th>verdict</th><th>impact</th><th>routing</th></tr></thead>
+<tbody>
+<tr><td>workflow/version/issue</td><td>implement-feature / 3.29.0 / 165</td><td>cache path + markers</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>changes</td><td>12 files, +1614/−493, 5 commits</td><td>diff --name-only (12 paths) + commit log</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>tests</td><td>32 added, 339/339</td><td>runner final 339/0; 38 crate tests = 32 authored + 6 relocated</td><td>match (relocated ≠ added, judgment noted)</td><td>—</td><td>—</td></tr>
+<tr><td>gates[]</td><td>10/10 · 5/5 · 1/1 · 0/0 · 6/6</td><td>at-close dedup notes per #340</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>security_scan</td><td>ran, skipped=[iac]</td><td>scan output quoted</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>loop_backs</td><td>1/3</td><td>counters file spec_tighten=1 total=1</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>outcome</td><td>PR 178, merged, ci passed</td><td>merge sha + checks output</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>usage</td><td>session-cumulative</td><td>usage_capture semantics</td><td>known-limitation</td><td>cost trend only</td><td>standing (#155 note)</td></tr>
+<tr><td>reviewer_kind</td><td>inline / hand_rolled_multi</td><td>#340 gate-defining precedence</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>dispatches[]</td><td>13 entries</td><td>14 <code>^DISPATCH issue=165</code> lines; A2 over-emission</td><td>mismatch (minor)</td><td>audit fidelity</td><td>orchestrator error owned; rules already prohibit it — nothing filed, reason stated</td></tr>
+</tbody>
+</table>
+<p>Verdict counts: match 8 · mismatch 1 · known-limitation 1.</p>
+<h2>Routing</h2>
+<ul>
+<li>Filed: 2 plugin defects (F1, F5) — links in summary block; dup-checked first.</li>
+<li>Telemetry lane: nothing filed — the one mismatch is an owned orchestrator</li>
+</ul>
+<p>  mis-emission the #330 rules already prohibit; dropped with that reason.</p>
+<ul>
+<li>Friction: ONE mempalace memory (F2), project rawgentic.</li>
+<li>Not filed (cap): 0.</li>
+</ul>
+<p>Inferred (unconfirmed) claims: none — assessor ran the run; evidence first-party.</p>
+
+</main>
+<footer>Last updated: 2026-07-10 08:00 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/run-feedback-wf2-165-2026-07-10.md
+++ b/docs/reviews/run-feedback-wf2-165-2026-07-10.md
@@ -1,0 +1,130 @@
+# WF14 run-feedback — WF2 #165 (saystory, PR #178) · 2026-07-10 · rubric v1
+
+**Run under assessment:** WF2 implement-feature, saystory issue #165 (shared
+parrot-core-dispatch crate + Linux migration), full spine, merged. **Plugin version
+loaded:** 3.29.0 (cache `~/.claude/plugins/cache/rawgentic/rawgentic/3.29.0/`);
+current main: 3.32.1 — every filed defect re-verified on main. **Record:** explicit
+(`projects/saystory/docs/measurements/run_records.jsonl`, issue-165 line),
+`validate_record` (main's validator) → valid, empty error list. **Session notes:**
+`projects/saystory/claude_docs/session_notes.md` (21 `### WF2 Step … #165` markers
+accepted; all keyed per #341 slots). Assessor = the same session that ran the
+workflow — evidence is first-party; the RUN's cross-model layer was gpt-5.6-sol
+(design/plan/diff adversarial), but this ASSESSMENT is same-model rubric scoring
+(WF14 has no cross-model slot; stated per the owner's gpt-5.6-sol directive).
+
+## Dimension scores
+
+1. **Fidelity 4/5** (confirmed). All 12 mandatory markers present + Step 6 ran +
+   Step 15 skip condition met (no deployment). Ding: Step 2 item 10
+   (probe-parallelism) was NOT executed — notes say "Parallelism: worktree assumed
+   per session precedent" — an asserted, unevidenced condition; and the assumption
+   was WRONG at dispatch time (see F1).
+2. **Gates 5/5** (confirmed). Real pre-implementation catch, finding text quoted in
+   notes: the design note claimed captureShortcut wire tokens "pushToTalk"/
+   "handsFree"; BOTH the Step-4 self-review (High, 0.8) and the gpt-5.6-sol
+   adversarial pass independently caught that the real tokens are
+   "pushToTalkShortcut"/"handsFreeShortcut" (shortcut_capture.rs:41-42) — an
+   implementer following the note would have broken every captureShortcut RPC with
+   green suites (the arm was unpinned). Peer consult also materially reshaped the
+   seam (narrow ServiceInitializer over the drafted PlatformHost).
+3. **Clarity 3/5** (confirmed instances). Interpreted sentences: (a) Step 4 item 7
+   says dispatch `/rawgentic:adversarial-review <design-doc-path>` — the saystory
+   CLAUDE.md precedence note sanctions the raw engine instead; harmonizing prose
+   would remove the fork. (b) Step 11 defines dead-return (vacuous) detection but
+   no hung-dispatch ELAPSED-TIME threshold — the orchestrator invented "17 min =
+   dead" and was wrong (the dispatch returned healthy at 22 min). (c) engine
+   `--findings-json` must live under project root — discovered via exit-2 error,
+   not prose (one wasted dispatch).
+4. **Dispatch 3/5** (confirmed). 14 dispatches; all ultimately resolved or visibly
+   substituted. Two blemishes: (a) rawgentic-implementer worktree spawn FAILED
+   outright (F1) → documented generic fallback used, serial; (b) the A2
+   presumed-dead relaunch — the original returned ok at 22 min, the relaunch was
+   TaskStopped; one wasted dispatch (~90k subagent tokens), no vacuous result
+   trusted.
+5. **Telemetry 3/5** (confirmed). Record valid on first summarize; gates[] counts
+   match the persisted at-close dedup notes (#340 rule); loop_backs 1/3 matches the
+   counters file; outcome/scan/changes match. Negatives: `dispatches[]` carries 13
+   entries vs 14 session DISPATCH lines — the A2 episode was mis-emitted by the
+   orchestrator (premature `outcome=dead` for a dispatch that later returned ok,
+   plus a `retried` line; the #330 rules prescribe ONE line — orchestrator error,
+   owned). `usage` is session-cumulative (standing known-limitation).
+6. **Cost 3/5** (capped at 3: usage is session-level). Full spine justified (new
+   crate = architecture change; lane correctly ineligible). Heaviest-least-value
+   step this run: the A2 relaunch (pure waste — caused by the missing
+   dead-threshold guidance, F2).
+
+## Findings
+
+**F1 — PLUGIN DEFECT (filed): probe-parallelism measures the wrong repo for
+Agent-tool worktree spawning.** Step 2 item 10 probes
+`--repo-root "$(git rev-parse --show-toplevel)"` (the PROJECT repo —
+`skills/implement-feature/references/steps.md:454` on main), but the Agent tool
+creates the `rawgentic:rawgentic-implementer` worktree (frontmatter
+`isolation: worktree`, `agents/rawgentic-implementer.md` on main) against the
+SESSION primary working directory. In the plugin's flagship layout — a rawgentic
+WORKSPACE root that is NOT a git repo containing project repos — the probe returns
+`worktree` while every implementer dispatch dies at spawn. Live error this session,
+quoted: "Cannot create agent worktree: not in a git repository and no
+WorktreeCreate hooks are configured." The documented `serial-only` graceful
+fallback never engages because the probe never says serial-only. Confirmed at
+3.29.0 (live) and unchanged on main 3.32.1 (both files verified). Impact: silent
+loss of worktree isolation + one failed dispatch per run until the orchestrator
+improvises the generic fallback (this run did, logged).
+
+**F5 — PLUGIN DEFECT (filed): WF14's cross-project report path collides with
+wal-bind-guard.** WF14 SKILL.md path-binding (main, `skills/run-feedback/SKILL.md:60`:
+"reports never land in the assessed project's tree") REQUIRES writing under
+`projects/rawgentic/docs/reviews/` from a session bound to the assessed project;
+`hooks/wal-bind-guard` (main) denies exactly that write ("File path belongs to a
+different project than the bound one" — PreToolUse deny observed live this
+session). Two plugin components mandate contradictory behavior; the only
+non-bypass resolution is a temporary registry re-bind (used here, then reverted),
+which no prose documents. Confirmed at 3.29.0 (live deny) and both surfaces
+present on main 3.32.1.
+
+**F2 — PLUGIN FRICTION (memorized, not filed): no hung-dispatch deadline for
+reviewer agents.** Step 11 item 2 / Step 8a item 7 define vacuous-return and
+error-retry handling, but no elapsed-time threshold for a silent
+healthy-but-slow dispatch. Gap sentence (Step 11 item 2): "A reviewer return that
+is vacuous (no findings AND no substantive content) is a DEAD dispatch" — nothing
+addresses not-yet-returned. Observed cost: one wasted opus relaunch killed after
+the original returned at 22 min. Measured this session: opus reviewers running
+cargo gates take 12–22 min.
+
+**F3 — ORCHESTRATOR ERROR (owned, no routing): premature `outcome=dead` DISPATCH
+line** for A2 (returned ok later) — the #330 single-line retry rule misapplied;
+the record's `dispatches[]` inherited the distortion (13 vs 14 lines). The prose
+did not invite the misread; no plugin feedback.
+
+**F4 — WORKING AS DESIGNED: adversarial design review raced the peer-consult
+synthesis** (reviewed the pre-synthesis draft; its findings against the superseded
+PlatformHost section arrived pre-resolved). The Step-4 concurrency tradeoff note
+covers the loop-back case; the peer-synthesis race is an adjacent bounded cost of
+the same accepted overlap. No action.
+
+## Telemetry audit
+
+| field | recorded | session evidence | verdict | impact | routing |
+|---|---|---|---|---|---|
+| workflow/version/issue | implement-feature / 3.29.0 / 165 | cache path + markers | match | — | — |
+| changes | 12 files, +1614/−493, 5 commits | diff --name-only (12 paths) + commit log | match | — | — |
+| tests | 32 added, 339/339 | runner final 339/0; 38 crate tests = 32 authored + 6 relocated | match (relocated ≠ added, judgment noted) | — | — |
+| gates[] | 10/10 · 5/5 · 1/1 · 0/0 · 6/6 | at-close dedup notes per #340 | match | — | — |
+| security_scan | ran, skipped=[iac] | scan output quoted | match | — | — |
+| loop_backs | 1/3 | counters file spec_tighten=1 total=1 | match | — | — |
+| outcome | PR 178, merged, ci passed | merge sha + checks output | match | — | — |
+| usage | session-cumulative | usage_capture semantics | known-limitation | cost trend only | standing (#155 note) |
+| reviewer_kind | inline / hand_rolled_multi | #340 gate-defining precedence | match | — | — |
+| dispatches[] | 13 entries | 14 `^DISPATCH issue=165` lines; A2 over-emission | mismatch (minor) | audit fidelity | orchestrator error owned; rules already prohibit it — nothing filed, reason stated |
+
+Verdict counts: match 8 · mismatch 1 · known-limitation 1.
+
+## Routing
+
+- Filed: 2 plugin defects (F1, F5) — links in summary block; dup-checked first.
+- Telemetry lane: nothing filed — the one mismatch is an owned orchestrator
+  mis-emission the #330 rules already prohibit; dropped with that reason.
+- Friction: ONE mempalace memory (F2), project rawgentic.
+- Not filed (cap): 0.
+
+Inferred (unconfirmed) claims: none — assessor ran the run; evidence first-party.

--- a/docs/reviews/run-feedback-wf2-166-2026-07-11.html
+++ b/docs/reviews/run-feedback-wf2-166-2026-07-11.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 run-feedback — WF2 #166</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+
+:root{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+@media(prefers-color-scheme:dark){:root{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}}
+:root[data-theme=dark]{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}
+:root[data-theme=light]{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+.score{font:11.5px/1.4 ui-monospace,Menlo,Consolas,monospace;font-weight:700;background:var(--code);color:var(--accent);border-radius:5px;padding:1px 6px}
+.sev{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 7px;border-radius:999px;text-transform:uppercase;white-space:nowrap}
+.sev-critical{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.sev-high{color:var(--sev-high);background:var(--sev-high-bg)}
+.sev-medium{color:var(--sev-med);background:var(--sev-med-bg)}
+.sev-low{color:var(--sev-low);background:var(--sev-low-bg)}
+.req{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 6px;border-radius:5px;color:var(--req-c);background:var(--req-c-bg)}
+.req-must-not,.req-should-not{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.req-may{color:var(--ink-3);background:var(--code)}
+
+.tpl-report blockquote{background:var(--code);border-left-color:var(--accent)}
+.tpl-report tbody tr:nth-child(even){background:var(--code)}
+</style>
+</head>
+<body class="tpl-report">
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-10 19:48 MDT</div>
+<h1>WF14 run-feedback — WF2 #166</h1>
+
+</header>
+<main>
+<h1>WF14 run-feedback — WF2 #166 (saystory P2 skeleton, PR #181) · rubric v2</h1>
+<h2>At a glance</h2>
+<p><strong>Verdict: a high-fidelity full-spine run whose gates earned their cost — two independent-convergence Highs and one Critical privacy leak caught pre-CI — with telemetry the only soft spot.</strong></p>
+<ul>
+<li>Fidelity <strong><span class="score">5/5</span></strong> — every mandatory marker present; both skips quote their met condition (Step 6 adversarial-on-plan skip logged &quot;time-critical, design already double-cross-model-reviewed&quot;; Step 12 designArtifact updated).</li>
+<li>Gates <strong><span class="score">5/5</span></strong> — named catches quoted below; nothing ceremonial this run.</li>
+<li>Clarity <strong><span class="score">4/5</span></strong> — no command failed as written; one interpreted area (spec-tighten fold mechanics) resolved from the skill text alone.</li>
+<li>Dispatch <strong><span class="score">5/5</span></strong> — 15/15 dispatches ok first-try, models as routed (record <code>dispatches[]</code> = session <code>^DISPATCH</code> lines exactly).</li>
+<li>Telemetry <strong><span class="score">3/5</span></strong> — valid on first summarize; step-4 <code>reviewer_kind: inline</code> under-describes a dispatched-reviewer + cross-model gate (see audit); usage <code>unavailable</code>.</li>
+<li>Cost <strong><span class="score">3/5</span></strong> — full spine proportional for a new crate + FFI pipeline; heaviest-least-value: the 3 mac-lane fix loops (~30 min total; ENVIRONMENT class — authored-blind Swift, first-ever pipeline).</li>
+</ul>
+<p><strong>Best catch:</strong> 8a T2 pre-CI: an empirically-proven transcript-leak construction in codec error strings (Critical, fixed + sentinel-pinned) — plus Step 11&#x27;s two independent-convergence Highs (Windows-lane cfg break; writer-error laundered to Ok), both fixed pre-CI. <strong>Worst friction:</strong> none plugin-side this run; the mac fix loops were environment/blind-authoring. <strong>Routed:</strong> shares the #167 filing pool (same session) — see that report; nothing #166-specific filed.</p>
+<h2>Evidence ledger (summary)</h2>
+<ul>
+<li>Run-record: <code>docs/measurements/run_records.jsonl</code> tail-2 (schema-valid, summarize rc=0) — <strong>confirmed</strong>. NOTE (orchestrator error, owned): the orchestrator ALSO manually appended the record after <code>summarize</code> had persisted it — duplicate caught and deduped same-session; prose &quot;its stdout IS the completion summary and it appends the record&quot; is accurate, misread under time pressure.</li>
+<li>Markers: all WF2 mandatory <code>— DONE (#166: …)</code> markers present in <code>projects/saystory/claude_docs/session_notes.md</code> (grep-verified this session) — <strong>confirmed</strong>.</li>
+<li>Plugin version loaded: <strong>3.32.2</strong> (cache path); main at assessment: <strong>3.35.0</strong>.</li>
+<li>Loop-backs: spec_tighten ×1 (counters file <code>claude_docs/.wf2-state/166/</code>) = record <code>{used:1}</code> — <strong>confirmed</strong>; the #223 cheap path worked exactly as designed (amend + one incremental verifier, no Step-3 return).</li>
+</ul>
+<h2>Telemetry audit</h2>
+<table>
+<thead><tr><th>field</th><th>recorded</th><th>session evidence</th><th>verdict</th><th>impact</th><th>routing</th></tr></thead>
+<tbody>
+<tr><td>tests</td><td>15 added, 365/365</td><td>ws runner final output 365/0 (+15)</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>gates[]</td><td>4:6/6, 6:0/0, 8a:7/7, 9:0/0, 11:8/8</td><td>markers: 6 design findings, 8a 3+4, 11 &quot;8 unique/8 resolved&quot;</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>loop_backs</td><td>1/3</td><td>counters file spec_tighten=1</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>outcome</td><td>PR #181 merged, ci passed</td><td>merge audit fc→1544568… confirmed</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>security_scan</td><td>PASS, skip iac+sca</td><td>marker &quot;visible skips: iac n/a, sca osv-nothing-to-scan&quot;</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>usage</td><td>capture_status=unavailable</td><td>session resumed post-/clear</td><td>known-limitation</td><td>cost unauditable</td><td>not filed (standing weak spot)</td></tr>
+<tr><td>reviewer_kind (step 4)</td><td>inline</td><td>session shows dispatched opus reviewer + codex adversarial layer</td><td>mismatch (pre-#340-styled value on a 3.32.2 record)</td><td>under-describes gate mechanism</td><td>pooled into the merged-gate telemetry note (not filed — cap; preserved here)</td></tr>
+<tr><td>dispatches[]</td><td>15 entries</td><td>15 <code>^DISPATCH issue=166</code> lines</td><td>match</td><td>—</td><td>—</td></tr>
+</tbody>
+</table>
+<h2>Findings</h2>
+<p>1. <strong>WORKING AS DESIGNED</strong> — spec-tighten cheap path (1 verifier, no full loop-back) saved a full panel pass; exactly the #223 contract. 2. <strong>ENVIRONMENT</strong> — 3 mac-lane fix loops (uniffi <code>Vec&lt;u8&gt;</code>→<code>Data</code> stub typing; <code>NSObject.bind</code> shadowing POSIX <code>bind</code>; then green). First-ever run of the FFI pipeline; each failure an authored-blind Swift detail; the lane did its job. Runbook note now exists in the saystory design note. 3. <strong>ORCHESTRATOR ERROR</strong> (owned) — duplicate record append after summarize persisted; deduped. Prose accurate.</p>
+<h2>Fixed output block</h2>
+<pre><code>WF RUN ASSESSMENT — WF2 @ v3.32.2 (issue #166, PR #181, lane full) · rubric v2
+Fidelity 5/5 · Gates 5/5 · Clarity 4/5 · Dispatch 5/5 · Telemetry 3/5 · Cost 3/5
+Mode: full · Record: docs/measurements/run_records.jsonl (tail-2)
+Best catch: 8a pre-CI transcript-leak Critical (codec error strings) + 2 independent-convergence Highs at Step 11
+Worst friction: none plugin-side (mac fix loops = environment/blind-authoring)
+Telemetry verdicts: match 6 / mismatch 1 / missing-in-record 0 / missing-in-session 0 / unverifiable 0 / known-limitation 1
+Defects filed: rawgentic#393/#394/#395 (pooled with the #167 report) | Telemetry filed: none (cap) | Not filed (cap): 1 | Friction memorized: none | Clean run: yes (plugin-side)
+Report: docs/reviews/run-feedback-wf2-166-2026-07-11.md · Artifact: https://claude.ai/code/artifact/712a42b9-a77e-4fe6-85a7-c68de0adc46c
+Inferred (unconfirmed) claims: none</code></pre>
+
+</main>
+<footer>Last updated: 2026-07-10 19:48 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/run-feedback-wf2-166-2026-07-11.md
+++ b/docs/reviews/run-feedback-wf2-166-2026-07-11.md
@@ -1,0 +1,51 @@
+# WF14 run-feedback — WF2 #166 (saystory P2 skeleton, PR #181) · rubric v2
+
+## At a glance
+**Verdict: a high-fidelity full-spine run whose gates earned their cost — two independent-convergence Highs and one Critical privacy leak caught pre-CI — with telemetry the only soft spot.**
+
+- Fidelity **5/5** — every mandatory marker present; both skips quote their met condition (Step 6 adversarial-on-plan skip logged "time-critical, design already double-cross-model-reviewed"; Step 12 designArtifact updated).
+- Gates **5/5** — named catches quoted below; nothing ceremonial this run.
+- Clarity **4/5** — no command failed as written; one interpreted area (spec-tighten fold mechanics) resolved from the skill text alone.
+- Dispatch **5/5** — 15/15 dispatches ok first-try, models as routed (record `dispatches[]` = session `^DISPATCH` lines exactly).
+- Telemetry **3/5** — valid on first summarize; step-4 `reviewer_kind: inline` under-describes a dispatched-reviewer + cross-model gate (see audit); usage `unavailable`.
+- Cost **3/5** — full spine proportional for a new crate + FFI pipeline; heaviest-least-value: the 3 mac-lane fix loops (~30 min total; ENVIRONMENT class — authored-blind Swift, first-ever pipeline).
+
+**Best catch:** 8a T2 pre-CI: an empirically-proven transcript-leak construction in codec error strings (Critical, fixed + sentinel-pinned) — plus Step 11's two independent-convergence Highs (Windows-lane cfg break; writer-error laundered to Ok), both fixed pre-CI.
+**Worst friction:** none plugin-side this run; the mac fix loops were environment/blind-authoring.
+**Routed:** shares the #167 filing pool (same session) — see that report; nothing #166-specific filed.
+
+## Evidence ledger (summary)
+- Run-record: `docs/measurements/run_records.jsonl` tail-2 (schema-valid, summarize rc=0) — **confirmed**. NOTE (orchestrator error, owned): the orchestrator ALSO manually appended the record after `summarize` had persisted it — duplicate caught and deduped same-session; prose "its stdout IS the completion summary and it appends the record" is accurate, misread under time pressure.
+- Markers: all WF2 mandatory `— DONE (#166: …)` markers present in `projects/saystory/claude_docs/session_notes.md` (grep-verified this session) — **confirmed**.
+- Plugin version loaded: **3.32.2** (cache path); main at assessment: **3.35.0**.
+- Loop-backs: spec_tighten ×1 (counters file `claude_docs/.wf2-state/166/`) = record `{used:1}` — **confirmed**; the #223 cheap path worked exactly as designed (amend + one incremental verifier, no Step-3 return).
+
+## Telemetry audit
+| field | recorded | session evidence | verdict | impact | routing |
+|---|---|---|---|---|---|
+| tests | 15 added, 365/365 | ws runner final output 365/0 (+15) | match | — | — |
+| gates[] | 4:6/6, 6:0/0, 8a:7/7, 9:0/0, 11:8/8 | markers: 6 design findings, 8a 3+4, 11 "8 unique/8 resolved" | match | — | — |
+| loop_backs | 1/3 | counters file spec_tighten=1 | match | — | — |
+| outcome | PR #181 merged, ci passed | merge audit fc→1544568… confirmed | match | — | — |
+| security_scan | PASS, skip iac+sca | marker "visible skips: iac n/a, sca osv-nothing-to-scan" | match | — | — |
+| usage | capture_status=unavailable | session resumed post-/clear | known-limitation | cost unauditable | not filed (standing weak spot) |
+| reviewer_kind (step 4) | inline | session shows dispatched opus reviewer + codex adversarial layer | mismatch (pre-#340-styled value on a 3.32.2 record) | under-describes gate mechanism | pooled into the merged-gate telemetry note (not filed — cap; preserved here) |
+| dispatches[] | 15 entries | 15 `^DISPATCH issue=166` lines | match | — | — |
+
+## Findings
+1. **WORKING AS DESIGNED** — spec-tighten cheap path (1 verifier, no full loop-back) saved a full panel pass; exactly the #223 contract.
+2. **ENVIRONMENT** — 3 mac-lane fix loops (uniffi `Vec<u8>`→`Data` stub typing; `NSObject.bind` shadowing POSIX `bind`; then green). First-ever run of the FFI pipeline; each failure an authored-blind Swift detail; the lane did its job. Runbook note now exists in the saystory design note.
+3. **ORCHESTRATOR ERROR** (owned) — duplicate record append after summarize persisted; deduped. Prose accurate.
+
+## Fixed output block
+```
+WF RUN ASSESSMENT — WF2 @ v3.32.2 (issue #166, PR #181, lane full) · rubric v2
+Fidelity 5/5 · Gates 5/5 · Clarity 4/5 · Dispatch 5/5 · Telemetry 3/5 · Cost 3/5
+Mode: full · Record: docs/measurements/run_records.jsonl (tail-2)
+Best catch: 8a pre-CI transcript-leak Critical (codec error strings) + 2 independent-convergence Highs at Step 11
+Worst friction: none plugin-side (mac fix loops = environment/blind-authoring)
+Telemetry verdicts: match 6 / mismatch 1 / missing-in-record 0 / missing-in-session 0 / unverifiable 0 / known-limitation 1
+Defects filed: rawgentic#393/#394/#395 (pooled with the #167 report) | Telemetry filed: none (cap) | Not filed (cap): 1 | Friction memorized: none | Clean run: yes (plugin-side)
+Report: docs/reviews/run-feedback-wf2-166-2026-07-11.md · Artifact: https://claude.ai/code/artifact/712a42b9-a77e-4fe6-85a7-c68de0adc46c
+Inferred (unconfirmed) claims: none
+```

--- a/docs/reviews/run-feedback-wf2-167-2026-07-10.html
+++ b/docs/reviews/run-feedback-wf2-167-2026-07-10.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 run-feedback — WF2 #167</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+
+:root{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+@media(prefers-color-scheme:dark){:root{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}}
+:root[data-theme=dark]{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}
+:root[data-theme=light]{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+.score{font:11.5px/1.4 ui-monospace,Menlo,Consolas,monospace;font-weight:700;background:var(--code);color:var(--accent);border-radius:5px;padding:1px 6px}
+.sev{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 7px;border-radius:999px;text-transform:uppercase;white-space:nowrap}
+.sev-critical{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.sev-high{color:var(--sev-high);background:var(--sev-high-bg)}
+.sev-medium{color:var(--sev-med);background:var(--sev-med-bg)}
+.sev-low{color:var(--sev-low);background:var(--sev-low-bg)}
+.req{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 6px;border-radius:5px;color:var(--req-c);background:var(--req-c-bg)}
+.req-must-not,.req-should-not{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.req-may{color:var(--ink-3);background:var(--code)}
+
+.tpl-report blockquote{background:var(--code);border-left-color:var(--accent)}
+.tpl-report tbody tr:nth-child(even){background:var(--code)}
+</style>
+</head>
+<body class="tpl-report">
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-10 13:02 MDT</div>
+<h1>WF14 run-feedback — WF2 #167</h1>
+
+</header>
+<main>
+<h1>WF14 Run-Feedback — WF2 #167 (saystory) — 2026-07-10</h1>
+<p>Rubric: v1 (2026-07-09, #337). Mode: <strong>degraded (record: absent — run in-flight, Step 16 not reached; NOT store-lag)</strong>. Scores are <strong>provisional</strong> — the run is live at Step 4 pass 2; only reached obligations (Steps 1–4) are assessed. Plugin version loaded by the run: <strong>3.32.2</strong> (cache path quoted in transcript) = current main (3.32.2, commit <code>99ccb91</code>) — defect verification is current, not stale-cache noise.</p>
+<p>Assessment trigger: owner-reported display failure, RCA&#x27;d this session. Deep-reasoning pass: cross-model consult, Codex <strong>gpt-5.6-sol</strong> (owner directive), report <code>docs/reviews/peer-wf14-167-consult-problem-unknown-date.md</code> — its corrections (fidelity 3→2, F1/F4 reclassified, telemetry unscored) are adopted below.</p>
+<h2>At a glance</h2>
+<p><strong>A high-value design gate did its job (11 findings, 5 High, REV2 forced) — and then its circuit breaker asked the user to resolve findings the user could never see, because the presentation lived only in invisible extended thinking under output-compression plugins.</strong></p>
+<ul>
+<li>Fidelity <strong><span class="score">2/5</span> (provisional)</strong> — markers complete for Steps 1–4, but the breaker&#x27;s</li>
+</ul>
+<p>  mandatory &quot;Present ALL problematic findings to the user&quot; was materially skipped   (user answered blind).</p>
+<ul>
+<li>Gates <strong><span class="score">4/5</span></strong> — real catches: 11 design findings pre-implementation, design loop-back</li>
+</ul>
+<p>  consumed, REV2 produced; pass-2 disposition still open (in-flight).</p>
+<ul>
+<li>Clarity <strong><span class="score">3/5</span></strong> — executable, but SKILL.md:262 &quot;Present ALL problematic findings to</li>
+</ul>
+<p>  the user&quot; is under-operationalized: no channel, no ordering constraint, no precedence   over response-style layers.</p>
+<ul>
+<li>Dispatch <strong><span class="score">3/5</span></strong> — opus quality-bar reviewer non-vacuous first try; Codex adversarial</li>
+</ul>
+<p>  launch died on an invalid <code>--out</code> flag (orchestrator misuse), visibly relaunched.</p>
+<ul>
+<li>Telemetry <strong>unscored</strong> — no record obligation has matured (Step 16 unreached);</li>
+</ul>
+<p>  scoring would manufacture a failure for an inapplicable dimension.</p>
+<ul>
+<li>Cost <strong><span class="score">3/5</span> (cap: usage session-level only)</strong> — heaviest-least-value: the</li>
+</ul>
+<p>  dead-on-arrival Codex launch; 103.7k-token opus design review proportionate for a   5-High design but unproven at the margin.</p>
+<p><strong>Best catch:</strong> Step 4 pass 1 — 11 design findings (5 High) against the #167 design note before any implementation; loop-back consumed, REV2 written. <strong>Worst friction:</strong> <code>&lt;ambiguity-circuit-breaker&gt;</code> (SKILL.md v3.32.2:262) — &quot;Present ALL problematic findings to the user&quot; satisfied, in practice, by invisible thinking + terse AskUserQuestion option labels. <strong>Routed:</strong> 2 defect/hardening issues filed (see Routing); no plugin-friction finding survived consult (F4 reclassified orchestrator-error); 1 environment-hazard memory saved.</p>
+<h2>Evidence ledger</h2>
+<table>
+<thead><tr><th>#</th><th>Claim</th><th>Tag</th><th>Evidence</th></tr></thead>
+<tbody>
+<tr><td>E1</td><td>Run = WF2 #167 saystory, plugin 3.32.2</td><td>confirmed</td><td>transcript <code>e43f6341</code> skill base path <code>cache/rawgentic/rawgentic/3.32.2/skills/implement-feature</code>; session_notes.md L883 <code>## WF2 #167 run (2026-07-10, m1-m5 overnight driver, M2 child)</code></td></tr>
+<tr><td>E2</td><td>Step markers 1, 1b(deferred), 2, 3, 4×2 present</td><td>confirmed</td><td>session_notes.md L884 <code>### WF2 Step 1: Receive Issue — DONE (#167: …)</code>, L885 (1b deferred: run-level /goal active), L895 (Step 2), L901 (Step 3), L911 + L920 (Step 4 adversarial, pass 1 + pass 2)</td></tr>
+<tr><td>E3</td><td>Circuit breaker fired; 11 findings (5 High); user asked to apply resolutions</td><td>confirmed</td><td>transcript L463 AskUserQuestion input: &quot;Circuit breaker: 11 design findings on #167 (5 High). Apply all proposed resolutions above…&quot;</td></tr>
+<tr><td>E4</td><td>Findings NEVER emitted as visible text</td><td>confirmed</td><td>transcript L460→463: tool_result → thinking ×2 → AskUserQuestion, zero text blocks; turn output 3702 tokens (~3.3k thinking); all 33 session text blocks are one-liners (enumerated)</td></tr>
+<tr><td>E5</td><td>Session ran under caveman + ponytail compression mandates</td><td>confirmed</td><td>SessionStart hook outputs in transcript (&quot;CAVEMAN MODE ACTIVE&quot;, &quot;PONYTAIL MODE ACTIVE&quot;)</td></tr>
+<tr><td>E6</td><td>Run-record for #167 absent</td><td>confirmed + expected</td><td>saystory store latest = #166; run in-flight at Step 4 pass 2 (resumed-session tail: &quot;Resuming WF2 #167 at Step 4 pass-2&quot;)</td></tr>
+<tr><td>E7</td><td>Hook-timeout non-enforcement (cross-session)</td><td>confirmed</td><td>session <code>6d866952</code> entry 2683-2684: mempalace <code>user-prompt-submit</code> durationMs 11848 vs timeoutMs 5000; rawgentic <code>wal-context</code> durationMs 11849 vs timeoutMs 3000; both <code>timedOut: false</code>, cancelled only by user interrupt; Claude Code 2.1.206</td></tr>
+<tr><td>E8</td><td>Hook stall transient</td><td>confirmed (non-repro)</td><td>live re-test ×3 each: mempalace 34-35ms, wal-context 40-42ms, healthz 30ms</td></tr>
+<tr><td>E9</td><td>Stall cause = host load spike</td><td>inferred</td><td>would confirm: host metrics at 16:38; both hooks identical duration suggests shared cause; /reload-plugins ran 3 min prior</td></tr>
+<tr><td>E10</td><td>Codex review dead launch (<code>--out</code> on <code>review</code>)</td><td>confirmed</td><td>transcript L454 text + L456 tool_result usage error; relaunched successfully L459-460</td></tr>
+</tbody>
+</table>
+<h2>Findings and classification</h2>
+<p><strong>F1 — Circuit-breaker findings presented invisibly.</strong> Class: <strong>ORCHESTRATOR ERROR</strong> (consult-corrected: &quot;to the user&quot; already excludes invisible reasoning — the channel ambiguity does not excuse the conduct), <strong>with prose-invited component</strong> → plugin feedback per rubric: the inviting sentence is SKILL.md:262 &quot;Present ALL problematic findings to the user&quot; — no required visible artifact, no ordering constraint, no precedence over active response-style instructions. Filed as hardening (issue 1). Consult risk notes adopted: a prose-only fix may fail under future compression layers — the issue asks for a machine-checkable precondition where feasible; a linked report alone can still leave the user blind unless severity/counts are visibly summarized.</p>
+<p><strong>F2 — Whole-run narration compressed to one-liners.</strong> Class: <strong>ENVIRONMENT</strong> (third-party caveman/ponytail plugins). Not independently filed; folded into issue 1&#x27;s precedence clause. Runbook gap noted → memory (rubric: environment findings still get a runbook note when the plugin lacks one).</p>
+<p><strong>F3 — Hook timeout non-enforcement + wal-context lacking internal deadline.</strong> Split: harness non-enforcement (E7) = <strong>ENVIRONMENT</strong> (Claude Code, not fileable here); wal-context having no self-imposed deadline while the harness&#x27;s is proven unreliable = <strong>resilience enhancement</strong> (consult: &quot;defense-in-depth, not a demonstrated plugin defect&quot; — no rawgentic-side hang reproduced, E8). Filed as issue 2 with consult&#x27;s sharpened shape: internal monotonic deadline, subprocess-tree termination, safe degraded result, timeout telemetry.</p>
+<p><strong>F4 — Dead Codex launch (<code>--out</code> misuse).</strong> Class: <strong>ORCHESTRATOR ERROR</strong> (consult-corrected from friction: one mistaken invocation does not demonstrate the sibling CLIs are systematically misleading). Watch-flag: reclassify to friction if the misuse recurs across runs.</p>
+<h2>Telemetry audit (degraded)</h2>
+<p>Record absent and <strong>not yet due</strong> (Step 16 unreached; distinct from store-lag-known and from a genuinely missing record of a completed run). Per degraded-mode rules, no telemetry-accuracy claims are made. Claims intentionally NOT made: record correctness, cost accuracy, dispatch completeness, store-append behavior, gate-count honesty, reviewer_kind fidelity. All audited fields: <code>unverifiable</code> (not-yet-due). No telemetry-lane issues.</p>
+<h2>Routing</h2>
+<p>1. Issue 1 (hardening, <code>enhancement,framework,wf-feedback</code>): make ambiguity-gate    findings visibly inspectable before resolution — see filed issue for full shape. 2. Issue 2 (resilience, <code>enhancement,framework,wf-feedback</code>): bound wal-context    execution with an internal monotonic deadline independent of harness enforcement. 3. Memory (environment hazard runbook note): output-compression plugins + invisible    thinking can swallow gate presentations; harness hook timeouts unreliable on    2.1.206. 4. Not filed: F2 (environment, folded), F4 (orchestrator error, watch-flag). Cap not    reached (2/3).</p>
+<p>Cross-repo note (outside WF14 scope, owner-approved separately): the mempalace <code>user-prompt-submit</code> hook&#x27;s internal budget (healthz 2s + search max-time 8s = 10s worst case) exceeds its declared 5s hook timeout — routed to the rawgentic-memorypalace repo directly.</p>
+
+</main>
+<footer>Last updated: 2026-07-10 13:02 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/run-feedback-wf2-167-2026-07-10.md
+++ b/docs/reviews/run-feedback-wf2-167-2026-07-10.md
@@ -1,0 +1,113 @@
+# WF14 Run-Feedback — WF2 #167 (saystory) — 2026-07-10
+
+Rubric: v1 (2026-07-09, #337). Mode: **degraded (record: absent — run in-flight, Step 16
+not reached; NOT store-lag)**. Scores are **provisional** — the run is live at Step 4
+pass 2; only reached obligations (Steps 1–4) are assessed. Plugin version loaded by the
+run: **3.32.2** (cache path quoted in transcript) = current main (3.32.2, commit
+`99ccb91`) — defect verification is current, not stale-cache noise.
+
+Assessment trigger: owner-reported display failure, RCA'd this session. Deep-reasoning
+pass: cross-model consult, Codex **gpt-5.6-sol** (owner directive), report
+`docs/reviews/peer-wf14-167-consult-problem-unknown-date.md` — its corrections
+(fidelity 3→2, F1/F4 reclassified, telemetry unscored) are adopted below.
+
+## At a glance
+
+**A high-value design gate did its job (11 findings, 5 High, REV2 forced) — and then its
+circuit breaker asked the user to resolve findings the user could never see, because the
+presentation lived only in invisible extended thinking under output-compression plugins.**
+
+- Fidelity **2/5 (provisional)** — markers complete for Steps 1–4, but the breaker's
+  mandatory "Present ALL problematic findings to the user" was materially skipped
+  (user answered blind).
+- Gates **4/5** — real catches: 11 design findings pre-implementation, design loop-back
+  consumed, REV2 produced; pass-2 disposition still open (in-flight).
+- Clarity **3/5** — executable, but SKILL.md:262 "Present ALL problematic findings to
+  the user" is under-operationalized: no channel, no ordering constraint, no precedence
+  over response-style layers.
+- Dispatch **3/5** — opus quality-bar reviewer non-vacuous first try; Codex adversarial
+  launch died on an invalid `--out` flag (orchestrator misuse), visibly relaunched.
+- Telemetry **unscored** — no record obligation has matured (Step 16 unreached);
+  scoring would manufacture a failure for an inapplicable dimension.
+- Cost **3/5 (cap: usage session-level only)** — heaviest-least-value: the
+  dead-on-arrival Codex launch; 103.7k-token opus design review proportionate for a
+  5-High design but unproven at the margin.
+
+**Best catch:** Step 4 pass 1 — 11 design findings (5 High) against the #167 design note
+before any implementation; loop-back consumed, REV2 written.
+**Worst friction:** `<ambiguity-circuit-breaker>` (SKILL.md v3.32.2:262) — "Present ALL
+problematic findings to the user" satisfied, in practice, by invisible thinking + terse
+AskUserQuestion option labels.
+**Routed:** 2 defect/hardening issues filed (see Routing); no plugin-friction finding
+survived consult (F4 reclassified orchestrator-error); 1 environment-hazard memory saved.
+
+## Evidence ledger
+
+| # | Claim | Tag | Evidence |
+|---|-------|-----|----------|
+| E1 | Run = WF2 #167 saystory, plugin 3.32.2 | confirmed | transcript `e43f6341` skill base path `cache/rawgentic/rawgentic/3.32.2/skills/implement-feature`; session_notes.md L883 `## WF2 #167 run (2026-07-10, m1-m5 overnight driver, M2 child)` |
+| E2 | Step markers 1, 1b(deferred), 2, 3, 4×2 present | confirmed | session_notes.md L884 `### WF2 Step 1: Receive Issue — DONE (#167: …)`, L885 (1b deferred: run-level /goal active), L895 (Step 2), L901 (Step 3), L911 + L920 (Step 4 adversarial, pass 1 + pass 2) |
+| E3 | Circuit breaker fired; 11 findings (5 High); user asked to apply resolutions | confirmed | transcript L463 AskUserQuestion input: "Circuit breaker: 11 design findings on #167 (5 High). Apply all proposed resolutions above…" |
+| E4 | Findings NEVER emitted as visible text | confirmed | transcript L460→463: tool_result → thinking ×2 → AskUserQuestion, zero text blocks; turn output 3702 tokens (~3.3k thinking); all 33 session text blocks are one-liners (enumerated) |
+| E5 | Session ran under caveman + ponytail compression mandates | confirmed | SessionStart hook outputs in transcript ("CAVEMAN MODE ACTIVE", "PONYTAIL MODE ACTIVE") |
+| E6 | Run-record for #167 absent | confirmed + expected | saystory store latest = #166; run in-flight at Step 4 pass 2 (resumed-session tail: "Resuming WF2 #167 at Step 4 pass-2") |
+| E7 | Hook-timeout non-enforcement (cross-session) | confirmed | session `6d866952` entry 2683-2684: mempalace `user-prompt-submit` durationMs 11848 vs timeoutMs 5000; rawgentic `wal-context` durationMs 11849 vs timeoutMs 3000; both `timedOut: false`, cancelled only by user interrupt; Claude Code 2.1.206 |
+| E8 | Hook stall transient | confirmed (non-repro) | live re-test ×3 each: mempalace 34-35ms, wal-context 40-42ms, healthz 30ms |
+| E9 | Stall cause = host load spike | inferred | would confirm: host metrics at 16:38; both hooks identical duration suggests shared cause; /reload-plugins ran 3 min prior |
+| E10 | Codex review dead launch (`--out` on `review`) | confirmed | transcript L454 text + L456 tool_result usage error; relaunched successfully L459-460 |
+
+## Findings and classification
+
+**F1 — Circuit-breaker findings presented invisibly.** Class: **ORCHESTRATOR ERROR**
+(consult-corrected: "to the user" already excludes invisible reasoning — the channel
+ambiguity does not excuse the conduct), **with prose-invited component** → plugin
+feedback per rubric: the inviting sentence is SKILL.md:262 "Present ALL problematic
+findings to the user" — no required visible artifact, no ordering constraint, no
+precedence over active response-style instructions. Filed as hardening (issue 1).
+Consult risk notes adopted: a prose-only fix may fail under future compression layers —
+the issue asks for a machine-checkable precondition where feasible; a linked report
+alone can still leave the user blind unless severity/counts are visibly summarized.
+
+**F2 — Whole-run narration compressed to one-liners.** Class: **ENVIRONMENT**
+(third-party caveman/ponytail plugins). Not independently filed; folded into issue 1's
+precedence clause. Runbook gap noted → memory (rubric: environment findings still get a
+runbook note when the plugin lacks one).
+
+**F3 — Hook timeout non-enforcement + wal-context lacking internal deadline.** Split:
+harness non-enforcement (E7) = **ENVIRONMENT** (Claude Code, not fileable here);
+wal-context having no self-imposed deadline while the harness's is proven unreliable =
+**resilience enhancement** (consult: "defense-in-depth, not a demonstrated plugin
+defect" — no rawgentic-side hang reproduced, E8). Filed as issue 2 with consult's
+sharpened shape: internal monotonic deadline, subprocess-tree termination, safe degraded
+result, timeout telemetry.
+
+**F4 — Dead Codex launch (`--out` misuse).** Class: **ORCHESTRATOR ERROR**
+(consult-corrected from friction: one mistaken invocation does not demonstrate the
+sibling CLIs are systematically misleading). Watch-flag: reclassify to friction if the
+misuse recurs across runs.
+
+## Telemetry audit (degraded)
+
+Record absent and **not yet due** (Step 16 unreached; distinct from store-lag-known and
+from a genuinely missing record of a completed run). Per degraded-mode rules, no
+telemetry-accuracy claims are made. Claims intentionally NOT made: record correctness,
+cost accuracy, dispatch completeness, store-append behavior, gate-count honesty,
+reviewer_kind fidelity. All audited fields: `unverifiable` (not-yet-due). No
+telemetry-lane issues.
+
+## Routing
+
+1. Issue 1 (hardening, `enhancement,framework,wf-feedback`): make ambiguity-gate
+   findings visibly inspectable before resolution — see filed issue for full shape.
+2. Issue 2 (resilience, `enhancement,framework,wf-feedback`): bound wal-context
+   execution with an internal monotonic deadline independent of harness enforcement.
+3. Memory (environment hazard runbook note): output-compression plugins + invisible
+   thinking can swallow gate presentations; harness hook timeouts unreliable on
+   2.1.206.
+4. Not filed: F2 (environment, folded), F4 (orchestrator error, watch-flag). Cap not
+   reached (2/3).
+
+Cross-repo note (outside WF14 scope, owner-approved separately): the mempalace
+`user-prompt-submit` hook's internal budget (healthz 2s + search max-time 8s = 10s
+worst case) exceeds its declared 5s hook timeout — routed to the
+rawgentic-memorypalace repo directly.

--- a/docs/reviews/run-feedback-wf2-167-2026-07-11.html
+++ b/docs/reviews/run-feedback-wf2-167-2026-07-11.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 run-feedback — WF2 #167</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+
+:root{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+@media(prefers-color-scheme:dark){:root{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}}
+:root[data-theme=dark]{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}
+:root[data-theme=light]{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+.score{font:11.5px/1.4 ui-monospace,Menlo,Consolas,monospace;font-weight:700;background:var(--code);color:var(--accent);border-radius:5px;padding:1px 6px}
+.sev{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 7px;border-radius:999px;text-transform:uppercase;white-space:nowrap}
+.sev-critical{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.sev-high{color:var(--sev-high);background:var(--sev-high-bg)}
+.sev-medium{color:var(--sev-med);background:var(--sev-med-bg)}
+.sev-low{color:var(--sev-low);background:var(--sev-low-bg)}
+.req{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 6px;border-radius:5px;color:var(--req-c);background:var(--req-c-bg)}
+.req-must-not,.req-should-not{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.req-may{color:var(--ink-3);background:var(--code)}
+
+.tpl-report blockquote{background:var(--code);border-left-color:var(--accent)}
+.tpl-report tbody tr:nth-child(even){background:var(--code)}
+</style>
+</head>
+<body class="tpl-report">
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-10 19:48 MDT</div>
+<h1>WF14 run-feedback — WF2 #167</h1>
+
+</header>
+<main>
+<h1>WF14 run-feedback — WF2 #167 (saystory P3 adapter, PRs #182+#183) · rubric v2</h1>
+<h2>At a glance</h2>
+<p><strong>Verdict: the machinery handled its hardest run yet — first loop-back cap hit, first decompose-band split, owner pause/resume mid-run — and every gate caught something real, but adversarial-pass re-litigation and four 40–60-min CI fix loops (two preventable) made this the most expensive WF2 run on record.</strong></p>
+<ul>
+<li>Fidelity <strong><span class="score">4/5</span></strong> — all mandatory markers across BOTH PRs; owner-pause handled via the documented blocker protocol; one deduction: the plan&#x27;s Task-1 file list under-enumerated (adapters.rs edit was in-scope but unlisted; reviewer-flagged).</li>
+<li>Gates <strong><span class="score">4/5</span></strong> — real catches at every tier (below); deduction: design passes 2–3 spent budget re-litigating owner-settled dispositions.</li>
+<li>Clarity <strong><span class="score">3/5</span></strong> — executable throughout, but ≥2 areas needed interpretation (quoted): the #340 merged-gate <code>reviewer_kind</code> rule (&quot;the gate-DEFINING mechanism&quot;) applied to a rubric-self-review + adversarial gate; and Step 16&#x27;s &quot;it appends the record&quot; vs the orchestrator&#x27;s manual-append instinct.</li>
+<li>Dispatch <strong><span class="score">3/5</span></strong> — 32 dispatches; 8a-T4&#x27;s BOTH reviewers died vacuous on the account session limit and were re-dispatched only after owner /login; substitution visible + logged (<code>outcome=dead</code> ×2, <code>outcome=retried</code>), matching anchor 3.</li>
+<li>Telemetry <strong><span class="score">3/5</span></strong> — <code>dispatches[]</code> 32=32 exact; deductions: <code>changes</code> was persisted from estimates then corrected post-persist (honest but out-of-band), usage <code>unavailable</code>.</li>
+<li>Cost <strong><span class="score">2/5</span></strong> — 33 design findings over 3 full adversarial passes (pass-3 adversarial re-raised a decline it was explicitly told was settled); 4 mac-lane CI loops ≈ 3h wall, of which loops 2–3 were preventable by pre-push whole-surface sweeps (owner said so mid-run; the corrected process then proved loop-4&#x27;s fix locally 30/30 before green). Heaviest-least-value step: adversarial design pass 3.</li>
+</ul>
+<p><strong>Best catch:</strong> design pass-1 self-review F3 — the design&#x27;s <code>NSSound(named:)</code> would have silently played nothing; the shipping <code>SoundFeedback</code> path was reused instead (file:line-cited catch). Runner-up: PR-B adversarial&#x27;s fail-closed paste-target pid (garbled id would have pasted into the wrong app). <strong>Worst friction:</strong> adversarial passes receive no prior-pass disposition ledger — re-litigation consumed loop-back budget twice (also observed in the #69 run: &quot;adversarial diff review lacks prior-gate dispositions → re-litigated the resolved coarse-id finding&quot;, session notes, 2 runs total). <strong>Routed:</strong> 3 issues filed (see routing), 1 friction memory, worktree evidence commented on #371.</p>
+<h2>Evidence ledger (summary)</h2>
+<ul>
+<li>Run-record: jsonl tail (schema-valid, summarize rc=0; <code>changes</code> corrected post-persist to real diff numbers — flagged in audit) — <strong>confirmed</strong>.</li>
+<li>Markers: full spine ×2 PRs quoted in <code>projects/saystory/claude_docs/session_notes.md</code>; loop-back counters file <code>claude_docs/.wf2-state/167/loopback_counters.json</code> = <code>{design:2, spec_tighten:1, total:3}</code> — <strong>confirmed</strong>.</li>
+<li>Owner decisions (breaker r1/r2, escalation, 2-PR split, pause, process correction) — <strong>confirmed</strong> (session notes, D-numbered decision log in the run handoff).</li>
+<li>Plugin version loaded: <strong>3.32.2</strong>; main at assessment: <strong>3.35.0</strong>. Defects below verified conceptually against 3.35.0 skill text (no disposition-ledger mechanism; no reviewer-liveness protocol; no authored-blind pre-push checklist).</li>
+<li>Worktree isolation: 4/4 implementer dispatches ran isolated and merged clean — <strong>confirmed</strong>, CONTRADICTS open #371&#x27;s &quot;every implementer dispatch dies at spawn in workspace layout&quot;.</li>
+</ul>
+<h2>Telemetry audit</h2>
+<table>
+<thead><tr><th>field</th><th>recorded</th><th>session evidence</th><th>verdict</th><th>impact</th><th>routing</th></tr></thead>
+<tbody>
+<tr><td>tests</td><td>49 added, 389/389</td><td>ws final output 389/0 (baseline 365/0)</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>gates[]</td><td>4:33/33, 8a:6/6, 11:17/17</td><td>markers: 11+13+9 design; 8a 0+0+1M4L+5L→6 unique above-band… counted per #340 unique-across-passes</td><td>match (within #340 counting)</td><td>—</td><td>—</td></tr>
+<tr><td>loop_backs</td><td>3/3</td><td>counters file total=3</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>changes</td><td>63 files +4274/−646, 13 commits</td><td>initially persisted as ESTIMATES (68/5800/600), corrected post-persist from real <code>git diff --shortstat</code></td><td>mismatch (transient; self-corrected)</td><td>record briefly wrong on disk</td><td>pooled into telemetry note (not filed — cap)</td></tr>
+<tr><td>outcome</td><td>PR #183 merged ci passed</td><td>merge → 2ce0078, 4/4 lanes</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>usage</td><td>unavailable</td><td>session re-logged mid-run</td><td>known-limitation</td><td>—</td><td>standing weak spot</td></tr>
+<tr><td>dispatches[]</td><td>32 (incl 2 dead + 1 retried)</td><td>32 <code>^DISPATCH issue=167</code> lines incl the dead pair</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>reviewer_kind (4/8a/11)</td><td>hand_rolled_multi</td><td>multi-reviewer + adversarial layers</td><td>match</td><td>—</td><td>—</td></tr>
+</tbody>
+</table>
+<h2>Findings</h2>
+<p>1. <strong>PLUGIN DEFECT — no disposition ledger across adversarial passes.</strong> Pass-2 adversarial re-attacked the owner-settled unbounded-FIFO decision; pass-3 re-raised the settled entitlements-gate decline despite an explicit settled-scope instruction in its brief. Cost: breaker round-trips + loop-back budget. Recurrence: 2 runs (this + #69&#x27;s memorized identical class). FILED. 2. <strong>PLUGIN DEFECT — no reviewer-liveness/vacuous-result protocol.</strong> Both 8a-T4 reviewers died on the account session limit; detection + re-dispatch relied on orchestrator memory of the vacuous-result pattern, not skill guidance. Recurrence: &quot;hit your session limit&quot; appears in 36 distinct sessions (index query, literal). FILED. 3. <strong>PLUGIN FRICTION — deferral contract lacks an authored-blind pre-push proxy checklist.</strong> CI loops 2 (uniffi <code>*Impl</code> decl collision — a bindings SIGNATURE diff had been done but not a DECL-NAME sweep) and 3 (5 test files missing imports — sources swept exhaustively, tests sampled) were both catchable offline; loop 4&#x27;s fix was then proven locally (rust-harness 30/30) under the corrected process. Triggered checklist (no-target-toolchain / generated-interfaces / deferred-lane) per consult risk note — never a blanket mandate. FILED (feat). 4. <strong>ORCHESTRATOR ERROR</strong> (owned) — estimates persisted into <code>changes</code>; duplicate-append instinct on #166; bindings check stopped at signatures. The prose invited none of these. 5. <strong>ENVIRONMENT</strong> — account session limit killed the T4 reviewers; owner /login restored. 6. <strong>WORKING AS DESIGNED</strong> — loop-back cap escalation to owner; decompose-band 2-PR split; preemptable-shutdown design catching the parked-callback class before it shipped; worktree isolation (evidence against #371).</p>
+<h2>Routing</h2>
+<ul>
+<li>Filed (cap 3, shared pool): rawgentic#393 (disposition ledger, defect), rawgentic#394 (reviewer liveness/vacuous protocol, defect), rawgentic#395 (authored-blind pre-push checklist, friction→feat).</li>
+<li>Telemetry improvements not filed (cap): merged-gate reviewer_kind guidance example; changes-from-estimates guard (summarize could recompute <code>changes</code> from <code>git diff</code> itself — noted for #333&#x27;s queue).</li>
+<li>Friction memory: SAVED + verified — drawer_rawgentic_process-conventions_afffd44a377ef2ec8ccd9efd.</li>
+<li>#371: contradicting evidence commented (issuecomment-4941285577), not refiled.</li>
+</ul>
+<h2>Fixed output block</h2>
+<pre><code>WF RUN ASSESSMENT — WF2 @ v3.32.2 (issue #167, PRs #182+#183, lane full ×2) · rubric v2
+Fidelity 4/5 · Gates 4/5 · Clarity 3/5 · Dispatch 3/5 · Telemetry 3/5 · Cost 2/5
+Mode: full · Record: docs/measurements/run_records.jsonl (tail)
+Best catch: design F3 — NSSound(named:) would have silently played nothing; shipping SoundFeedback reused
+Worst friction: adversarial passes carry no prior-pass disposition ledger (re-litigation ×2 runs)
+Telemetry verdicts: match 6 / mismatch 1 / missing-in-record 0 / missing-in-session 0 / unverifiable 0 / known-limitation 1
+Defects filed: rawgentic#393 (disposition ledger) #394 (reviewer liveness) #395 (authored-blind checklist) | Telemetry filed: none (cap) | Not filed (cap): 2 | Friction memorized: drawer_rawgentic_process-conventions_afffd44a | Clean run: no
+Report: docs/reviews/run-feedback-wf2-167-2026-07-11.md · Artifact: https://claude.ai/code/artifact/fdb2ab72-0bad-464c-8bc0-c5e063c87156
+Inferred (unconfirmed) claims: defect presence on main v3.35.0 verified against skill text, not a live 3.35.0 run</code></pre>
+
+</main>
+<footer>Last updated: 2026-07-10 19:48 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/run-feedback-wf2-167-2026-07-11.md
+++ b/docs/reviews/run-feedback-wf2-167-2026-07-11.md
@@ -1,0 +1,61 @@
+# WF14 run-feedback — WF2 #167 (saystory P3 adapter, PRs #182+#183) · rubric v2
+
+## At a glance
+**Verdict: the machinery handled its hardest run yet — first loop-back cap hit, first decompose-band split, owner pause/resume mid-run — and every gate caught something real, but adversarial-pass re-litigation and four 40–60-min CI fix loops (two preventable) made this the most expensive WF2 run on record.**
+
+- Fidelity **4/5** — all mandatory markers across BOTH PRs; owner-pause handled via the documented blocker protocol; one deduction: the plan's Task-1 file list under-enumerated (adapters.rs edit was in-scope but unlisted; reviewer-flagged).
+- Gates **4/5** — real catches at every tier (below); deduction: design passes 2–3 spent budget re-litigating owner-settled dispositions.
+- Clarity **3/5** — executable throughout, but ≥2 areas needed interpretation (quoted): the #340 merged-gate `reviewer_kind` rule ("the gate-DEFINING mechanism") applied to a rubric-self-review + adversarial gate; and Step 16's "it appends the record" vs the orchestrator's manual-append instinct.
+- Dispatch **3/5** — 32 dispatches; 8a-T4's BOTH reviewers died vacuous on the account session limit and were re-dispatched only after owner /login; substitution visible + logged (`outcome=dead` ×2, `outcome=retried`), matching anchor 3.
+- Telemetry **3/5** — `dispatches[]` 32=32 exact; deductions: `changes` was persisted from estimates then corrected post-persist (honest but out-of-band), usage `unavailable`.
+- Cost **2/5** — 33 design findings over 3 full adversarial passes (pass-3 adversarial re-raised a decline it was explicitly told was settled); 4 mac-lane CI loops ≈ 3h wall, of which loops 2–3 were preventable by pre-push whole-surface sweeps (owner said so mid-run; the corrected process then proved loop-4's fix locally 30/30 before green). Heaviest-least-value step: adversarial design pass 3.
+
+**Best catch:** design pass-1 self-review F3 — the design's `NSSound(named:)` would have silently played nothing; the shipping `SoundFeedback` path was reused instead (file:line-cited catch). Runner-up: PR-B adversarial's fail-closed paste-target pid (garbled id would have pasted into the wrong app).
+**Worst friction:** adversarial passes receive no prior-pass disposition ledger — re-litigation consumed loop-back budget twice (also observed in the #69 run: "adversarial diff review lacks prior-gate dispositions → re-litigated the resolved coarse-id finding", session notes, 2 runs total).
+**Routed:** 3 issues filed (see routing), 1 friction memory, worktree evidence commented on #371.
+
+## Evidence ledger (summary)
+- Run-record: jsonl tail (schema-valid, summarize rc=0; `changes` corrected post-persist to real diff numbers — flagged in audit) — **confirmed**.
+- Markers: full spine ×2 PRs quoted in `projects/saystory/claude_docs/session_notes.md`; loop-back counters file `claude_docs/.wf2-state/167/loopback_counters.json` = `{design:2, spec_tighten:1, total:3}` — **confirmed**.
+- Owner decisions (breaker r1/r2, escalation, 2-PR split, pause, process correction) — **confirmed** (session notes, D-numbered decision log in the run handoff).
+- Plugin version loaded: **3.32.2**; main at assessment: **3.35.0**. Defects below verified conceptually against 3.35.0 skill text (no disposition-ledger mechanism; no reviewer-liveness protocol; no authored-blind pre-push checklist).
+- Worktree isolation: 4/4 implementer dispatches ran isolated and merged clean — **confirmed**, CONTRADICTS open #371's "every implementer dispatch dies at spawn in workspace layout".
+
+## Telemetry audit
+| field | recorded | session evidence | verdict | impact | routing |
+|---|---|---|---|---|---|
+| tests | 49 added, 389/389 | ws final output 389/0 (baseline 365/0) | match | — | — |
+| gates[] | 4:33/33, 8a:6/6, 11:17/17 | markers: 11+13+9 design; 8a 0+0+1M4L+5L→6 unique above-band… counted per #340 unique-across-passes | match (within #340 counting) | — | — |
+| loop_backs | 3/3 | counters file total=3 | match | — | — |
+| changes | 63 files +4274/−646, 13 commits | initially persisted as ESTIMATES (68/5800/600), corrected post-persist from real `git diff --shortstat` | mismatch (transient; self-corrected) | record briefly wrong on disk | pooled into telemetry note (not filed — cap) |
+| outcome | PR #183 merged ci passed | merge → 2ce0078, 4/4 lanes | match | — | — |
+| usage | unavailable | session re-logged mid-run | known-limitation | — | standing weak spot |
+| dispatches[] | 32 (incl 2 dead + 1 retried) | 32 `^DISPATCH issue=167` lines incl the dead pair | match | — | — |
+| reviewer_kind (4/8a/11) | hand_rolled_multi | multi-reviewer + adversarial layers | match | — | — |
+
+## Findings
+1. **PLUGIN DEFECT — no disposition ledger across adversarial passes.** Pass-2 adversarial re-attacked the owner-settled unbounded-FIFO decision; pass-3 re-raised the settled entitlements-gate decline despite an explicit settled-scope instruction in its brief. Cost: breaker round-trips + loop-back budget. Recurrence: 2 runs (this + #69's memorized identical class). FILED.
+2. **PLUGIN DEFECT — no reviewer-liveness/vacuous-result protocol.** Both 8a-T4 reviewers died on the account session limit; detection + re-dispatch relied on orchestrator memory of the vacuous-result pattern, not skill guidance. Recurrence: "hit your session limit" appears in 36 distinct sessions (index query, literal). FILED.
+3. **PLUGIN FRICTION — deferral contract lacks an authored-blind pre-push proxy checklist.** CI loops 2 (uniffi `*Impl` decl collision — a bindings SIGNATURE diff had been done but not a DECL-NAME sweep) and 3 (5 test files missing imports — sources swept exhaustively, tests sampled) were both catchable offline; loop 4's fix was then proven locally (rust-harness 30/30) under the corrected process. Triggered checklist (no-target-toolchain / generated-interfaces / deferred-lane) per consult risk note — never a blanket mandate. FILED (feat).
+4. **ORCHESTRATOR ERROR** (owned) — estimates persisted into `changes`; duplicate-append instinct on #166; bindings check stopped at signatures. The prose invited none of these.
+5. **ENVIRONMENT** — account session limit killed the T4 reviewers; owner /login restored.
+6. **WORKING AS DESIGNED** — loop-back cap escalation to owner; decompose-band 2-PR split; preemptable-shutdown design catching the parked-callback class before it shipped; worktree isolation (evidence against #371).
+
+## Routing
+- Filed (cap 3, shared pool): rawgentic#393 (disposition ledger, defect), rawgentic#394 (reviewer liveness/vacuous protocol, defect), rawgentic#395 (authored-blind pre-push checklist, friction→feat).
+- Telemetry improvements not filed (cap): merged-gate reviewer_kind guidance example; changes-from-estimates guard (summarize could recompute `changes` from `git diff` itself — noted for #333's queue).
+- Friction memory: SAVED + verified — drawer_rawgentic_process-conventions_afffd44a377ef2ec8ccd9efd.
+- #371: contradicting evidence commented (issuecomment-4941285577), not refiled.
+
+## Fixed output block
+```
+WF RUN ASSESSMENT — WF2 @ v3.32.2 (issue #167, PRs #182+#183, lane full ×2) · rubric v2
+Fidelity 4/5 · Gates 4/5 · Clarity 3/5 · Dispatch 3/5 · Telemetry 3/5 · Cost 2/5
+Mode: full · Record: docs/measurements/run_records.jsonl (tail)
+Best catch: design F3 — NSSound(named:) would have silently played nothing; shipping SoundFeedback reused
+Worst friction: adversarial passes carry no prior-pass disposition ledger (re-litigation ×2 runs)
+Telemetry verdicts: match 6 / mismatch 1 / missing-in-record 0 / missing-in-session 0 / unverifiable 0 / known-limitation 1
+Defects filed: rawgentic#393 (disposition ledger) #394 (reviewer liveness) #395 (authored-blind checklist) | Telemetry filed: none (cap) | Not filed (cap): 2 | Friction memorized: drawer_rawgentic_process-conventions_afffd44a | Clean run: no
+Report: docs/reviews/run-feedback-wf2-167-2026-07-11.md · Artifact: https://claude.ai/code/artifact/fdb2ab72-0bad-464c-8bc0-c5e063c87156
+Inferred (unconfirmed) claims: defect presence on main v3.35.0 verified against skill text, not a live 3.35.0 run
+```

--- a/docs/reviews/run-feedback-wf2-168-2026-07-11.html
+++ b/docs/reviews/run-feedback-wf2-168-2026-07-11.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 run-feedback — WF2 #168</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+
+:root{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+@media(prefers-color-scheme:dark){:root{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}}
+:root[data-theme=dark]{--sev-crit:#f87171;--sev-crit-bg:#3b1717;--sev-high:#fb923c;--sev-high-bg:#3a2410;--sev-med:#fbbf24;--sev-med-bg:#302a14;--sev-low:#a8b6bd;--sev-low-bg:#232d34;--req-c:#2dd4bf;--req-c-bg:#123531}
+:root[data-theme=light]{--sev-crit:#b91c1c;--sev-crit-bg:#fdecec;--sev-high:#c2410c;--sev-high-bg:#fdeee2;--sev-med:#a16207;--sev-med-bg:#f8f2e2;--sev-low:#4b5a63;--sev-low-bg:#eef1f3;--req-c:#0f766e;--req-c-bg:#e6f2f0}
+.score{font:11.5px/1.4 ui-monospace,Menlo,Consolas,monospace;font-weight:700;background:var(--code);color:var(--accent);border-radius:5px;padding:1px 6px}
+.sev{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 7px;border-radius:999px;text-transform:uppercase;white-space:nowrap}
+.sev-critical{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.sev-high{color:var(--sev-high);background:var(--sev-high-bg)}
+.sev-medium{color:var(--sev-med);background:var(--sev-med-bg)}
+.sev-low{color:var(--sev-low);background:var(--sev-low-bg)}
+.req{font-size:11px;font-weight:700;letter-spacing:.03em;padding:1px 6px;border-radius:5px;color:var(--req-c);background:var(--req-c-bg)}
+.req-must-not,.req-should-not{color:var(--sev-crit);background:var(--sev-crit-bg)}
+.req-may{color:var(--ink-3);background:var(--code)}
+
+.tpl-report blockquote{background:var(--code);border-left-color:var(--accent)}
+.tpl-report tbody tr:nth-child(even){background:var(--code)}
+</style>
+</head>
+<body class="tpl-report">
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-11 05:25 MDT</div>
+<h1>WF14 run-feedback — WF2 #168</h1>
+
+</header>
+<main>
+<h1>WF14 run-feedback — WF2 #168 (saystory, 2-PR split: PR #186 rust + PR #189 swift)</h1>
+<p>Assessed under rubric v2 (2026-07-10, #377). Plugin version loaded by the run: 3.35.0 (cache <code>~/.claude/plugins/cache/rawgentic/rawgentic/3.35.0/</code>); current main version not re-checked this pass (defects verified against 3.35.0 prose; the one filed-class finding was already filed upstream as #393, so no stale-cache filing risk). Record: explicit <code>--record</code> (claude_docs/.rawgentic-168-record.json), persisted to the saystory store (<code>docs/measurements/run_records.jsonl</code>, 23rd line) — schema-valid on SECOND summarize (see telemetry). Reviewer model directive honored: adversarial layers this run used gpt-5.6-sol (owner directive 2026-07-10 ~08:50).</p>
+<h2>At a glance</h2>
+<p><strong>A high-value, high-friction run: the gates earned their cost several times over (the single-llama localization mechanism, a hang-class bridge bug, and a merge-gate heading requirement were all caught pre-merge), but PR-A burned six mac-lane CI loops before the run adopted the preflight rule that then took PR-B through CI in one.</strong></p>
+<ul>
+<li><strong>Fidelity <span class="score">3/5</span></strong> — all mandatory markers present across both PR legs EXCEPT an</li>
+</ul>
+<p>  explicit Step-9 marker for the PR-B leg (drift verification demonstrably happened   inside Step 11 A1&#x27;s whole-diff task mapping, but the marker is absent → cap).</p>
+<ul>
+<li><strong>Gates <span class="score">5/5</span></strong> — multiple named real catches, quoted below.</li>
+<li><strong>Clarity <span class="score">4/5</span></strong> — executable throughout; one tool contract needed discovery</li>
+</ul>
+<p>  (engine sidecar path must live under project root — error text was clear, but no   skill prose states it).</p>
+<ul>
+<li><strong>Dispatch <span class="score">4/5</span></strong> — 25 dispatches, zero vacuous, all opus-as-routed; one implementer</li>
+</ul>
+<p>  idled holding for its own background gate and needed a SendMessage nudge.</p>
+<ul>
+<li><strong>Telemetry <span class="score">2/5</span></strong> — record REJECTED on first summarize (assessor used <code>type</code> for</li>
+</ul>
+<p>  the documented <code>subagent_type</code> — orchestrator error, validator correct); gate   counts initially recorded as per-pass sums (corrected in-store to the #340 unique   rule before any PR carries the line).</p>
+<ul>
+<li><strong>Cost <span class="score">3/5</span></strong> — proportional for a <code>complex</code> 2-PR feature overall; the heaviest</li>
+</ul>
+<p>  least-value spend was PR-A CI loop 3 (a full mac lane burned re-testing <code>lto=off</code>   on a conclusion drawn with the wrong instrument).</p>
+<p><strong>Best catch:</strong> Step 4 pass-2 H4 — &quot;the single SwiftPM TEST BUNDLE links ParrotCore (Swift llama xcframework) AND ParrotCoreFFI (rust llama .a) together from PR-A onward&quot; — this produced the R6 symbol-localization mechanism whose CI hardening then dominated (and justified) PR-A&#x27;s fix loops. Runner-up: adversarial diff on PR-B caught the unbounded <code>gate.wait()</code> hang class AFTER an 8a lens had passed the same code as &quot;documented R7 case&quot; — the redundant-lens design worked exactly as intended.</p>
+<p><strong>Worst friction:</strong> adversarial diff reviews still re-litigate settled dispositions (2 of 4 PR-B findings; 3 of 4 on PR-A) — already filed as rawgentic#393 (OPEN), recurrence now ≥3 runs (#166, #167, #168).</p>
+<p><strong>Routed:</strong> 0 new defects filed (1 recurrent friction linked to existing #393); 1 friction memory saved; telemetry improvements: none filed (both negatives were assessor-caused, validator behaved correctly).</p>
+<h2>Evidence ledger (selected, tagged)</h2>
+<ul>
+<li>Steps 1–5, 7, 8, 8a, 11, 11.5, 12, 14, 16 markers present for both PR legs —</li>
+</ul>
+<p>  <strong>confirmed</strong> (session_notes.md <code>### WF2 Step ...</code> markers; e.g. Step 4:   &quot;pass 2, 12 findings → 8 resolutions owner-approved, REV3 ... loop-backs design 2/3&quot;   @ line 1112; Step 12 PR-B: &quot;PR #189 OPEN &#x27;Closes #168&#x27; (7 commits, v0.2.46)&quot;).</p>
+<ul>
+<li>Step 9 (PR-B leg): explicit marker <strong>absent</strong>; drift check evidenced inside Step 11</li>
+</ul>
+<p>  A1 result (&quot;Whole-diff drift: every changed file maps to a task ... No unowned   file&quot;) — <strong>confirmed as performed, unverifiable as a step</strong>.</p>
+<ul>
+<li>PR-A six CI loops + root causes — <strong>confirmed</strong> (session notes postmortem marker:</li>
+</ul>
+<p>  &quot;L1 platform_version; L2 nm bitcode death masked by ||true; L3 wrong-instrument   inference (lto=off); L4 phantom over-strip ...; L5 swift-link httplib undefineds;   L6 GREEN: -u root-set&quot;).</p>
+<ul>
+<li>PR-B zero CI loops; mac lane green first run — <strong>confirmed</strong> (run 29150102046</li>
+</ul>
+<p>  jobs: macOS SUCCESS; preflight rounds 1–3 log reads: 82→84 tests/1 skip/0 fail).</p>
+<ul>
+<li>25 dispatches (2 implementer, 7 reviewer this leg + 16 <code>DISPATCH issue=168</code></li>
+</ul>
+<p>  markers from earlier legs), zero vacuous — <strong>confirmed</strong> (marker grep + agent   results in-session).</p>
+<ul>
+<li>Owner process rule adopted mid-run (&quot;no mac-lane push without full</li>
+</ul>
+<p>  build-macos-ffi.sh + swift test on the mac host&quot;) — <strong>confirmed</strong> (owner challenge   + session-notes rule marker); its effect (6 loops → 0) — <strong>confirmed</strong>.</p>
+<h2>Telemetry audit (record: present, explicit)</h2>
+<table>
+<thead><tr><th>field</th><th>recorded</th><th>session evidence</th><th>verdict</th><th>impact</th><th>routing</th></tr></thead>
+<tbody>
+<tr><td>workflow/issue</td><td>implement-feature / 168</td><td>matches run</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>tests</td><td>33 added / 491 passing</td><td>ws 407/0 (runner output) + swift 84/1/0 (preflight log); &quot;added&quot; is an estimate across two count methods</td><td>mismatch-risk on <code>added</code> (estimate, stated here)</td><td>low — analytics only</td><td>not filed: assessor-assembled estimate, noted in-record context</td></tr>
+<tr><td>gates[] step 4</td><td>20/20 (corrected in-store from 24/24)</td><td>pass1 &quot;12 merged (4H/6M/2L)&quot;, pass2 &quot;deduped to 8 resolutions&quot;</td><td>match after correction; initial value was a per-pass-sum over-count</td><td>corrected pre-PR</td><td>orchestrator error, no filing</td></tr>
+<tr><td>gates[] 8a/11</td><td>8/8, 11/11</td><td>markers + reviewer results</td><td>match (counts assembled from markers)</td><td>—</td><td>—</td></tr>
+<tr><td>loop_backs</td><td>2/3</td><td>&quot;.wf2-state/168/loopback_counters.json&quot; markers (&quot;design 2/3, total 2/3&quot;)</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>security_scan</td><td>ran, 0 blocking, iac skipped</td><td>&quot;Security scan: PASS ... iac: not applicable&quot; output</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>outcome</td><td>PR 189 merged, ci passed</td><td>merge SHA 904fc65, run success</td><td>match</td><td>—</td><td>—</td></tr>
+<tr><td>usage</td><td>capture_status unavailable</td><td>no session usage capture</td><td>known-limitation (standing)</td><td>—</td><td>#329/#330 open</td></tr>
+<tr><td>reviewer_kind</td><td>hand_rolled_multi on merged gates</td><td>multi-reviewer + adversarial layers</td><td>match under #340 precedence</td><td>—</td><td>—</td></tr>
+<tr><td>dispatches[]</td><td>25 entries</td><td>markers + this session&#x27;s agents</td><td>match; NOTE first summarize REJECTED the field (<code>type</code> vs documented <code>subagent_type</code>) — assessor error, validator correct and loud</td><td>schema held</td><td>none</td></tr>
+</tbody>
+</table>
+<p>Verdict counts: match 7 · mismatch 0 (2 corrected/stated) · missing-in-record 0 · missing-in-session 0 · unverifiable 0 · known-limitation 1.</p>
+<h2>Findings and classes</h2>
+<p>1. <strong>PLUGIN FRICTION (recurrent, ≥3 runs: #166/#167/#168)</strong> — adversarial diff    passes lack the settled-disposition ledger; PR-A: 3 of 4 findings re-litigated    settled decisions; PR-B: 2 of 4 declined against already-recorded evidence    (cleanup-routing = merged PR-A; detect-flag branch unreachable under the rust    invariant). <strong>Already filed: rawgentic#393 (OPEN)</strong> — linked, not refiled. This    run adds a data point: the cost is real but bounded (each decline took one    evidence lookup), and one adversarial finding on the same pass was the run&#x27;s    second-best catch — the lens must not be weakened, only fed dispositions. 2. <strong>ORCHESTRATOR ERROR</strong> — run-record first-summarize rejection (<code>type</code> instead of    the documented <code>subagent_type</code>, run-record.md:44) and the initial per-pass-sum    gate count. Both caught by machinery (validator; rubric #340 rule at assessment    time). Own goal; the docs were right; no prose invited the misread. 3. <strong>ORCHESTRATOR ERROR (earlier leg)</strong> — PR-A CI loop 3: <code>lto=off</code> re-tested on the    runner after loop 2, but the failing reader (Apple nm) was the wrong instrument;    the conclusion &quot;LTO inference WRONG&quot; was drawn from a stale-cache artifact. One    full mac lane spent. The corrective (instrument swap + on-runner forensics) came    from the owner&#x27;s challenge, not the workflow prose — WF2 has no &quot;verify the    instrument before re-testing the hypothesis&quot; guidance for CI fix loops; recorded    here as a data point for the existing authored-blind checklist thread    (peer-review defect #3 lineage, #391-class), not filed separately. 4. <strong>ENVIRONMENT ×2</strong> — mac host disk 100% full (killed preflight round 1; owner    freed 137G; agent-owned spike dirs deleted with approval) and WSL root 100% full    (per-worktree cargo <code>target/</code> dirs ~3–7G each + a 13G incremental cache; harness    task-output writes fail loudly on ENOSPC). No plugin runbook covers worktree    disk hygiene — worth one line in the implementer-dispatch prose eventually;    below filing threshold this run (cap discipline). 5. <strong>WORKING AS DESIGNED</strong> — the mid-run adoption of the mac-preflight rule    (full FFI script + swift test on the target host before any mac-lane push):    PR-B&#x27;s zero-loop CI empirically validates it. Candidate for promotion from    session rule to WF2 prose via the existing #391-class checklist issue.</p>
+<h2>Claims intentionally not made</h2>
+<ul>
+<li>No per-run cost claim (usage capture unavailable — session-level only).</li>
+<li>No claim that PR-A&#x27;s Step-16 record behavior matched convention (that leg&#x27;s</li>
+</ul>
+<p>  record was assembled and persisted in THIS leg, post-merge — a deviation from the   append-pre-merge convention, driven by the 2-PR structure; noted, not scored).</p>
+<h2>Summary block</h2>
+<pre><code>WF RUN ASSESSMENT — WF2 @ v3.35.0 (issue #168, PRs #186+#189, lane full) · rubric v2
+Fidelity 3/5 · Gates 5/5 · Clarity 4/5 · Dispatch 4/5 · Telemetry 2/5 · Cost 3/5
+Mode: full · Record: claude_docs/.rawgentic-168-record.json (persisted, corrected)
+Best catch: Step-4 H4 double-llama test-bundle → R6 localization mechanism (pre-merge)
+Worst friction: adversarial diff re-litigates settled dispositions — rawgentic#393, recurrence ≥3 runs
+Telemetry verdicts: match 7 / mismatch 0 / missing-in-record 0 / missing-in-session 0 / unverifiable 0 / known-limitation 1
+Defects filed: none (recurrent friction → existing #393) | Telemetry filed: none | Not filed (cap): 0 | Friction memorized: wf2-adversarial-needs-disposition-ledger-168 | Clean run: no
+Report: projects/rawgentic/docs/reviews/run-feedback-wf2-168-2026-07-11.md
+Inferred (unconfirmed) claims: tests.added=33 (two count methods); current-main defect presence not re-verified (nothing filed that depends on it)</code></pre>
+
+</main>
+<footer>Last updated: 2026-07-11 05:25 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/run-feedback-wf2-168-2026-07-11.md
+++ b/docs/reviews/run-feedback-wf2-168-2026-07-11.md
@@ -1,0 +1,143 @@
+# WF14 run-feedback — WF2 #168 (saystory, 2-PR split: PR #186 rust + PR #189 swift)
+
+Assessed under rubric v2 (2026-07-10, #377). Plugin version loaded by the run:
+3.35.0 (cache `~/.claude/plugins/cache/rawgentic/rawgentic/3.35.0/`); current main
+version not re-checked this pass (defects verified against 3.35.0 prose; the one
+filed-class finding was already filed upstream as #393, so no stale-cache filing risk).
+Record: explicit `--record` (claude_docs/.rawgentic-168-record.json), persisted to the
+saystory store (`docs/measurements/run_records.jsonl`, 23rd line) — schema-valid on
+SECOND summarize (see telemetry). Reviewer model directive honored: adversarial layers
+this run used gpt-5.6-sol (owner directive 2026-07-10 ~08:50).
+
+## At a glance
+
+**A high-value, high-friction run: the gates earned their cost several times over
+(the single-llama localization mechanism, a hang-class bridge bug, and a merge-gate
+heading requirement were all caught pre-merge), but PR-A burned six mac-lane CI loops
+before the run adopted the preflight rule that then took PR-B through CI in one.**
+
+- **Fidelity 3/5** — all mandatory markers present across both PR legs EXCEPT an
+  explicit Step-9 marker for the PR-B leg (drift verification demonstrably happened
+  inside Step 11 A1's whole-diff task mapping, but the marker is absent → cap).
+- **Gates 5/5** — multiple named real catches, quoted below.
+- **Clarity 4/5** — executable throughout; one tool contract needed discovery
+  (engine sidecar path must live under project root — error text was clear, but no
+  skill prose states it).
+- **Dispatch 4/5** — 25 dispatches, zero vacuous, all opus-as-routed; one implementer
+  idled holding for its own background gate and needed a SendMessage nudge.
+- **Telemetry 2/5** — record REJECTED on first summarize (assessor used `type` for
+  the documented `subagent_type` — orchestrator error, validator correct); gate
+  counts initially recorded as per-pass sums (corrected in-store to the #340 unique
+  rule before any PR carries the line).
+- **Cost 3/5** — proportional for a `complex` 2-PR feature overall; the heaviest
+  least-value spend was PR-A CI loop 3 (a full mac lane burned re-testing `lto=off`
+  on a conclusion drawn with the wrong instrument).
+
+**Best catch:** Step 4 pass-2 H4 — "the single SwiftPM TEST BUNDLE links ParrotCore
+(Swift llama xcframework) AND ParrotCoreFFI (rust llama .a) together from PR-A
+onward" — this produced the R6 symbol-localization mechanism whose CI hardening then
+dominated (and justified) PR-A's fix loops. Runner-up: adversarial diff on PR-B
+caught the unbounded `gate.wait()` hang class AFTER an 8a lens had passed the same
+code as "documented R7 case" — the redundant-lens design worked exactly as intended.
+
+**Worst friction:** adversarial diff reviews still re-litigate settled dispositions
+(2 of 4 PR-B findings; 3 of 4 on PR-A) — already filed as rawgentic#393 (OPEN),
+recurrence now ≥3 runs (#166, #167, #168).
+
+**Routed:** 0 new defects filed (1 recurrent friction linked to existing #393);
+1 friction memory saved; telemetry improvements: none filed (both negatives were
+assessor-caused, validator behaved correctly).
+
+## Evidence ledger (selected, tagged)
+
+- Steps 1–5, 7, 8, 8a, 11, 11.5, 12, 14, 16 markers present for both PR legs —
+  **confirmed** (session_notes.md `### WF2 Step ...` markers; e.g. Step 4:
+  "pass 2, 12 findings → 8 resolutions owner-approved, REV3 ... loop-backs design 2/3"
+  @ line 1112; Step 12 PR-B: "PR #189 OPEN 'Closes #168' (7 commits, v0.2.46)").
+- Step 9 (PR-B leg): explicit marker **absent**; drift check evidenced inside Step 11
+  A1 result ("Whole-diff drift: every changed file maps to a task ... No unowned
+  file") — **confirmed as performed, unverifiable as a step**.
+- PR-A six CI loops + root causes — **confirmed** (session notes postmortem marker:
+  "L1 platform_version; L2 nm bitcode death masked by ||true; L3 wrong-instrument
+  inference (lto=off); L4 phantom over-strip ...; L5 swift-link httplib undefineds;
+  L6 GREEN: -u root-set").
+- PR-B zero CI loops; mac lane green first run — **confirmed** (run 29150102046
+  jobs: macOS SUCCESS; preflight rounds 1–3 log reads: 82→84 tests/1 skip/0 fail).
+- 25 dispatches (2 implementer, 7 reviewer this leg + 16 `DISPATCH issue=168`
+  markers from earlier legs), zero vacuous — **confirmed** (marker grep + agent
+  results in-session).
+- Owner process rule adopted mid-run ("no mac-lane push without full
+  build-macos-ffi.sh + swift test on the mac host") — **confirmed** (owner challenge
+  + session-notes rule marker); its effect (6 loops → 0) — **confirmed**.
+
+## Telemetry audit (record: present, explicit)
+
+| field | recorded | session evidence | verdict | impact | routing |
+|---|---|---|---|---|---|
+| workflow/issue | implement-feature / 168 | matches run | match | — | — |
+| tests | 33 added / 491 passing | ws 407/0 (runner output) + swift 84/1/0 (preflight log); "added" is an estimate across two count methods | mismatch-risk on `added` (estimate, stated here) | low — analytics only | not filed: assessor-assembled estimate, noted in-record context |
+| gates[] step 4 | 20/20 (corrected in-store from 24/24) | pass1 "12 merged (4H/6M/2L)", pass2 "deduped to 8 resolutions" | match after correction; initial value was a per-pass-sum over-count | corrected pre-PR | orchestrator error, no filing |
+| gates[] 8a/11 | 8/8, 11/11 | markers + reviewer results | match (counts assembled from markers) | — | — |
+| loop_backs | 2/3 | ".wf2-state/168/loopback_counters.json" markers ("design 2/3, total 2/3") | match | — | — |
+| security_scan | ran, 0 blocking, iac skipped | "Security scan: PASS ... iac: not applicable" output | match | — | — |
+| outcome | PR 189 merged, ci passed | merge SHA 904fc65, run success | match | — | — |
+| usage | capture_status unavailable | no session usage capture | known-limitation (standing) | — | #329/#330 open |
+| reviewer_kind | hand_rolled_multi on merged gates | multi-reviewer + adversarial layers | match under #340 precedence | — | — |
+| dispatches[] | 25 entries | markers + this session's agents | match; NOTE first summarize REJECTED the field (`type` vs documented `subagent_type`) — assessor error, validator correct and loud | schema held | none |
+
+Verdict counts: match 7 · mismatch 0 (2 corrected/stated) · missing-in-record 0 ·
+missing-in-session 0 · unverifiable 0 · known-limitation 1.
+
+## Findings and classes
+
+1. **PLUGIN FRICTION (recurrent, ≥3 runs: #166/#167/#168)** — adversarial diff
+   passes lack the settled-disposition ledger; PR-A: 3 of 4 findings re-litigated
+   settled decisions; PR-B: 2 of 4 declined against already-recorded evidence
+   (cleanup-routing = merged PR-A; detect-flag branch unreachable under the rust
+   invariant). **Already filed: rawgentic#393 (OPEN)** — linked, not refiled. This
+   run adds a data point: the cost is real but bounded (each decline took one
+   evidence lookup), and one adversarial finding on the same pass was the run's
+   second-best catch — the lens must not be weakened, only fed dispositions.
+2. **ORCHESTRATOR ERROR** — run-record first-summarize rejection (`type` instead of
+   the documented `subagent_type`, run-record.md:44) and the initial per-pass-sum
+   gate count. Both caught by machinery (validator; rubric #340 rule at assessment
+   time). Own goal; the docs were right; no prose invited the misread.
+3. **ORCHESTRATOR ERROR (earlier leg)** — PR-A CI loop 3: `lto=off` re-tested on the
+   runner after loop 2, but the failing reader (Apple nm) was the wrong instrument;
+   the conclusion "LTO inference WRONG" was drawn from a stale-cache artifact. One
+   full mac lane spent. The corrective (instrument swap + on-runner forensics) came
+   from the owner's challenge, not the workflow prose — WF2 has no "verify the
+   instrument before re-testing the hypothesis" guidance for CI fix loops; recorded
+   here as a data point for the existing authored-blind checklist thread
+   (peer-review defect #3 lineage, #391-class), not filed separately.
+4. **ENVIRONMENT ×2** — mac host disk 100% full (killed preflight round 1; owner
+   freed 137G; agent-owned spike dirs deleted with approval) and WSL root 100% full
+   (per-worktree cargo `target/` dirs ~3–7G each + a 13G incremental cache; harness
+   task-output writes fail loudly on ENOSPC). No plugin runbook covers worktree
+   disk hygiene — worth one line in the implementer-dispatch prose eventually;
+   below filing threshold this run (cap discipline).
+5. **WORKING AS DESIGNED** — the mid-run adoption of the mac-preflight rule
+   (full FFI script + swift test on the target host before any mac-lane push):
+   PR-B's zero-loop CI empirically validates it. Candidate for promotion from
+   session rule to WF2 prose via the existing #391-class checklist issue.
+
+## Claims intentionally not made
+
+- No per-run cost claim (usage capture unavailable — session-level only).
+- No claim that PR-A's Step-16 record behavior matched convention (that leg's
+  record was assembled and persisted in THIS leg, post-merge — a deviation from the
+  append-pre-merge convention, driven by the 2-PR structure; noted, not scored).
+
+## Summary block
+
+```
+WF RUN ASSESSMENT — WF2 @ v3.35.0 (issue #168, PRs #186+#189, lane full) · rubric v2
+Fidelity 3/5 · Gates 5/5 · Clarity 4/5 · Dispatch 4/5 · Telemetry 2/5 · Cost 3/5
+Mode: full · Record: claude_docs/.rawgentic-168-record.json (persisted, corrected)
+Best catch: Step-4 H4 double-llama test-bundle → R6 localization mechanism (pre-merge)
+Worst friction: adversarial diff re-litigates settled dispositions — rawgentic#393, recurrence ≥3 runs
+Telemetry verdicts: match 7 / mismatch 0 / missing-in-record 0 / missing-in-session 0 / unverifiable 0 / known-limitation 1
+Defects filed: none (recurrent friction → existing #393) | Telemetry filed: none | Not filed (cap): 0 | Friction memorized: wf2-adversarial-needs-disposition-ledger-168 | Clean run: no
+Report: projects/rawgentic/docs/reviews/run-feedback-wf2-168-2026-07-11.md
+Inferred (unconfirmed) claims: tests.added=33 (two count methods); current-main defect presence not re-verified (nothing filed that depends on it)
+```

--- a/docs/reviews/run-feedback-wf2-69-2026-07-10.html
+++ b/docs/reviews/run-feedback-wf2-69-2026-07-10.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WF14 run-feedback — WF2 #69</title>
+<style>
+:root{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;--ink-3:#7b8a92;
+--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+@media(prefers-color-scheme:dark){:root{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;
+--ink-2:#a8b6bd;--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}}
+:root[data-theme=dark]{--bg:#12181c;--surface:#1a2228;--ink:#e7edf0;--ink-2:#a8b6bd;
+--ink-3:#71808a;--line:#2a353c;--accent:#2dd4bf;--code:#232d34}
+:root[data-theme=light]{--bg:#f6f7f8;--surface:#fff;--ink:#1a2126;--ink-2:#4b5a63;
+--ink-3:#7b8a92;--line:#dde3e6;--accent:#0f766e;--code:#eef1f3}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.6 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:900px;margin:0 auto;padding:0 20px 72px}
+header{padding:40px 0 18px;border-bottom:1px solid var(--line);margin-bottom:20px}
+.eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}
+h1{font-size:clamp(22px,4vw,30px);margin:.3em 0;font-weight:750;letter-spacing:-.02em}
+h2{font-size:19px;font-weight:700;margin:1.4em 0 .4em}
+h3{font-size:16px;font-weight:650;margin:1.2em 0 .3em}
+p,li{color:var(--ink-2)}
+code{background:var(--code);border-radius:4px;padding:1px 5px;font:12.5px/1.4 ui-monospace,Menlo,Consolas,monospace}
+pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid var(--accent);margin:.6em 0;padding:.2em 0 .2em 14px;color:var(--ink-3)}
+table{border-collapse:collapse;width:100%;margin:.6em 0;font-size:13.5px}
+th,td{text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+.telemetry th{white-space:nowrap;color:var(--ink-3);width:1%}
+.telemetry-section{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:4px 18px 14px;margin-top:24px}
+footer{margin-top:40px;padding-top:16px;border-top:1px solid var(--line);color:var(--ink-3);font-size:12.5px}
+</style>
+</head>
+<body>
+<div class="wrap">
+<header>
+<div class="eyebrow">rawgentic design artifact · updated 2026-07-10 08:05 MDT</div>
+<h1>WF14 run-feedback — WF2 #69</h1>
+
+</header>
+<main>
+<h1>WF14 run-feedback — WF2 #69 (saystory, PR #179) · 2026-07-10 · rubric v1</h1>
+<p><strong>Run under assessment:</strong> WF2 implement-feature, saystory #69 (caret-context paste-spacing fallback into parrot-core-service), <strong>small-standard lane</strong>, merged <code>fc15659</code>. <strong>Plugin version loaded:</strong> 3.29.0 (cache); main: 3.32.1. <strong>Record:</strong> explicit (saystory store, issue-69 line; <code>validate_record</code> → valid, <code>lane: &quot;small-standard&quot;</code> present). <strong>Session notes:</strong> saystory <code>claude_docs/session_notes.md</code> (all <code>#69</code>-keyed markers accepted; assessor ran the run — first-party evidence).</p>
+<h2>Dimension scores</h2>
+<p>1. <strong>Fidelity 4/5</strong> (confirmed). All lane-collapsed mandatory steps ran and are    marked (Step 3 brief note, Step 4 rubric, Step 5 checklist, Step 9    evidence-only + lane cross-check 4 ≤ 7); Step 6 skip quotes its lane condition.    Ding (same class as the #165 run): Step 2 item 10 probe-parallelism not    executed — generic dispatch chosen directly from the #165 discovery rather than    a fresh probe (rational, but the marker asserts rather than evidences; see    rawgentic#371 for the underlying probe defect). 2. <strong>Gates 5/5</strong> (confirmed, quoted catch). Step 8a caught a REAL design-claim    error pre-PR: the design asserted &quot;Cross-app bleed → same_target platform_id    gate … a previous window&#x27;s text cannot bleed into a new one&quot;, but on Linux    X11/non-Hyprland Wayland <code>platform_id</code> is session-constant (&quot;x11&quot;/&quot;wayland&quot;) —    the guard is vacuous exactly on the target platform (reviewer cited    linux/platform/paste.rs:42,118-121,443-445). Resolved as accept-and-document    with a pinning test + owner-reversible flag in the PR. The Step-11 adversarial    pass additionally contributed an ADOPTED privacy hardening (store only the    resolver tail — behavior-invisible); the lane reviewer caught a doc-count error    (347→349). Three distinct gates each earned their cost. 3. <strong>Clarity 4/5</strong> (confirmed). Lane prose executed cleanly; residual    interpretation (engine-vs-skill adversarial invocation) is the same fork already    quoted in the #165 report — counted once there, noted here. 4. <strong>Dispatch 4/5</strong> (confirmed). 5 dispatches, all resolved first-try, non-vacuous,    models as routed (impl opus, reviewers opus, memorize sonnet). Short of 5:    worktree isolation unavailable (rawgentic#371), so all impl dispatches ran    generic/unisolated. 5. <strong>Telemetry 3/5</strong> (confirmed; anchor: valid + ≥1 known-limitation). Valid on    first summarize; <code>dispatches[]</code> 5 entries == 5 session lines; gates[] counts    match at-close notes (Step 4 recorded <code>fast_path</code> 0/0 per the lane convention);    loop_backs 0/3 matches (no counters file → none consumed); usage    session-cumulative (known-limitation). 6. <strong>Cost 3/5</strong> (capped: usage session-level; would otherwise anchor high — the    lane election demonstrably fit: 1 impl file, design ceremony collapsed, review    + security kept, and the kept reviews were exactly where the value landed).</p>
+<h2>Findings</h2>
+<p><strong>F1 — PLUGIN FRICTION (memorized): the adversarial diff review re-litigates already-resolved per-task findings.</strong> The Step-11 1a diff review (gpt-5.6-sol) returned the coarse-platform_id finding as its top item — the SAME defect Step 8a had already caught, adjudicated (accept-and-document, pinned by test), and committed BEFORE the diff review dispatched. The dispatch carries the raw diff only; nothing in Step 11 1a&#x27;s brief-construction prose passes prior-gate dispositions (the 8a review log / deferrals ARE passed to the 3 same-model reviewers via the P15 pre-flight — but not to the adversarial engine artifact). Cost: one-third of the cross-model pass spent re-arguing a settled point; the orchestrator must re-derive the disposition at the join. Exact gap: Step 11 1a &quot;Dispatch … build the diff high-risk-first …&quot; (no disposition-context clause), vs Step 11 item 1&#x27;s P15 pre-flight which does this for same-model reviewers.</p>
+<p><strong>F2 — ENVIRONMENT (no plugin action, positive recovery data):</strong> a ~90-minute usage-window stall hit mid-CI-wait; the run resumed exactly as designed via the overnight recovery tick reading the handoff file. The plugin&#x27;s checkpoint/handoff/session-notes substrate carried the resume with zero loss. The CI poller background task was killed during the stall — state was re-read directly; no runbook gap worth filing (the contract&#x27;s own recovery design covered it).</p>
+<p><strong>F3 — ORCHESTRATOR ERROR (owned): premature dead-declaration pattern avoided here</strong> only because the #165 lesson was fresh (waited through 12–22 min reviewer runtimes). Covered by the memorized #165 friction; nothing new.</p>
+<h2>Telemetry audit</h2>
+<table>
+<thead><tr><th>field</th><th>recorded</th><th>session evidence</th><th>verdict</th></tr></thead>
+<tbody>
+<tr><td>workflow/version/issue</td><td>implement-feature / 3.29.0 / 69</td><td>cache + markers</td><td>match</td></tr>
+<tr><td>changes</td><td>7 files, +369/−13, 4 commits</td><td>PR #179 merge stat + log</td><td>match</td></tr>
+<tr><td>tests</td><td>11 added, 350/350</td><td>runner final 350/0; 8 reproduce-first + 3 pins</td><td>match</td></tr>
+<tr><td>gates[]</td><td>4 rows (fast_path 0/0 · 3/3 · 0/0 · 5/5)</td><td>at-close dedup notes (#340 rule)</td><td>match</td></tr>
+<tr><td>security_scan</td><td>ran, skipped=[iac]</td><td>scan output</td><td>match</td></tr>
+<tr><td>loop_backs</td><td>0/3</td><td>no counters file for #69</td><td>match</td></tr>
+<tr><td>outcome</td><td>PR 179, merged, ci passed</td><td>fc15659 + all-lanes-pass checks</td><td>match</td></tr>
+<tr><td>usage</td><td>session-cumulative</td><td>capture semantics</td><td>known-limitation</td></tr>
+<tr><td>reviewer_kind</td><td>inline / hand_rolled_multi</td><td>#340 precedence</td><td>match</td></tr>
+<tr><td>dispatches[]</td><td>5 entries</td><td>5 <code>^DISPATCH issue=69</code> lines</td><td>match</td></tr>
+<tr><td>lane</td><td>small-standard</td><td>lane_decision tier=lane logged</td><td>match</td></tr>
+</tbody>
+</table>
+<p>Verdicts: match 10 · known-limitation 1.</p>
+<h2>Routing</h2>
+<ul>
+<li>Defects: none new filed (the worktree/probe defect and the WF14-write-guard</li>
+</ul>
+<p>  collision were filed from the #165 assessment: rawgentic#371, rawgentic#372 —   linked, not refiled).</p>
+<ul>
+<li>Friction: ONE mempalace memory (F1 — adversarial diff review lacks prior-gate</li>
+</ul>
+<p>  disposition context), project rawgentic.</p>
+<ul>
+<li>Telemetry lane: nothing filed (all match).</li>
+</ul>
+<p>Inferred (unconfirmed) claims: none — first-party evidence throughout.</p>
+
+</main>
+<footer>Last updated: 2026-07-10 08:05 MDT · generated by hooks/render_artifact.py — self-contained, no external resources.</footer>
+</div>
+</body>
+</html>

--- a/docs/reviews/run-feedback-wf2-69-2026-07-10.md
+++ b/docs/reviews/run-feedback-wf2-69-2026-07-10.md
@@ -1,0 +1,99 @@
+# WF14 run-feedback — WF2 #69 (saystory, PR #179) · 2026-07-10 · rubric v1
+
+**Run under assessment:** WF2 implement-feature, saystory #69 (caret-context
+paste-spacing fallback into parrot-core-service), **small-standard lane**, merged
+`fc15659`. **Plugin version loaded:** 3.29.0 (cache); main: 3.32.1. **Record:**
+explicit (saystory store, issue-69 line; `validate_record` → valid, `lane:
+"small-standard"` present). **Session notes:** saystory
+`claude_docs/session_notes.md` (all `#69`-keyed markers accepted; assessor ran the
+run — first-party evidence).
+
+## Dimension scores
+
+1. **Fidelity 4/5** (confirmed). All lane-collapsed mandatory steps ran and are
+   marked (Step 3 brief note, Step 4 rubric, Step 5 checklist, Step 9
+   evidence-only + lane cross-check 4 ≤ 7); Step 6 skip quotes its lane condition.
+   Ding (same class as the #165 run): Step 2 item 10 probe-parallelism not
+   executed — generic dispatch chosen directly from the #165 discovery rather than
+   a fresh probe (rational, but the marker asserts rather than evidences; see
+   rawgentic#371 for the underlying probe defect).
+2. **Gates 5/5** (confirmed, quoted catch). Step 8a caught a REAL design-claim
+   error pre-PR: the design asserted "Cross-app bleed → same_target platform_id
+   gate … a previous window's text cannot bleed into a new one", but on Linux
+   X11/non-Hyprland Wayland `platform_id` is session-constant ("x11"/"wayland") —
+   the guard is vacuous exactly on the target platform (reviewer cited
+   linux/platform/paste.rs:42,118-121,443-445). Resolved as accept-and-document
+   with a pinning test + owner-reversible flag in the PR. The Step-11 adversarial
+   pass additionally contributed an ADOPTED privacy hardening (store only the
+   resolver tail — behavior-invisible); the lane reviewer caught a doc-count error
+   (347→349). Three distinct gates each earned their cost.
+3. **Clarity 4/5** (confirmed). Lane prose executed cleanly; residual
+   interpretation (engine-vs-skill adversarial invocation) is the same fork already
+   quoted in the #165 report — counted once there, noted here.
+4. **Dispatch 4/5** (confirmed). 5 dispatches, all resolved first-try, non-vacuous,
+   models as routed (impl opus, reviewers opus, memorize sonnet). Short of 5:
+   worktree isolation unavailable (rawgentic#371), so all impl dispatches ran
+   generic/unisolated.
+5. **Telemetry 3/5** (confirmed; anchor: valid + ≥1 known-limitation). Valid on
+   first summarize; `dispatches[]` 5 entries == 5 session lines; gates[] counts
+   match at-close notes (Step 4 recorded `fast_path` 0/0 per the lane convention);
+   loop_backs 0/3 matches (no counters file → none consumed); usage
+   session-cumulative (known-limitation).
+6. **Cost 3/5** (capped: usage session-level; would otherwise anchor high — the
+   lane election demonstrably fit: 1 impl file, design ceremony collapsed, review
+   + security kept, and the kept reviews were exactly where the value landed).
+
+## Findings
+
+**F1 — PLUGIN FRICTION (memorized): the adversarial diff review re-litigates
+already-resolved per-task findings.** The Step-11 1a diff review (gpt-5.6-sol)
+returned the coarse-platform_id finding as its top item — the SAME defect Step 8a
+had already caught, adjudicated (accept-and-document, pinned by test), and
+committed BEFORE the diff review dispatched. The dispatch carries the raw diff only;
+nothing in Step 11 1a's brief-construction prose passes prior-gate dispositions
+(the 8a review log / deferrals ARE passed to the 3 same-model reviewers via the
+P15 pre-flight — but not to the adversarial engine artifact). Cost: one-third of
+the cross-model pass spent re-arguing a settled point; the orchestrator must
+re-derive the disposition at the join. Exact gap: Step 11 1a "Dispatch … build the
+diff high-risk-first …" (no disposition-context clause), vs Step 11 item 1's P15
+pre-flight which does this for same-model reviewers.
+
+**F2 — ENVIRONMENT (no plugin action, positive recovery data):** a ~90-minute
+usage-window stall hit mid-CI-wait; the run resumed exactly as designed via the
+overnight recovery tick reading the handoff file. The plugin's
+checkpoint/handoff/session-notes substrate carried the resume with zero loss. The
+CI poller background task was killed during the stall — state was re-read directly;
+no runbook gap worth filing (the contract's own recovery design covered it).
+
+**F3 — ORCHESTRATOR ERROR (owned): premature dead-declaration pattern avoided
+here** only because the #165 lesson was fresh (waited through 12–22 min reviewer
+runtimes). Covered by the memorized #165 friction; nothing new.
+
+## Telemetry audit
+
+| field | recorded | session evidence | verdict |
+|---|---|---|---|
+| workflow/version/issue | implement-feature / 3.29.0 / 69 | cache + markers | match |
+| changes | 7 files, +369/−13, 4 commits | PR #179 merge stat + log | match |
+| tests | 11 added, 350/350 | runner final 350/0; 8 reproduce-first + 3 pins | match |
+| gates[] | 4 rows (fast_path 0/0 · 3/3 · 0/0 · 5/5) | at-close dedup notes (#340 rule) | match |
+| security_scan | ran, skipped=[iac] | scan output | match |
+| loop_backs | 0/3 | no counters file for #69 | match |
+| outcome | PR 179, merged, ci passed | fc15659 + all-lanes-pass checks | match |
+| usage | session-cumulative | capture semantics | known-limitation |
+| reviewer_kind | inline / hand_rolled_multi | #340 precedence | match |
+| dispatches[] | 5 entries | 5 `^DISPATCH issue=69` lines | match |
+| lane | small-standard | lane_decision tier=lane logged | match |
+
+Verdicts: match 10 · known-limitation 1.
+
+## Routing
+
+- Defects: none new filed (the worktree/probe defect and the WF14-write-guard
+  collision were filed from the #165 assessment: rawgentic#371, rawgentic#372 —
+  linked, not refiled).
+- Friction: ONE mempalace memory (F1 — adversarial diff review lacks prior-gate
+  disposition context), project rawgentic.
+- Telemetry lane: nothing filed (all match).
+
+Inferred (unconfirmed) claims: none — first-party evidence throughout.

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.35.0",
+  "version": "3.35.1",
   "description": "8 SDLC workflow skills + 7 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -38,7 +38,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.35.0"
+    assert plugin["version"] == "3.35.1"
 
 
 def test_descriptions_consistent_count():


### PR DESCRIPTION
## Summary

Nine WF14 run-feedback assessment pairs (.md+.html) from the saystory M1+M2 overnight campaign, plus the cross-run aggregate mandated by the campaign goal (one roll-up: scoreboard, systemic patterns, routing ledger).

## Changes

- docs/reviews/run-feedback-wf2-{164,165,69,157,166,167×2,168,156,162}-*.{md,html} — the per-run assessments (rubric v2; the two #167 files are the interim and final passes, both preserved per the never-overwrite rule).
- docs/reviews/2026-07-11-wf14-m1-m2-aggregate.{md,html} — the aggregate. Published Artifact: https://claude.ai/code/artifact/6f5b8f10-0385-4b2d-a72b-68b93a6b075b
- Version 3.35.1 ×3 surfaces (docs-only patch per repo rule); pin test green.

## Workflow-diagram decision

No spine change — reviews-only docs PR; no diagram edit.

## Testing

- `pytest tests/ -q` — 2727 passed / 0 failed / 1 skipped (full suite, exit 0, run after the version bump).
- `pytest tests/hooks/test_adversarial_review_registration.py -q` — 29 passed.

## Privacy impact

None — assessment prose about workflow machinery; secrets by name only throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
