### PR TITLE
ci: migrate rawgentic CI to org self-hosted fleet 3ds-fleet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: 3ds-fleet
+      labels: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,7 +51,9 @@ jobs:
   code-review:
     # AC1: draft-gated — only review PRs proposed for merge.
     if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: 3ds-fleet
+      labels: [self-hosted, linux]
     # No continue-on-error (#233 AC1): the job's real outcome IS the signal. Green
     # only when the review ran + succeeded; RED on no-auth / bad token / outage.
     # Advisory = this check is NOT required, so red never blocks the merge.

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -51,7 +51,9 @@ permissions:
 
 jobs:
   security-review:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: 3ds-fleet
+      labels: [self-hosted, linux]
     # No continue-on-error (#233 AC1): the job's real outcome IS the signal. Green
     # only when the review ran + succeeded; RED on no-auth / bad token / outage.
     # Advisory = this check is NOT required, so red never blocks the merge.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,9 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: 3ds-fleet
+      labels: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/mirror-to-stars.yml
+++ b/.github/workflows/mirror-to-stars.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   mirror:
     if: github.repository == '3D-Stories/rawgentic'
-    runs-on: ubuntu-latest
+    runs-on:
+      group: 3ds-fleet
+      labels: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rawgentic-auto.yml
+++ b/.github/workflows/rawgentic-auto.yml
@@ -41,7 +41,9 @@ jobs:
     # `labeled` with the drive-by author as sender — that would make this an
     # unauthenticated trigger; a test pins templates label-free).
     if: ${{ github.event.label.name == 'rawgentic:auto' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: 3ds-fleet
+      labels: [self-hosted, linux]
     # AC4/#52: hard guardrail. A healthy WF2 run posts STATUS heartbeats at
     # step boundaries; a wedged one hits this wall instead of burning hours.
     timeout-minutes: 120


### PR DESCRIPTION
## Summary

Migrate all 6 GitHub Actions workflows from GitHub-hosted `ubuntu-latest` to the org self-hosted fleet: `runs-on: {group: 3ds-fleet, labels: [self-hosted, linux]}`.

Repo admitted to runner group `3ds-fleet` (id 3; members now: kukakuka, rawgentic, saystory, slopslap). Online Linux runner verified before migration (3ds-fleet-linux). Planner verdict `ready` on all 6 files; `check-hosted` clean — no hosted fallback survives.

Context: epic #529 run D-5 — PR #539 lanes sat 45+ min queued on the hosted pool during a GitHub Actions partial outage; owner directive is default-self-hosted.

## Jobs moved

- ci.yml test, lint.yml (both lint jobs via line 19 job), claude-code-review.yml, claude-security-review.yml, mirror-to-stars.yml mirror, rawgentic-auto.yml — all -> {group: 3ds-fleet, labels: [self-hosted, linux]}

🤖 Generated with [Claude Code](https://claude.com/claude-code)
