### PR TITLE
feat(admit-to-org-runners): admit bound repo to org runner fleet + migrate ci.yml, fail-closed (#397)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,7 @@
       "strict": true,
       "skills": [
         "./skills/add-exception",
+        "./skills/admit-to-org-runners",
         "./skills/adversarial-review",
         "./skills/create-issue",
         "./skills/fix-bug",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rawgentic",
-  "version": "3.35.1",
-  "description": "8 SDLC workflow skills + 7 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
+  "version": "3.36.0",
+  "description": "8 SDLC workflow skills + 8 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, org self-hosted runner admission, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",
     "url": "https://github.com/3D-Stories"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rawgentic
 
-**8 SDLC workflow skills + 7 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code**
+**8 SDLC workflow skills + 8 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-purple)](https://docs.anthropic.com/en/docs/claude-code)
@@ -11,7 +11,7 @@
 
 Claude Code is powerful but unstructured. Complex tasks — building features, fixing bugs, running security audits — need consistent quality gates, test-driven development, and deployment verification. Without guardrails, it's easy to skip code review, forget to run CI, or merge without testing.
 
-**Rawgentic** provides 18 skills organized in four layers (six little-used workflows were deprecated at v2.60.0 — #160 — and removed at v3.0.0; see `docs/upgrade-3.0.md`):
+**Rawgentic** provides 19 skills organized in four layers (six little-used workflows were deprecated at v2.60.0 — #160 — and removed at v3.0.0; see `docs/upgrade-3.0.md`):
 
 - **Workspace management** (7 skills) — Project registration, configuration, session binding, guard exception management, opt-in operating-charter installation, session-registry housekeeping, and full-text session-history recall
 - **SDLC workflows** (8 skills) — Multi-step guided processes with quality gates, code review, CI verification, and deployment, plus a post-run `run-feedback` self-assessment (WF14) and human-gated session-history mining (WF17)
@@ -436,7 +436,7 @@ Tracks all registered projects. Created automatically by `/rawgentic:new-project
 
 ### Config-Loading Protocol
 
-All 8 config-driven skills (the active workflows plus `/rawgentic:scan`) share an identical config-loading block that runs before any workflow step:
+All 9 config-driven skills (the active workflows plus `/rawgentic:scan` and `/rawgentic:admit-to-org-runners`) share an identical config-loading block that runs before any workflow step:
 
 1. Read `.rawgentic_workspace.json` → find active project (if multiple are active, stop and prompt user to `/rawgentic:switch`)
 2. Load + derive: `python3 hooks/capabilities_lib.py derive --config <project-path>/.rawgentic.json` validates the config and emits `{config, capabilities}`
@@ -655,7 +655,7 @@ pytest tests/hooks/test_wal_guard.py -v
 
 **Impact measurement:** `scripts/wf2_impact_metrics.py` computes deterministic Tier-1 impact metrics (test growth, fail-closed coverage, dedup, diff volume) for a skill-extraction effort over a `--baseline`/`--head` git range. See [docs/measurements/2026-06-15-wf2-extraction-impact.md](docs/measurements/2026-06-15-wf2-extraction-impact.md) for the WF2 extraction analysis.
 
-Skills are tested via the `/skill-creator` eval pipeline (9/18 skills have evals.json files, in `skills/<skill>-workspace/evals/` or the skill's own `evals/` directory; the lightweight `add-exception`, `housekeeping`, `install-operating-charter`, `interview`, `run-feedback`, `scan`, `session-mining`, and `session-recall` skills have none, and `peer-consult` ships an empty stub — `skills/peer-consult/evals.json` — pending eval authoring). The fraction and the have-none list are computed from disk by a drift guard.
+Skills are tested via the `/skill-creator` eval pipeline (9/19 skills have evals.json files, in `skills/<skill>-workspace/evals/` or the skill's own `evals/` directory; the lightweight `add-exception`, `admit-to-org-runners`, `housekeeping`, `install-operating-charter`, `interview`, `run-feedback`, `scan`, `session-mining`, and `session-recall` skills have none, and `peer-consult` ships an empty stub — `skills/peer-consult/evals.json` — pending eval authoring). The fraction and the have-none list are computed from disk by a drift guard.
 
 **Workspace directories:** Some skills have a corresponding `*-workspace/` directory (e.g., `skills/setup-workspace/`) used for internal skill iteration and evaluation. These contain `evals/`, `iteration-N/`, and `skill-snapshot/` subdirectories. They are **excluded from marketplace installs** via the `skills` whitelist in `marketplace.json`. If you add a new workspace directory, never name a file `SKILL.md` inside it — the marketplace validator scans for that filename recursively and will reject duplicates.
 
@@ -706,6 +706,8 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v3.36.0 (2026-07-12)
+- **`/rawgentic:admit-to-org-runners` — admit the bound repo to an org self-hosted runner fleet + migrate its CI off GitHub-hosted runners (#397).** New operational skill: resolves the bound repo via the shared `<config-loading>` block, discovers the org's runner groups and their ONLINE runners with a SEPARATE runner-admin credential (`--admin-token-file` / `$RAWGENTIC_RUNNER_ADMIN_TOKEN`, used ONLY on `orgs/<org>/actions/runner-*` — never the default gh token, never a hosted fallback), and migrates each workflow's hosted `runs-on` to a `{group, labels}` fleet block. Fail-closed by construction: it verifies an online runner carries the target labels BEFORE editing (never strands CI on a label no runner has), refuses the whole file if any hosted lane is unmappable or a `${{ }}`/matrix shape it will not mangle, and never leaves a hosted fallback; idempotent (already-admitted + already-on-fleet = clean no-op); dry-run by default, `--apply` ships the migration as a PR. Risky logic lives in the new tested helper `hooks/org_runners_lib.py` (workflow `runs-on` parse/classify, OS→label map, online-runner label match, hosted-remnant detection); 27 red-before-green tests. Registered across all surfaces (whitelist between `add-exception`/`adversarial-review`, codex mirror symlink, config-loading canary 8→9, counts 18→19 / workspace management 7→8). No workflow-spine change → no diagram REV. Suite 2727+1skip→2759+1skip.
 ### v3.35.0 (2026-07-10)
 - **WF14 rubric v2 — cross-session recurrence evidence wiring (#377, epic #378).** Prose-only change closing the epic's third child: WF14 friction findings gain an OPTIONAL `recurrence: <n> runs (index query, quoted)` tag backed by a #375 session-index query (distinct sessions), upgrading one-off observations to confirmed patterns at higher anchor confidence — the tag is optional, an index-less assessment stays fully valid, degraded-mode rules unchanged. Provenance boundary pinned: the index SUPPLEMENTS evidence; Step 1 marker-grepping remains the SOLE provenance source for run facts (a derived cache can lag mid-run). Step 4 routing: recurrence cross-links on filed findings; WF17 (#376) candidates at recurrence ≥ 3 runs may be filed via WF1 and then SHARE the `MAX_FEEDBACK_ISSUES_PER_RUN` pool — below threshold they stay in the WF17 report/queue, so a candidate never crowds out a defect. Rubric stamped v2 with a comparability note (no anchors changed; v1 reports comparable per-dimension). Tests: 4 new canonical-sentence drift guards red-before-green + the v1 stamp pin updated. No workflow-spine change → no diagram REV (wf14 sheet is skeletal; prose-only). Suite 2723+1skip→2727+1skip.
 ### v3.34.0 (2026-07-10)

--- a/hooks/org_runners_lib.py
+++ b/hooks/org_runners_lib.py
@@ -1,0 +1,300 @@
+"""hooks/org_runners_lib.py — tested core of `rawgentic:admit-to-org-runners` (#397).
+
+Migrating a repo's CI workflow from GitHub-hosted runners to an org self-hosted
+runner fleet is easy to get wrong in ways that silently kill CI: targeting a label
+that no ONLINE runner carries strands every future run (queued forever); a partial
+edit leaves a GitHub-hosted fallback that, on an org whose Actions minutes are
+exhausted, means CI is simply dead.
+
+This module is the fail-closed core the skill shells out to. The SKILL.md drives the
+`gh api` calls (runner-group discovery, admit); THIS decides what is safe to rewrite:
+
+  - classify each workflow `runs-on:` (hosted / already-fleet / expression / list),
+  - map a hosted OS -> the minimal labels a fleet job needs,
+  - confirm an ONLINE runner in the group carries those labels before editing,
+  - plan the migration fail-closed: ANY un-migratable hosted lane refuses the WHOLE
+    file (never a partial migration that leaves a hosted fallback),
+  - rewrite a hosted scalar into a `{group, labels}` block, touching nothing else.
+
+No new dependency: workflow YAML is scanned line-by-line (a targeted `runs-on:`
+rewrite that preserves every other byte), never round-tripped through a YAML dumper
+that would reflow comments/quoting.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+from atomic_write_lib import atomic_write_text
+
+# Minimal labels a job needs to land on a fleet runner of each OS. GitHub matches a
+# job to a runner iff the runner carries ALL the job's labels (case-insensitive), so
+# these are a SUBSET the online runner must satisfy — never the runner's full set.
+DEFAULT_OS_LABELS = {
+    "linux": ["self-hosted", "linux"],
+    "windows": ["self-hosted", "windows"],
+    "macos": ["self-hosted", "macos"],
+}
+
+# GitHub-HOSTED runner image label prefix -> OS. `ubuntu-latest`, `windows-2022`,
+# `macos-14` all split on the first '-'. A bare self-hosted label ('linux',
+# 'self-hosted', a custom name) has no hosted prefix and maps to None.
+_HOSTED_PREFIX = {"ubuntu": "linux", "windows": "windows", "macos": "macos"}
+
+# Tolerates spec-valid variants that still parse to a `runs-on` key: whitespace
+# before the colon and an optionally-quoted key. Missing these silently drops a
+# hosted lane (it reads as "clean"), which is the exact silent-CI-death to avoid.
+_RUNS_ON_RE = re.compile(r"""^(\s*)["']?runs-on["']?\s*:(.*)$""")
+
+
+def hosted_os(label: str) -> str | None:
+    """OS for a GitHub-HOSTED runner label (ubuntu*/windows*/macos*), else None.
+    Quotes are stripped first so a quoted scalar (`"ubuntu-latest"`) is still seen
+    as hosted — matching what `_list_items` already does for list members."""
+    if not label:
+        return None
+    head = label.strip().strip("'\"").lower().split("-", 1)[0]
+    return _HOSTED_PREFIX.get(head)
+
+
+def _strip_comment(s: str) -> str:
+    """Drop a trailing YAML inline comment (` # ...`) — a comment requires a space
+    before the `#`, so a `#` inside a value is preserved."""
+    return s.split(" #", 1)[0].strip()
+
+
+def _list_items(s: str) -> list[str]:
+    """Items of an inline `[a, b]` or a block `- a\\n- b` labels list."""
+    s = s.strip()
+    if s.startswith("["):
+        inner = s[1:s.rindex("]")] if "]" in s else s[1:]
+        return [x.strip().strip("'\"") for x in inner.split(",") if x.strip()]
+    out = []
+    for ln in s.splitlines():
+        ln = ln.strip()
+        if ln.startswith("- "):
+            out.append(ln[2:].strip().strip("'\""))
+    return out
+
+
+def classify_runs_on(raw: str) -> str:
+    """Classify the text after `runs-on:` (inline scalar OR a reconstructed block).
+
+    Returns one of:
+      - 'hosted'      a bare GitHub-hosted image label -> safely migratable
+      - 'fleet'       already a {group,labels} mapping or a self-hosted labels list
+      - 'expression'  contains `${{ }}` -> never rewritten (fails closed)
+      - 'manual'      any other shape (incl. a hosted label buried in a list)
+    """
+    s = _strip_comment(raw.strip())
+    if not s:
+        return "manual"
+    if "${{" in s:
+        return "expression"
+    if s.startswith("[") or s.lstrip().startswith("- "):
+        items = _list_items(s)
+        if any(hosted_os(i) for i in items):
+            return "manual"  # a hosted label inside a list — never mangle
+        if any(i.lower() == "self-hosted" for i in items):
+            return "fleet"
+        return "manual"
+    if "group:" in s:  # a {group, labels} mapping block -> already on the fleet
+        return "fleet"
+    if hosted_os(s):
+        return "hosted"
+    return "manual"  # an unknown bare scalar (a custom single self-hosted label, …)
+
+
+def labels_satisfied_by(required, runner_labels) -> bool:
+    """True iff every `required` label is present in `runner_labels` (GitHub label
+    matching is case-insensitive, so 'linux' is satisfied by a runner's 'Linux')."""
+    have = {str(x).lower() for x in (runner_labels or [])}
+    return all(str(x).lower() in have for x in (required or []))
+
+
+def online_runner_for(required, runners):
+    """First ONLINE runner whose labels satisfy `required`, else None. An offline
+    runner that would match is never selected — migrating to it strands the job."""
+    for r in runners or []:
+        if str(r.get("status", "")).lower() == "online" \
+                and labels_satisfied_by(required, r.get("labels", [])):
+            return r
+    return None
+
+
+def find_runs_on(text: str) -> list[dict]:
+    """Every `runs-on:` in the workflow, with its classification. Handles the inline
+    scalar form and the block-mapping form (`runs-on:` then indented `group:`/`labels:`)."""
+    lines = text.splitlines()
+    occ = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        m = _RUNS_ON_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        indent, rest = m.group(1), _strip_comment(m.group(2).strip())
+        if rest:
+            value_repr, end = rest, i
+        else:  # block form — gather following lines indented deeper than runs-on
+            block, j = [], i + 1
+            while j < n:
+                ln = lines[j]
+                if ln.strip() == "":
+                    j += 1
+                    continue
+                if len(ln) - len(ln.lstrip()) <= len(indent):
+                    break
+                block.append(ln)
+                j += 1
+            value_repr, end = "\n".join(block), j - 1
+        kind = classify_runs_on(value_repr)
+        occ.append({
+            "line": i, "indent": indent, "kind": kind, "raw": value_repr,
+            "os": hosted_os(value_repr) if kind == "hosted" else None,
+        })
+        i = end + 1
+    return occ
+
+
+def has_hosted_remnant(text: str) -> bool:
+    """True if any `runs-on:` still resolves (directly) to a GitHub-hosted image —
+    a bare hosted scalar, or a hosted label buried in a list. Expression/matrix
+    forms are NOT decidable here; the migration planner refuses those as 'manual'."""
+    for o in find_runs_on(text):
+        if o["kind"] == "hosted":
+            return True
+        if any(hosted_os(item) for item in _list_items(o["raw"])):
+            return True
+    return False
+
+
+def is_migrated(text: str) -> bool:
+    """No directly-hosted `runs-on:` remains (the post-migration / idempotency target)."""
+    return not has_hosted_remnant(text)
+
+
+def _verdict(jobs: list[dict]) -> str:
+    """Overall verdict, fail-closed: any blocked lane blocks the whole file; any
+    manual lane needs a human; otherwise ready if there's work, else noop."""
+    actions = {j["action"] for j in jobs}
+    if "blocked" in actions:
+        return "blocked"
+    if "manual" in actions:
+        return "manual"
+    if "migrate" in actions:
+        return "ready"
+    return "noop"
+
+
+def plan_migration(text: str, group: str, runners, os_labels=None) -> dict:
+    """Per-`runs-on` migration plan + an overall fail-closed verdict."""
+    os_labels = os_labels or DEFAULT_OS_LABELS
+    jobs = []
+    for o in find_runs_on(text):
+        base = {"line": o["line"], "indent": o["indent"], "kind": o["kind"], "os": o["os"]}
+        if o["kind"] == "fleet":
+            jobs.append({**base, "action": "skip", "reason": "already on the fleet"})
+        elif o["kind"] == "hosted":
+            required = os_labels.get(o["os"])
+            if required and online_runner_for(required, runners):
+                jobs.append({**base, "action": "migrate", "target_labels": required,
+                             "reason": f"hosted {o['os']} -> group '{group}' {required}"})
+            else:
+                jobs.append({**base, "action": "blocked",
+                             "reason": f"no ONLINE runner in group '{group}' "
+                                       f"carrying labels {required}"})
+        elif o["kind"] == "expression":
+            jobs.append({**base, "action": "manual",
+                         "reason": "runs-on is an expression (${{ }}); migrate by hand"})
+        else:
+            jobs.append({**base, "action": "manual",
+                         "reason": "runs-on shape not safely rewritable; migrate by hand"})
+    return {"group": group, "verdict": _verdict(jobs), "jobs": jobs}
+
+
+def rewrite_migration(text: str, plan: dict, group: str) -> str:
+    """Apply the plan's 'migrate' jobs (hosted scalar -> {group,labels} block),
+    preserving every other line. Refuses unless the verdict is ready/noop."""
+    if plan["verdict"] not in ("ready", "noop"):
+        raise ValueError(
+            f"refusing to rewrite: verdict '{plan['verdict']}' — resolve the "
+            f"blocked/manual lanes first (never leave a hosted fallback)")
+    if plan["verdict"] == "noop":
+        return text
+    lines = text.splitlines(keepends=True)
+    # bottom-to-top so earlier edits don't shift later line indices
+    for j in sorted((j for j in plan["jobs"] if j["action"] == "migrate"),
+                    key=lambda j: j["line"], reverse=True):
+        idx, indent = j["line"], j["indent"]
+        orig = lines[idx]
+        # Never "" — an unterminated last line would otherwise collapse the block
+        # onto one line (invalid YAML the post-check would wrongly pass).
+        eol = "\r\n" if orig.endswith("\r\n") else "\n"
+        labels = ", ".join(j["target_labels"])
+        lines[idx] = (f"{indent}runs-on:{eol}"
+                      f"{indent}  group: {group}{eol}"
+                      f"{indent}  labels: [{labels}]{eol}")
+    return "".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI — the SKILL.md shells out to these; runner data arrives as JSON on stdin
+# (from `gh api …/runner-groups/<id>/runners`), never fetched here.
+# ---------------------------------------------------------------------------
+
+def _load_runners(arg: str):
+    data = sys.stdin.read() if arg == "-" else open(arg, encoding="utf-8").read()
+    return json.loads(data)
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(prog="org_runners_lib")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    for name in ("plan", "rewrite"):
+        sp = sub.add_parser(name)
+        sp.add_argument("--workflow", required=True)
+        sp.add_argument("--group", required=True)
+        sp.add_argument("--runners", required=True,
+                        help="path to runner JSON, or '-' for stdin")
+        if name == "rewrite":
+            sp.add_argument("--in-place", action="store_true")
+    cp = sub.add_parser("check-hosted")
+    cp.add_argument("--workflow", required=True)
+    args = p.parse_args(argv)
+
+    text = open(args.workflow, encoding="utf-8").read()
+
+    if args.cmd == "check-hosted":
+        remnant = has_hosted_remnant(text)
+        print(json.dumps({"hosted_remnant": remnant}))
+        return 1 if remnant else 0
+
+    runners = _load_runners(args.runners)
+    plan = plan_migration(text, args.group, runners)
+
+    if args.cmd == "plan":
+        print(json.dumps(plan, indent=2))
+        return 0 if plan["verdict"] in ("ready", "noop") else 1
+
+    # rewrite
+    try:
+        out = rewrite_migration(text, plan, args.group)
+    except ValueError as e:
+        print(json.dumps({"error": str(e), "verdict": plan["verdict"]}), file=sys.stderr)
+        return 1
+    if has_hosted_remnant(out):  # fail-closed: never write a hosted fallback back out
+        print(json.dumps({"error": "post-rewrite hosted remnant detected"}), file=sys.stderr)
+        return 1
+    if args.in_place:
+        atomic_write_text(args.workflow, out)
+    else:
+        sys.stdout.write(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rawgentic",
-  "version": "3.35.1",
-  "description": "8 SDLC workflow skills + 7 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
+  "version": "3.36.0",
+  "description": "8 SDLC workflow skills + 8 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, org self-hosted runner admission, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",
     "url": "https://github.com/3D-Stories"
@@ -27,7 +27,7 @@
   "interface": {
     "displayName": "Rawgentic",
     "shortDescription": "SDLC workflow skills with TDD, quality gates, and project config.",
-    "longDescription": "Rawgentic packages 18 workflow and workspace skills for disciplined software delivery. This Codex Phase 1 package exposes the skills through a private marketplace while Codex hook support is planned for Phase 2.",
+    "longDescription": "Rawgentic packages 19 workflow and workspace skills for disciplined software delivery. This Codex Phase 1 package exposes the skills through a private marketplace while Codex hook support is planned for Phase 2.",
     "developerName": "3D-Stories",
     "category": "Productivity",
     "capabilities": [

--- a/plugins/rawgentic/skills/admit-to-org-runners
+++ b/plugins/rawgentic/skills/admit-to-org-runners
@@ -1,0 +1,1 @@
+../../../skills/admit-to-org-runners

--- a/scripts/sync_shared_blocks.py
+++ b/scripts/sync_shared_blocks.py
@@ -34,7 +34,7 @@ MANIFEST = {
         "config-loading.md": [
             # WF4/7/8/9/10/12 removed 2026-07-04 (#160): deprecation stubs carry
             # no config-loading block; removal at v3.0.0 (#161).
-            "adversarial-review", "incident",
+            "admit-to-org-runners", "adversarial-review", "incident",
             "implement-feature", "fix-bug", "peer-consult", "run-feedback", "scan",
         ],
     },

--- a/skills/admit-to-org-runners/SKILL.md
+++ b/skills/admit-to-org-runners/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: rawgentic:admit-to-org-runners
+description: Admit the BOUND project's repo to an org self-hosted runner group and migrate its CI workflow from GitHub-hosted runners to the fleet. Use when a project's `ci.yml` runs on `ubuntu-latest`/`windows-latest`/`macos-*` and you want it on a shared org fleet instead — e.g. org Actions minutes are exhausted (an account-wide pool that blocks hosted jobs in every repo), or the workspace directive is "default self-hosted, never GitHub-hosted." Dry-run by default; fail-closed (never strands CI on a label no online runner has, never leaves a hosted fallback); idempotent. Do NOT use to CREATE runners/groups, to add NEW OS jobs to a workflow (it only migrates existing `runs-on`), or for repo-level (non-org) runners. Invoke with /rawgentic:admit-to-org-runners.
+argument-hint: "[--group <name>] [--admin-token-file <path>] [--workflow <path>] [--apply]  (dry-run unless --apply)"
+---
+
+# Admit to Org Runners — fleet admission + CI migration
+
+<role>
+You admit the BOUND project's repo to an organization self-hosted runner group and
+migrate its CI workflow off GitHub-hosted runners onto that fleet. You are fail-closed
+by construction: you verify an ONLINE runner carries the exact labels a job will target
+BEFORE editing anything, you NEVER leave (or instate) a GitHub-hosted fallback, and you
+are idempotent — a repo already admitted and a workflow already on the fleet are a clean
+no-op. Dry-run is the default; you write nothing and open nothing until `--apply`.
+
+Credential discipline is absolute: the org runner API needs a SEPARATE admin credential
+from ordinary repo ops. The admin token is used ONLY on `orgs/<org>/actions/runner-*`
+endpoints; the default `gh` token is used for everything repo/workflow/PR. You never
+cross them, and a missing admin token is a STOP — never a fall back to the default token,
+never a fall back to hosted runners.
+</role>
+
+<config-loading>
+Before executing any workflow steps, load the project configuration:
+
+1. Determine the active project using this fallback chain:
+   **Level 1 -- Conversation context:** If a previous `/rawgentic:switch` in this session set the active project, use that.
+   **Level 2 -- Session registry:** Read `claude_docs/session_registry.jsonl`. Grep for your session_id. If found, use the project from the most recent matching line.
+   **Level 3 -- Workspace default:** Read `.rawgentic_workspace.json` from the Claude root directory. If exactly one project has `active == true`, use it. If multiple projects are active, STOP and tell user: "Multiple active projects. Run `/rawgentic:switch <name>` to bind this session."
+
+   At any level:
+   - `.rawgentic_workspace.json` missing -> STOP. Tell user: "No rawgentic workspace found. Run /rawgentic:new-project."
+   - `.rawgentic_workspace.json` malformed -> STOP. Tell user: "Workspace file is corrupted. Run /rawgentic:new-project to regenerate, or fix manually."
+   - No active project found at any level -> STOP. Tell user: "No active project. Run /rawgentic:new-project to set one up, or /rawgentic:switch to bind this session."
+   - **Path resolution:** The `activeProject.path` may be relative (e.g., `./projects/my-app`). Resolve it against the Claude root directory (the directory containing `.rawgentic_workspace.json`) to get the absolute path for file operations.
+
+2. Load the config and derive capabilities with the helper CLI (one tested
+   source of truth — never hand-derive the `capabilities` object, so every
+   config-driven skill and the docs table cannot drift apart):
+   ```bash
+   python3 hooks/capabilities_lib.py derive \
+     --config <activeProject.path>/.rawgentic.json
+   ```
+   - **Non-zero exit** -> the config is missing, corrupt, or invalid. **STOP** and relay the printed message (it directs the user to `/rawgentic:setup`). A `config.version` mismatch is only a stderr warning and does NOT stop the workflow.
+   - **Exit 0** -> stdout is `{"config": {...}, "capabilities": {...}}`. Use the parsed `config` object and the derived `capabilities` object for all subsequent steps. The `capabilities` fields are: `has_tests`, `test_commands`, `has_ci`, `ci_quarantined`, `ci_quarantine_reason`, `ci_quarantined_since`, `has_deploy`, `deploy_method`, `has_database`, `has_docker`, `project_type`, `repo`, `default_branch`, `migration_dir`. Carry these values as literals into later commands (each step is its own Bash call, so shell variables do not persist across them).
+
+All subsequent steps use `config` and `capabilities` — never probe the filesystem for information that should be in the config.
+</config-loading>
+
+## Step 1: Resolve the bound repo and org
+
+From the loaded `capabilities`:
+- `repo` = `owner/name` (e.g. `3D-Stories/kukakuka`). **`org` = the `owner` segment.**
+- `default_branch` (for the migration PR base).
+
+If `capabilities.repo` is empty, STOP: the project config has no repo — run `/rawgentic:setup`.
+
+## Step 2: Resolve the admin credential (fail-closed)
+
+The org runner API requires a credential with **org "Self-hosted runners: Read/Write"**.
+Resolve it in this order; **do not** fall back to the default `gh` token:
+
+1. `--admin-token-file <path>` → the token is the file's contents.
+2. `$RAWGENTIC_RUNNER_ADMIN_TOKEN` → the token is the env value directly.
+3. Neither present → **STOP**: "No runner-admin credential. Pass `--admin-token-file
+   <path>` (a file holding a fine-grained PAT with org Self-hosted-runners R/W) or set
+   `$RAWGENTIC_RUNNER_ADMIN_TOKEN`. The default gh token is NOT used for the org runner
+   API." Do not proceed.
+
+Reference the token by its **path/name only** — never echo its value into chat, commits,
+or issues. In every org-API call below, supply it as `GH_TOKEN=$(cat <admin-token-file>)`
+(or `GH_TOKEN="$RAWGENTIC_RUNNER_ADMIN_TOKEN"`) on that single command — nowhere else.
+
+## Step 3: Discover the runner group and its ONLINE runners
+
+List the org's runner groups (admin token):
+
+```bash
+GH_TOKEN=$(cat <admin-token-file>) gh api --paginate \
+  orgs/<org>/actions/runner-groups --jq '.runner_groups[] | {id, name, visibility}'
+```
+
+Choose the group:
+- `--group <name>` given → select the group with that name; if none matches, STOP and
+  list the available group names.
+- omitted and exactly one group exists → use it.
+- omitted and several exist → present the list and ask which group.
+
+Then fetch the group's runners with their status + labels (admin token):
+
+```bash
+GH_TOKEN=$(cat <admin-token-file>) gh api --paginate \
+  orgs/<org>/actions/runner-groups/<group_id>/runners \
+  --jq '[.runners[] | {name, status, labels: [.labels[].name]}]'
+```
+
+Keep this JSON array — it is the `--runners` input to the migration planner. If the
+group has **zero online runners**, STOP: migrating now would strand every job.
+
+## Step 4: Admit status (idempotency check — read only here)
+
+Is the bound repo already in the group?
+
+```bash
+GH_TOKEN=$(cat <admin-token-file>) gh api --paginate \
+  orgs/<org>/actions/runner-groups/<group_id>/repositories --jq '.repositories[].full_name'
+```
+
+If `<owner>/<name>` is present → **already admitted**; the admit step is a no-op. Record
+this; do not re-admit.
+
+## Step 5: Plan the CI migration (dry-run — the default)
+
+Pick the workflow file(s):
+- `--workflow <path>` → just that file.
+- omitted → every `.github/workflows/*.yml` / `*.yaml` in the repo.
+
+For each workflow, feed the Step-3 runner JSON to the planner (it decides what is safe —
+you do not hand-parse YAML):
+
+```bash
+printf '%s' '<runners-json>' | python3 hooks/org_runners_lib.py \
+  plan --workflow <path> --group <group_name> --runners -
+```
+
+Read the JSON `verdict`:
+- **`ready`** — one or more hosted `runs-on` map to an online runner in the group; each
+  `migrate` job names its `target_labels`.
+- **`noop`** — already on the fleet (or nothing hosted). Nothing to do for this file.
+- **`blocked`** — a hosted job has **no online runner** in the group with the needed
+  labels. Migrating would strand it → this file is NOT migrated; report the blocked job.
+- **`manual`** — a `runs-on` shape the planner will not rewrite (a `${{ }}` expression /
+  matrix, or an unrecognized form). It is NOT touched; report it for hand-migration.
+
+**Fail-closed rule:** only `ready`/`noop` files are eligible to apply. A `blocked` or
+`manual` file is left exactly as-is — never a partial edit that leaves a hosted fallback.
+
+## Step 6: Present the plan and stop (unless `--apply`)
+
+Show, together (a quality-gate presentation — never compressed away):
+- admit status (already-in-group vs will-admit),
+- per-workflow verdict + each job's action/reason,
+- the exact diff each `ready` file would get (hosted scalar → `{group, labels}` block),
+- any `blocked`/`manual` lanes, called out as the reason the migration is incomplete.
+
+**Without `--apply`: stop here.** This is a dry run — nothing was admitted, nothing edited.
+
+## Step 7: Apply (`--apply` only)
+
+Perform, in order. If everything is already admitted + on the fleet, report a clean
+**no-op** and stop.
+
+**7a — Admit the repo (admin token), only if Step 4 said it isn't a member:**
+
+```bash
+REPO_ID=$(gh api repos/<owner>/<name> --jq '.id')          # default token — repo read
+GH_TOKEN=$(cat <admin-token-file>) gh api --method PUT \    # admin token — org runner API
+  orgs/<org>/actions/runner-groups/<group_id>/repositories/$REPO_ID
+```
+
+(PUT is idempotent — re-admitting a member is harmless.)
+
+**7b — Migrate each `ready` workflow as a PR (default token — repo ops):**
+
+1. Branch from fresh `origin/<default_branch>`: `git fetch origin` then
+   `git checkout -b ci/migrate-<group_name>-fleet origin/<default_branch>`.
+2. Rewrite in place (the planner re-verifies and refuses anything not `ready`, and
+   fails closed if a hosted remnant would survive):
+   ```bash
+   printf '%s' '<runners-json>' | python3 hooks/org_runners_lib.py \
+     rewrite --workflow <path> --group <group_name> --runners - --in-place
+   ```
+3. Confirm no hosted fallback survived (exit 0 required):
+   ```bash
+   python3 hooks/org_runners_lib.py check-hosted --workflow <path>
+   ```
+   Non-zero → STOP; do not commit a workflow that still has a hosted `runs-on`.
+4. Stage **only** the workflow file(s) by name, commit (conventional
+   `ci: migrate <repo> CI to org self-hosted fleet <group_name>`), push, and open a PR
+   against `<default_branch>`. Body: which jobs moved to which `{group, labels}`, and the
+   admit status. A repo that cannot take a PR should not be on the fleet — the migration
+   ships as a reviewable PR, never a direct push to the default branch.
+
+Report the PR URL. Do NOT merge it (no standing merge grant).
+
+<completion-gate>
+Before declaring done: the admit status was read (Step 4), every targeted workflow was
+planned (Step 5) with its verdict surfaced, and — on `--apply` — the repo is a group
+member, each migrated file passes `check-hosted` (no hosted remnant), and a PR is open
+(or a clean no-op was reported). The admin token was used ONLY on `orgs/<org>/actions/…`
+calls and never echoed by value. On a dry run, confirm nothing was admitted or edited.
+</completion-gate>

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -31,14 +31,15 @@ def test_skill_dir_and_frontmatter_exist():
 def test_marketplace_registers_skill():
     mp = json.loads((REPO_ROOT / ".claude-plugin" / "marketplace.json").read_text())
     skills = mp["plugins"][0]["skills"]
-    assert "./skills/adversarial-review" in skills
-    # alphabetical placement right after add-exception
-    assert skills.index("./skills/adversarial-review") == skills.index("./skills/add-exception") + 1
+    assert "./skills/admit-to-org-runners" in skills
+    # alphabetical placement: add-exception < admit-to-org-runners < adversarial-review
+    assert skills.index("./skills/admit-to-org-runners") == skills.index("./skills/add-exception") + 1
+    assert skills.index("./skills/adversarial-review") == skills.index("./skills/admit-to-org-runners") + 1
 
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.35.1"
+    assert plugin["version"] == "3.36.0"
 
 
 def test_descriptions_consistent_count():
@@ -73,7 +74,7 @@ def test_readme_count_strings_updated():
         f"plugin description breakdown {breakdown} must sum to the "
         f"{n_skills} skills on disk"
     )
-    assert "All 8 config-driven skills" in readme
+    assert "All 9 config-driven skills" in readme
     # #271: computed from disk, never a hand-maintained literal. A skill
     # "has evals" iff evals.json exists in its own evals/ dir or its
     # -workspace evals/ dir.
@@ -104,7 +105,7 @@ def test_readme_count_strings_updated():
         f"{sorted(set(skills) - have - {'peer-consult'})} (peer-consult is "
         f"called out separately as a stub)"
     )
-    assert "7 workspace management" in readme  # #113 — README count must match plugin/marketplace descriptions
+    assert "8 workspace management" in readme  # #113 — README count must match plugin/marketplace descriptions
 
 
 def test_readme_changelog_has_no_spliced_headings():

--- a/tests/hooks/test_headless.py
+++ b/tests/hooks/test_headless.py
@@ -1303,7 +1303,7 @@ class TestSkillCountCanary:
     """Canary: assert the number of SKILL.md files with <config-loading> matches expected."""
 
     SKILLS_DIR = Path(__file__).resolve().parent.parent.parent / "skills"
-    EXPECTED_CONFIG_LOADING_COUNT = 8  # -6 deprecated stubs (#160: WF4/7/8/9/10/12), +scan (#160), +run-feedback (#337); was 12
+    EXPECTED_CONFIG_LOADING_COUNT = 9  # -6 deprecated stubs (#160: WF4/7/8/9/10/12), +scan (#160), +run-feedback (#337), +admit-to-org-runners (#397); was 12
 
     def test_config_loading_skill_count(self):
         """If a new workflow skill is added, this test reminds you to wire in the config-loading preamble."""

--- a/tests/hooks/test_org_runners.py
+++ b/tests/hooks/test_org_runners.py
@@ -1,0 +1,318 @@
+"""Tests for hooks/org_runners_lib.py — the tested core of the
+`rawgentic:admit-to-org-runners` skill (#397).
+
+Covers the risky logic the skill must never get wrong:
+  - classifying a workflow `runs-on:` (hosted / already-fleet / expression / list),
+  - OS -> required-label mapping,
+  - matching required labels against an ONLINE runner (case-insensitive subset),
+  - planning a migration fail-closed (any un-migratable hosted lane refuses the
+    whole file — never a partial migration that leaves a hosted fallback),
+  - rewriting a hosted scalar into a `{group, labels}` block without touching
+    anything else,
+  - detecting a hosted remnant (idempotency + post-migration verification).
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+import org_runners_lib as orl  # noqa: E402
+
+CLI = HOOKS_DIR / "org_runners_lib.py"
+
+# Real fleet shape (3ds-fleet) — online runners carry a superset of the minimal
+# [self-hosted, <os>] labels the migration targets.
+FLEET_RUNNERS = [
+    {"name": "3ds-fleet-linux", "status": "online",
+     "labels": ["self-hosted", "Linux", "X64", "saystory"]},
+    {"name": "3ds-fleet-windows", "status": "online",
+     "labels": ["self-hosted", "X64", "saystory", "Windows"]},
+    {"name": "3ds-fleet-mac", "status": "offline",
+     "labels": ["self-hosted", "macOS", "ARM64", "fleet"]},
+]
+
+HOSTED_CI = """\
+name: ci
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo test
+"""
+
+FLEET_CI = """\
+name: ci
+on: [push]
+jobs:
+  test:
+    runs-on:
+      group: 3ds-fleet
+      labels: [self-hosted, linux]
+    steps:
+      - run: cargo test
+"""
+
+MATRIX_CI = """\
+name: ci
+on: [push]
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: cargo test
+"""
+
+SELFHOSTED_LIST_CI = """\
+name: ci
+on: [push]
+jobs:
+  test:
+    runs-on: [self-hosted, linux]
+    steps:
+      - run: cargo test
+"""
+
+
+# ---------- hosted_os ----------
+
+def test_hosted_os_maps_github_labels():
+    assert orl.hosted_os("ubuntu-latest") == "linux"
+    assert orl.hosted_os("ubuntu-22.04") == "linux"
+    assert orl.hosted_os("windows-latest") == "windows"
+    assert orl.hosted_os("windows-2022") == "windows"
+    assert orl.hosted_os("macos-latest") == "macos"
+    assert orl.hosted_os("macos-14") == "macos"
+
+
+def test_hosted_os_case_insensitive():
+    assert orl.hosted_os("Ubuntu-Latest") == "linux"
+
+
+def test_hosted_os_none_for_self_hosted_or_custom():
+    assert orl.hosted_os("self-hosted") is None
+    assert orl.hosted_os("my-custom-runner") is None
+    assert orl.hosted_os("linux") is None  # bare 'linux' is a self-hosted label, not hosted
+
+
+# ---------- classify_runs_on ----------
+
+def test_classify_hosted():
+    assert orl.classify_runs_on("ubuntu-latest") == "hosted"
+
+
+def test_classify_expression():
+    assert orl.classify_runs_on("${{ matrix.os }}") == "expression"
+
+
+def test_classify_selfhosted_list():
+    assert orl.classify_runs_on("[self-hosted, linux]") == "fleet"
+
+
+def test_classify_hosted_inside_list_is_manual():
+    # A list that names a hosted label can't be safely 1:1 mapped -> manual, never mangled.
+    assert orl.classify_runs_on("[ubuntu-latest]") == "manual"
+
+
+# ---------- labels_satisfied_by ----------
+
+def test_labels_subset_case_insensitive():
+    assert orl.labels_satisfied_by(
+        ["self-hosted", "linux"], ["self-hosted", "Linux", "X64", "saystory"])
+
+
+def test_labels_not_satisfied_when_missing():
+    assert not orl.labels_satisfied_by(
+        ["self-hosted", "windows"], ["self-hosted", "Linux", "X64"])
+
+
+# ---------- online_runner_for ----------
+
+def test_online_runner_found_for_linux():
+    r = orl.online_runner_for(["self-hosted", "linux"], FLEET_RUNNERS)
+    assert r and r["name"] == "3ds-fleet-linux"
+
+
+def test_offline_runner_never_selected():
+    # mac runner satisfies the labels but is OFFLINE -> migration must not target it.
+    assert orl.online_runner_for(["self-hosted", "macos"], FLEET_RUNNERS) is None
+
+
+# ---------- find_runs_on ----------
+
+def test_find_runs_on_hosted_scalar():
+    occ = orl.find_runs_on(HOSTED_CI)
+    assert len(occ) == 1
+    assert occ[0]["kind"] == "hosted"
+    assert occ[0]["os"] == "linux"
+
+
+def test_find_runs_on_fleet_block():
+    occ = orl.find_runs_on(FLEET_CI)
+    assert len(occ) == 1
+    assert occ[0]["kind"] == "fleet"
+
+
+# ---------- has_hosted_remnant / is_migrated ----------
+
+def test_hosted_ci_has_remnant():
+    assert orl.has_hosted_remnant(HOSTED_CI)
+    assert not orl.is_migrated(HOSTED_CI)
+
+
+def test_fleet_ci_has_no_remnant():
+    assert not orl.has_hosted_remnant(FLEET_CI)
+    assert orl.is_migrated(FLEET_CI)
+
+
+# ---------- plan_migration ----------
+
+def test_plan_hosted_ready():
+    plan = orl.plan_migration(HOSTED_CI, "3ds-fleet", FLEET_RUNNERS)
+    assert plan["verdict"] == "ready"
+    assert plan["jobs"][0]["action"] == "migrate"
+    assert plan["jobs"][0]["target_labels"] == ["self-hosted", "linux"]
+
+
+def test_plan_already_fleet_is_noop():
+    plan = orl.plan_migration(FLEET_CI, "3ds-fleet", FLEET_RUNNERS)
+    assert plan["verdict"] == "noop"
+    assert plan["jobs"][0]["action"] == "skip"
+
+
+def test_plan_blocked_when_no_online_runner():
+    # macos hosted job but the only macos runner is offline -> STOP, never strand CI.
+    macos_ci = HOSTED_CI.replace("ubuntu-latest", "macos-latest")
+    plan = orl.plan_migration(macos_ci, "3ds-fleet", FLEET_RUNNERS)
+    assert plan["verdict"] == "blocked"
+    assert plan["jobs"][0]["action"] == "blocked"
+
+
+def test_plan_expression_is_manual_and_fails_closed():
+    plan = orl.plan_migration(MATRIX_CI, "3ds-fleet", FLEET_RUNNERS)
+    assert plan["verdict"] == "manual"
+    assert plan["jobs"][0]["action"] == "manual"
+
+
+def test_plan_selfhosted_list_is_noop():
+    plan = orl.plan_migration(SELFHOSTED_LIST_CI, "3ds-fleet", FLEET_RUNNERS)
+    assert plan["verdict"] == "noop"
+
+
+# ---------- rewrite_migration ----------
+
+def test_rewrite_hosted_scalar_to_block():
+    plan = orl.plan_migration(HOSTED_CI, "3ds-fleet", FLEET_RUNNERS)
+    out = orl.rewrite_migration(HOSTED_CI, plan, "3ds-fleet")
+    assert "runs-on:\n      group: 3ds-fleet\n      labels: [self-hosted, linux]" in out
+    # nothing else touched
+    assert "name: ci" in out and "- run: cargo test" in out
+    # result is fully migrated (idempotent target)
+    assert orl.is_migrated(out)
+
+
+def test_rewrite_refuses_when_not_ready():
+    plan = orl.plan_migration(MATRIX_CI, "3ds-fleet", FLEET_RUNNERS)
+    try:
+        orl.rewrite_migration(MATRIX_CI, plan, "3ds-fleet")
+        assert False, "expected refusal on a non-ready plan"
+    except ValueError:
+        pass
+
+
+def test_rewrite_of_noop_is_identity():
+    plan = orl.plan_migration(FLEET_CI, "3ds-fleet", FLEET_RUNNERS)
+    assert orl.rewrite_migration(FLEET_CI, plan, "3ds-fleet") == FLEET_CI
+
+
+# ---------- CLI ----------
+
+def _run(args, stdin=None):
+    return subprocess.run(
+        [sys.executable, str(CLI), *args], input=stdin,
+        capture_output=True, text=True)
+
+
+def test_cli_plan_ready_exit0(tmp_path):
+    wf = tmp_path / "ci.yml"
+    wf.write_text(HOSTED_CI)
+    r = _run(["plan", "--workflow", str(wf), "--group", "3ds-fleet",
+              "--runners", "-"], stdin=json.dumps(FLEET_RUNNERS))
+    assert r.returncode == 0, r.stderr
+    assert json.loads(r.stdout)["verdict"] == "ready"
+
+
+def test_cli_plan_blocked_exit1(tmp_path):
+    wf = tmp_path / "ci.yml"
+    wf.write_text(HOSTED_CI.replace("ubuntu-latest", "macos-latest"))
+    r = _run(["plan", "--workflow", str(wf), "--group", "3ds-fleet",
+              "--runners", "-"], stdin=json.dumps(FLEET_RUNNERS))
+    assert r.returncode == 1
+    assert json.loads(r.stdout)["verdict"] == "blocked"
+
+
+def test_cli_check_hosted_detects_remnant(tmp_path):
+    wf = tmp_path / "ci.yml"
+    wf.write_text(HOSTED_CI)
+    assert _run(["check-hosted", "--workflow", str(wf)]).returncode == 1
+    wf.write_text(FLEET_CI)
+    assert _run(["check-hosted", "--workflow", str(wf)]).returncode == 0
+
+
+def test_cli_rewrite_in_place(tmp_path):
+    wf = tmp_path / "ci.yml"
+    wf.write_text(HOSTED_CI)
+    r = _run(["rewrite", "--workflow", str(wf), "--group", "3ds-fleet",
+              "--runners", "-", "--in-place"], stdin=json.dumps(FLEET_RUNNERS))
+    assert r.returncode == 0, r.stderr
+    assert orl.is_migrated(wf.read_text())
+
+
+# ---------- review hardening (#397 diff review): unusual-but-valid YAML shapes ----------
+# A hosted lane in any of these spec-valid shapes must NEVER read as clean/noop —
+# that is the silent-CI-death the module exists to prevent.
+
+SPACE_COLON_CI = HOSTED_CI.replace("runs-on: ubuntu-latest", "runs-on : ubuntu-latest")
+QUOTED_KEY_CI = HOSTED_CI.replace("runs-on: ubuntu-latest", '"runs-on": ubuntu-latest')
+QUOTED_VAL_CI = HOSTED_CI.replace("runs-on: ubuntu-latest", 'runs-on: "ubuntu-latest"')
+
+
+def test_hosted_os_strips_quotes():
+    assert orl.hosted_os('"ubuntu-latest"') == "linux"
+    assert orl.hosted_os("'macos-14'") == "macos"
+
+
+def test_space_before_colon_detected_as_hosted():
+    occ = orl.find_runs_on(SPACE_COLON_CI)
+    assert len(occ) == 1 and occ[0]["kind"] == "hosted" and occ[0]["os"] == "linux"
+    assert orl.has_hosted_remnant(SPACE_COLON_CI)
+    assert orl.plan_migration(SPACE_COLON_CI, "g", FLEET_RUNNERS)["verdict"] == "ready"
+
+
+def test_quoted_key_detected_as_hosted():
+    assert orl.has_hosted_remnant(QUOTED_KEY_CI)
+    assert orl.plan_migration(QUOTED_KEY_CI, "g", FLEET_RUNNERS)["verdict"] == "ready"
+
+
+def test_quoted_value_is_hosted_not_clean():
+    # the safety primitive (check-hosted / is_migrated) must not call a
+    # genuinely-hosted file clean, and it should be migratable.
+    assert orl.has_hosted_remnant(QUOTED_VAL_CI)
+    assert not orl.is_migrated(QUOTED_VAL_CI)
+    assert orl.plan_migration(QUOTED_VAL_CI, "g", FLEET_RUNNERS)["verdict"] == "ready"
+
+
+def test_rewrite_runs_on_as_last_line_no_newline():
+    text = "jobs:\n  t:\n    runs-on: ubuntu-latest"  # no trailing newline
+    plan = orl.plan_migration(text, "3ds-fleet", FLEET_RUNNERS)
+    out = orl.rewrite_migration(text, plan, "3ds-fleet")
+    assert orl.is_migrated(out)
+    # the block must be three separate lines, never collapsed onto one
+    assert "runs-on:\n      group: 3ds-fleet\n      labels: [self-hosted, linux]" in out
+    assert "runs-on:      group" not in out


### PR DESCRIPTION
Closes #397.

New operational plugin skill **`/rawgentic:admit-to-org-runners`** — admits the bound
project's repo to an org self-hosted runner group and migrates its CI workflow off
GitHub-hosted runners onto the fleet. Dry-run by default; fail-closed; idempotent.

## What it does
1. Resolves the bound repo via the shared `<config-loading>` block (`capabilities.repo`); org = owner.
2. **Separate creds:** runner-admin token (`--admin-token-file` / `$RAWGENTIC_RUNNER_ADMIN_TOKEN`) used ONLY on `orgs/<org>/actions/runner-*`; default `gh` token for repo/PR ops. Missing admin token = STOP (never the default token on the org API, never a hosted fallback).
3. Discovers the group's ONLINE runners + labels; **verifies an online runner carries the target labels before editing** (never strands CI on a label no runner has).
4. **Idempotent:** repo already in group → skip admit; workflow already on the fleet → skip edit; all done → clean no-op.
5. **Never a hosted fallback:** any hosted `runs-on` it can't map, or a `${{ }}`/matrix shape it won't safely rewrite, refuses the whole file (no partial migration).
6. Dry-run default; `--apply` admits the repo and ships the `ci.yml` migration as a **PR** (a repo that can't do PR rigor shouldn't be on the fleet).

## Where the logic lives
`hooks/org_runners_lib.py` — pure, tested core (workflow `runs-on` parse/classify, OS→label map, online-runner label match, hosted-remnant detection, plan/rewrite). No new dependency: workflow YAML is scanned line-by-line, never round-tripped through a dumper. `SKILL.md` orchestrates the `gh api` calls.

## Review
An independent Opus diff review (empirically confirmed against pyyaml) found **3 real gaps**, all fixed here with red-before-green tests:
- **HIGH** — `runs-on : x` (space before colon) / `"runs-on": x` (quoted key) slipped past the line matcher → hosted lane silently read as "clean". Broadened the anchor.
- **MEDIUM** — quoted scalar value `runs-on: "ubuntu-latest"` read as clean by the `check-hosted`/`is_migrated` safety primitive. `hosted_os` now strips quotes.
- **LOW** — `rewrite_migration` collapsed the block when `runs-on` was the file's last line with no trailing newline. `eol` never `""` now.

## Gates
- Full suite **2759 passed, 1 skipped** (baseline 2727+1skip → +32 new tests, exit 0).
- Both pylint lanes 10.00/10.
- `security_scan.py scan --base-ref origin/main`: PASS (iac/sca skips visible, not silent).
- Version ×3 (3.36.0); README changelog; registered across all surfaces (`add-skill` list) + count guards green.
- **No workflow-spine change → no diagram REV.**

## Not yet done (honest status)
The live end-to-end **dogfood against `3D-Stories/kukakuka`** (real fleet + real `ci.yml`, read-only dry-run — should report a clean idempotent no-op since kukakuka is already admitted + already on the fleet) has **not** been run: it needs the runner-admin PAT against the live org API, which is owner-gated. The `gh api … --jq` shapes match what the helper's tests assert, but the real API responses have not been exercised. This is the one path the tests can only proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
