### PR TITLE
feat(epic-run): bundle the epic-run workspace skill into the plugin (#401)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "rawgentic",
-      "description": "8 SDLC workflow skills + 7 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
+      "description": "8 SDLC workflow skills + 9 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, org self-hosted runner admission, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
       "source": "./",
       "strict": true,
       "skills": [
@@ -19,6 +19,7 @@
         "./skills/admit-to-org-runners",
         "./skills/adversarial-review",
         "./skills/create-issue",
+        "./skills/epic-run",
         "./skills/fix-bug",
         "./skills/housekeeping",
         "./skills/implement-feature",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rawgentic",
-  "version": "3.36.0",
-  "description": "8 SDLC workflow skills + 8 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, org self-hosted runner admission, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
+  "version": "3.37.0",
+  "description": "8 SDLC workflow skills + 9 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, org self-hosted runner admission, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",
     "url": "https://github.com/3D-Stories"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rawgentic
 
-**8 SDLC workflow skills + 8 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code**
+**8 SDLC workflow skills + 9 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-purple)](https://docs.anthropic.com/en/docs/claude-code)
@@ -11,7 +11,7 @@
 
 Claude Code is powerful but unstructured. Complex tasks — building features, fixing bugs, running security audits — need consistent quality gates, test-driven development, and deployment verification. Without guardrails, it's easy to skip code review, forget to run CI, or merge without testing.
 
-**Rawgentic** provides 19 skills organized in four layers (six little-used workflows were deprecated at v2.60.0 — #160 — and removed at v3.0.0; see `docs/upgrade-3.0.md`):
+**Rawgentic** provides 20 skills organized in four layers (six little-used workflows were deprecated at v2.60.0 — #160 — and removed at v3.0.0; see `docs/upgrade-3.0.md`):
 
 - **Workspace management** (7 skills) — Project registration, configuration, session binding, guard exception management, opt-in operating-charter installation, session-registry housekeeping, and full-text session-history recall
 - **SDLC workflows** (8 skills) — Multi-step guided processes with quality gates, code review, CI verification, and deployment, plus a post-run `run-feedback` self-assessment (WF14) and human-gated session-history mining (WF17)
@@ -655,7 +655,7 @@ pytest tests/hooks/test_wal_guard.py -v
 
 **Impact measurement:** `scripts/wf2_impact_metrics.py` computes deterministic Tier-1 impact metrics (test growth, fail-closed coverage, dedup, diff volume) for a skill-extraction effort over a `--baseline`/`--head` git range. See [docs/measurements/2026-06-15-wf2-extraction-impact.md](docs/measurements/2026-06-15-wf2-extraction-impact.md) for the WF2 extraction analysis.
 
-Skills are tested via the `/skill-creator` eval pipeline (9/19 skills have evals.json files, in `skills/<skill>-workspace/evals/` or the skill's own `evals/` directory; the lightweight `add-exception`, `admit-to-org-runners`, `housekeeping`, `install-operating-charter`, `interview`, `run-feedback`, `scan`, `session-mining`, and `session-recall` skills have none, and `peer-consult` ships an empty stub — `skills/peer-consult/evals.json` — pending eval authoring). The fraction and the have-none list are computed from disk by a drift guard.
+Skills are tested via the `/skill-creator` eval pipeline (9/20 skills have evals.json files, in `skills/<skill>-workspace/evals/` or the skill's own `evals/` directory; the lightweight `add-exception`, `admit-to-org-runners`, `epic-run`, `housekeeping`, `install-operating-charter`, `interview`, `run-feedback`, `scan`, `session-mining`, and `session-recall` skills have none, and `peer-consult` ships an empty stub — `skills/peer-consult/evals.json` — pending eval authoring). The fraction and the have-none list are computed from disk by a drift guard.
 
 **Workspace directories:** Some skills have a corresponding `*-workspace/` directory (e.g., `skills/setup-workspace/`) used for internal skill iteration and evaluation. These contain `evals/`, `iteration-N/`, and `skill-snapshot/` subdirectories. They are **excluded from marketplace installs** via the `skills` whitelist in `marketplace.json`. If you add a new workspace directory, never name a file `SKILL.md` inside it — the marketplace validator scans for that filename recursively and will reject duplicates.
 
@@ -706,6 +706,8 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v3.37.0 (2026-07-14)
+- **`/rawgentic:epic-run` — bundle the epic-run workspace skill into the plugin (#401).** Promotes the interactive front-end for the multi-issue driver (`docs/multi-issue-driver.md` + `hooks/driver_lib.py`) from a loose workspace skill to `rawgentic:epic-run` so it ships with the plugin: derives the queue from an epic's task-list checkboxes, gets the per-run merge-policy decision (scoped auto-merge vs PR-only), drafts the `/goal` Stop-hook condition with the WF2 per-child contract, and drives child-by-child with the ERROR-comment-and-continue blocker protocol. Registered across all surfaces (whitelist between `create-issue`/`fix-bug`, codex mirror symlink, codex longDescription, counts 19→20 / workspace management 8→9); no `<config-loading>` block (not config-driven — canary unchanged at 9). Bonus: reconciled the `marketplace.json` description, stale at "7 workspace management" since #398 (it missed admit-to-org-runners' documented 7→8 bump) — now correct at 9 with both `admit-to-org-runners` and `epic-run` in its prose list. No workflow-spine change → no diagram REV. Suite 2759+1skip→2759+1skip.
 ### v3.36.0 (2026-07-12)
 - **`/rawgentic:admit-to-org-runners` — admit the bound repo to an org self-hosted runner fleet + migrate its CI off GitHub-hosted runners (#397).** New operational skill: resolves the bound repo via the shared `<config-loading>` block, discovers the org's runner groups and their ONLINE runners with a SEPARATE runner-admin credential (`--admin-token-file` / `$RAWGENTIC_RUNNER_ADMIN_TOKEN`, used ONLY on `orgs/<org>/actions/runner-*` — never the default gh token, never a hosted fallback), and migrates each workflow's hosted `runs-on` to a `{group, labels}` fleet block. Fail-closed by construction: it verifies an online runner carries the target labels BEFORE editing (never strands CI on a label no runner has), refuses the whole file if any hosted lane is unmappable or a `${{ }}`/matrix shape it will not mangle, and never leaves a hosted fallback; idempotent (already-admitted + already-on-fleet = clean no-op); dry-run by default, `--apply` ships the migration as a PR. Risky logic lives in the new tested helper `hooks/org_runners_lib.py` (workflow `runs-on` parse/classify, OS→label map, online-runner label match, hosted-remnant detection); 27 red-before-green tests. Registered across all surfaces (whitelist between `add-exception`/`adversarial-review`, codex mirror symlink, config-loading canary 8→9, counts 18→19 / workspace management 7→8). No workflow-spine change → no diagram REV. Suite 2727+1skip→2759+1skip.
 ### v3.35.0 (2026-07-10)

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.36.0",
+  "version": "3.37.0",
   "description": "8 SDLC workflow skills + 8 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, incident response, peer consultation, post-run workflow self-assessment, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, org self-hosted runner admission, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",
@@ -27,7 +27,7 @@
   "interface": {
     "displayName": "Rawgentic",
     "shortDescription": "SDLC workflow skills with TDD, quality gates, and project config.",
-    "longDescription": "Rawgentic packages 19 workflow and workspace skills for disciplined software delivery. This Codex Phase 1 package exposes the skills through a private marketplace while Codex hook support is planned for Phase 2.",
+    "longDescription": "Rawgentic packages 20 workflow and workspace skills for disciplined software delivery. This Codex Phase 1 package exposes the skills through a private marketplace while Codex hook support is planned for Phase 2.",
     "developerName": "3D-Stories",
     "category": "Productivity",
     "capabilities": [

--- a/plugins/rawgentic/skills/epic-run
+++ b/plugins/rawgentic/skills/epic-run
@@ -1,0 +1,1 @@
+../../../skills/epic-run

--- a/skills/epic-run/SKILL.md
+++ b/skills/epic-run/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: rawgentic:epic-run
+description: Use when setting up or driving a multi-issue epic auto-run in a rawgentic project — the user says "cycle through all issues in epic #N", "write me a goal for the epic", "auto-run these children", or asks to sequence WF2 across an epic's task list. Covers drafting the /goal condition, deriving the queue, the merge-policy decision, and the per-child + wrap-up contract. Do NOT use for a single issue (use /rawgentic:implement-feature or /rawgentic:fix-bug directly) or to define/plan the epic itself (that is /rawgentic:create-issue).
+argument-hint: <epic issue number>
+---
+
+# Epic Auto-Run
+
+Set up and drive a sequential WF2 run over an epic's children: derive the queue, get
+the merge-policy decision, draft the `/goal` Stop-hook condition, and run child-by-child
+with honest blocker handling. The driver contract lives in
+`docs/multi-issue-driver.md` + `hooks/driver_lib.py`; this skill is the interactive
+front-end for it.
+
+## Step 1: Derive the queue from the epic
+
+- Read the epic issue. The queue is its task-list checkboxes, exactly the shape
+  `- [ ] #N` (already-checked `- [x]` children are done — exclude them).
+- Per-child dependencies come from **each child's own body** via the
+  `parse_depends_on` phrasing: `depends on #N` / `blocked by #N` (immediate `#N` list
+  only; negations like "no longer depends on" are ignored; a bare `#N` in prose is not
+  a dependency). **Never parse the epic body for dependencies** — its checkboxes would
+  be misread as deps.
+- Topo-order the children (deps first; tie-break lowest issue number). A cycle is a
+  blocker to surface, not to route around.
+- Read each child for rescope markers ("🔄 Rescope", edited ACs) — the CURRENT body is
+  the contract, not the original filing. Note children that build on siblings' outputs
+  so the goal can pin the order.
+
+## Step 2: The merge-policy decision (the user's call, every run)
+
+Ask ONE question with the options:
+1. **Auto-merge (scoped override)** — the run creates AND merges each PR; the
+  authorization is one-time and scoped to this run, spent when it ends. Sequential
+  merge-between is required (next child branches from the merged main).
+2. **PR-only** — the run stops each child at PR creation; the user merges.
+
+Never assume auto-merge from a past run — the grant does not carry over.
+
+## Step 3: Draft the /goal condition
+
+Hand the user a block they can paste into `/goal` (you cannot invoke /goal for them —
+it is session-level). The condition must contain, explicitly:
+
+- **The queue**: all open children in topo order, by number, and the epic number/repo.
+- **Mode**: the Step-2 decision, with "scoped one-time override, spent when the run
+  ends" language if auto-merge.
+- **Per-child contract** (WF2 non-negotiables spelled out so the Stop hook can check
+  them): branch from fresh origin/main; TDD red-before-green; Step-4 design gate,
+  Step-11 review, Step-11.5 scan; full suite green vs baseline; version bump ×3
+  surfaces (patch fix/chore/docs/ci, minor feat); README changelog + docs + diagram REV
+  decision; PR; wait for CI (name the hard lanes: test, lint); merge (if auto);
+  verify issue auto-close; persist the Step-16 run-record.
+- **Child-specific notes**: rescoped children implement the rescope section;
+  dependency-ordered children build on the merged predecessor; investigation children
+  deliver a report + drift-guard (docs-patch PR if no code change).
+- **Blocker protocol**: a blocked child gets an ERROR blocker comment on its issue,
+  then the run CONTINUES to the next child; the epic stays OPEN with an honest summary.
+  Never hang the run on an unsatisfiable condition.
+- **DONE definition**: all children merged+closed, epic checkboxes checked, epic
+  CLOSED with a summary comment.
+- **A decision log**: forks and substitutions go to
+  `claude_docs/session_notes/epic-<N>-autorun-log.md` (append-only).
+
+## Step 4: Drive the run
+
+- One child at a time, WF2 fresh per child, terminating at its Step 16 — the driver
+  never reaches into a WF2 step.
+- Between children (auto-merge mode): merge, verify the merge SHA on main and the issue
+  auto-closed, `git fetch origin`, branch the next child from the new main. Use the
+  `merge-watch` skill's lane doctrine for CI triage (hard vs advisory lanes; OAuth
+  false-red signature).
+- Tick the epic checkbox after each merged child (state flows one-way: run → epic;
+  never un-tick a human's edit).
+- Mid-run environment changes (a CI outage, a denied permission) that force a policy
+  deviation are the USER's call — ask once with options, log the decision (D-numbered)
+  in the run log, apply it for the rest of the run.
+- Keep a per-child running record: issue, PR, version shipped, suite delta, deviations.
+
+## Step 5: Wrap up
+
+- Verify every child CLOSED and every box checked; close the epic with a summary
+  comment (children → PRs → versions table, deviations, follow-ups).
+- Persist any run-records not yet committed (`chore(telemetry):` PR if the project
+  keeps telemetry in-repo).
+- Final report: what merged (with versions), what was blocked and why, decisions made
+  under the run's authority, and the one claim most worth re-checking.
+
+## Common mistakes
+
+- Treating a past run's auto-merge grant as still live — it is spent; ask again.
+- Deriving deps from the epic body (checkboxes ≠ dependencies).
+- Implementing a child's ORIGINAL ACs when the body was rescoped after filing.
+- Skipping merge-verification between children — the next child then branches from a
+  main that doesn't contain its dependency.
+- Silently skipping a blocked child instead of the ERROR-comment-and-continue protocol.
+- Letting the run end with the epic open but unannotated — the honest summary is part
+  of DONE.

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -39,7 +39,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.36.0"
+    assert plugin["version"] == "3.37.0"
 
 
 def test_descriptions_consistent_count():
@@ -105,7 +105,7 @@ def test_readme_count_strings_updated():
         f"{sorted(set(skills) - have - {'peer-consult'})} (peer-consult is "
         f"called out separately as a stub)"
     )
-    assert "8 workspace management" in readme  # #113 — README count must match plugin/marketplace descriptions
+    assert "9 workspace management" in readme  # #113 — README count must match plugin/marketplace descriptions
 
 
 def test_readme_changelog_has_no_spliced_headings():


### PR DESCRIPTION
## Summary

Bundles the `epic-run` workspace skill into the rawgentic plugin as `rawgentic:epic-run`, so it ships with the plugin instead of living as a loose workspace file. It's the interactive front-end for the multi-issue driver (`docs/multi-issue-driver.md` + `hooks/driver_lib.py`) that already lives in the plugin — a product feature for any rawgentic user driving a multi-issue epic, not maintainer-only tooling. Follows the existing plugin split (e.g. `create-issue` / `create-issue-workspace`).

## Changes (all registration surfaces)

- `skills/epic-run/SKILL.md` — new, frontmatter `name: rawgentic:epic-run` + `argument-hint`
- `.claude-plugin/marketplace.json` — whitelist entry alphabetical (between `create-issue`/`fix-bug`)
- `plugins/rawgentic/skills/epic-run` — codex mirror symlink → `../../../skills/epic-run`
- Version ×3: `.claude-plugin/plugin.json`, `plugins/rawgentic/.codex-plugin/plugin.json`, `test_plugin_version_bumped` → **3.37.0** (minor, feat)
- Computed count guards: `provides 19→20 skills`, plugin-description breakdown `8→9 workspace management` (sums to 20), codex `longDescription` `19→20`, evals fraction `9/19→9/20` + `epic-run` added to the have-none list; the `9 workspace management` README pin updated in `test_adversarial_review_registration.py`
- **Not config-driven** — no `<config-loading>` block, canary unchanged at 9

## Bonus (pre-existing drift)

`marketplace.json`'s description was stale at **"7 workspace management"** — it never got admit-to-org-runners' documented 7→8 bump (#398). Reconciled to **9** with both `admit-to-org-runners` and `epic-run` now in its prose list (mirrors the #375 "README breakdown fixed" bonus precedent).

## Testing

- Full suite: `pytest tests/ -q` → **2759 passed, 1 skipped, 0 failing** (baseline 2759+1skip → unchanged; registration is computed-guarded, no new test)
- Registration/version/diagram guards: 245 passed (`test_v3_removals`, `test_codex_plugin_packaging`, `test_adversarial_review_registration`, `test_headless`, `test_workflow_diagram`)
- Both pylint lanes 10.00/10; `security_scan` PASS (iac + sca visible skips)

## Diagram

No workflow-spine change → **no diagram REV** (`test_diagram_newest_rev_matches_plugin_version` holds: newest rev ≤ 3.37.0).

## Privacy

None — skill markdown + manifest metadata only.

Closes #401
