### PR TITLE
fix(adversarial-review,peer-consult): replace dead Codex install URL at 7 sites, single-source the command (#580)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.90.1",
+  "version": "3.90.2",
   "description": "9 SDLC workflow skills + 9 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, org self-hosted runner admission, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ are found. Findings reports are written locally to `<project>/docs/reviews/` and
 never uploaded. The feature is **default-disabled** per project; existing WF1/WF2/WF3/WF4
 runs are unchanged unless explicitly opted in via `adversarialReview` (WF5) or `peerConsult`
 (WF13) in `.rawgentic_workspace.json`. Requires the Codex CLI installed
-(`curl -fsSL https://codex.openai.com/install.sh | bash`) and authenticated
+(`npm install -g @openai/codex`) and authenticated
 (`codex login`). See [config-reference.md](docs/config-reference.md#adversarial-review-data-handling).
 
 ### Run-Record Telemetry (Tier-2 substrate)
@@ -726,6 +726,8 @@ For major changes, please open an issue first to discuss the approach.
 Entries are one line per released version (most recent first), derived from the
 merged PR. Dates are the merge dates; `#N` links the PR.
 
+### v3.90.2 (2026-07-22)
+- **Codex CLI install command: dead URL replaced at 7 sites, single-sourced (#580).** The documented install command pointed at a retired domain (NXDOMAIN) — the exact self-fix text printed when the Codex prereq gate STOPs, so a user blocked on a missing Codex CLI could not recover by following it. All 7 occurrences (the issue's 6 sites + README) now carry the official npm method `npm install -g @openai/codex` (verified against the live openai/codex README; the curl installer's domain moved once already — the npm package name is the stable surface). The canonical string is single-sourced as `CODEX_INSTALL_CMD` in `hooks/adversarial_review_lib.py` (`_INSTALL_MSG` builds from it), and a new drift guard (`tests/test_codex_install_drift.py`, 4 tests, red-before-green) pins the constant, requires it verbatim at every doc site, and asserts the dead domain is absent across README/skills/docs/hooks. No workflow-spine change → no diagram REV. Suite 4574+18skip→4578+18skip.
 ### v3.90.1 (2026-07-22)
 - **incident skill bootstraps its label before creating the tracking issue (#581).** The incident workflow's Step-1 `gh issue create --repo … --label incident` (`skills/incident/SKILL.md:150`) had no step creating the `incident` label when absent, so `gh issue create --label` errored on any repo lacking it — the `incident` label was missing even in this repo; Step 1 now runs `gh label create incident … 2>/dev/null || true` first, mirroring the create-issue/run-feedback label-bootstrap pattern. +1 drift-guard test (`tests/test_incident_skill.py`, red-before-green). No workflow-spine change → no diagram REV. Suite 4574→4575.
 ### v3.90.0 (2026-07-22)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -649,7 +649,7 @@ proceeds. The engine also scans the artifact for obvious secrets (API keys, pass
 tokens, private keys) and names any detected categories in the notice. Set
 `RAWGENTIC_ADV_REVIEW_BLOCK_SECRETS=1` to make detection blocking instead of advisory.
 Findings reports are written locally to `<project>/docs/reviews/` and are never uploaded.
-The gpt backend requires the Codex CLI installed (`curl -fsSL https://codex.openai.com/install.sh | bash`)
+The gpt backend requires the Codex CLI installed (`npm install -g @openai/codex`)
 and authenticated (`codex login`, or `printenv OPENAI_API_KEY | codex login --with-api-key`
 for headless/CI). The glm backend (#403) requires `pip install "zhipuai>=2.1.5"` and a key in
 `ZHIPUAI_API_KEY` — its egress goes to z.ai/Zhipu (a distinct provider and jurisdiction),

--- a/docs/design/workflow-adversarial-review.md
+++ b/docs/design/workflow-adversarial-review.md
@@ -172,7 +172,7 @@ skill count, and the WF2/WF3 config-gated invocations.
 
 ## Troubleshooting
 
-- **"Codex CLI is not installed"** — `curl -fsSL https://codex.openai.com/install.sh | bash`.
+- **"Codex CLI is not installed"** — `npm install -g @openai/codex`.
 - **"not authenticated"** — `codex login`; for headless, API-key auth.
 - **Exit 3 (timeout/error)** — Codex failed; retry or check `codex` status.
 - **Exit 4 (parse error)** — Codex returned unexpected output; artifact may be too large.

--- a/hooks/adversarial_review_lib.py
+++ b/hooks/adversarial_review_lib.py
@@ -724,9 +724,11 @@ def _glm_prereq() -> tuple[bool, str]:
     return True, f"GLM ready ({sdk_detail}, endpoint {redact_endpoint(url)})."
 
 
+CODEX_INSTALL_CMD = "npm install -g @openai/codex"
+
 _INSTALL_MSG = (
-    "Codex CLI is not installed. Install it (standalone binary) with:\n"
-    "  curl -fsSL https://codex.openai.com/install.sh | bash\n"
+    "Codex CLI is not installed. Install it with:\n"
+    f"  {CODEX_INSTALL_CMD}\n"
     "then restart your shell so `codex` is on PATH."
 )
 _AUTH_MSG = (

--- a/phase_executor/src/phase_executor/canary.py
+++ b/phase_executor/src/phase_executor/canary.py
@@ -35,7 +35,7 @@ from . import contract
 
 # --- Pinned constants (re-pinned per release, drift-guarded by test_canary_digest_pin.py) ---
 POLICY_REVISION = 1
-EXPECTED_PLUGIN_VERSION = "3.90.1"
+EXPECTED_PLUGIN_VERSION = "3.90.2"
 # Computed live over hooks/hooks.json + the scripts referenced in its command fields (the
 # canonical length-framed encoding below). test_canary_digest_pin.py asserts pin == live.
 EXPECTED_REGISTRATION_DIGEST = "sha256:7ec8cbff3426af999406db12dec82d327271db352a848721c650fc65451747ce"

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.90.1",
+  "version": "3.90.2",
   "description": "9 SDLC workflow skills + 9 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, opt-in operating-charter installation, session-registry housekeeping, org self-hosted runner admission, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -157,7 +157,7 @@ Size:     <bytes> (cap <MAX_BYTES>)
    python3 hooks/adversarial_review_lib.py prereq --backend <resolved backend> [--headless]
    ```
 2. If the prerequisite check fails (exit 2), **STOP** and print the message verbatim. It tells the user how to install and authenticate:
-   - gpt — install (standalone binary): `curl -fsSL https://codex.openai.com/install.sh | bash`; authenticate: `codex login` (headless/CI: `printenv OPENAI_API_KEY | codex login --with-api-key`)
+   - gpt — install: `npm install -g @openai/codex`; authenticate: `codex login` (headless/CI: `printenv OPENAI_API_KEY | codex login --with-api-key`)
    - glm — install: `pip install "zhipuai>=2.1.5"`; credential: export `ZHIPUAI_API_KEY` (a z.ai Coding Plan subscription key works with the default endpoint)
 3. **`both` is DEGRADE-AND-WARN (#403):** the check passes when AT LEAST ONE backend is ready; the message names BOTH backends' results, and an unready backend is a loud warning (the run will degrade to the ready backend, exit 5). Only zero-ready fails. Surface the warning to the user, then proceed.
 4. **Headless note:** ChatGPT OAuth login is interactive-only. If the session is headless (`RAWGENTIC_HEADLESS=1`) and the gpt prereq fails on authentication, this is a terminal ERROR — do not wait for an interactive login. The glm credential is an env var (no interactive step), so its headless message is the same export instruction.

--- a/skills/peer-consult/SKILL.md
+++ b/skills/peer-consult/SKILL.md
@@ -124,7 +124,7 @@ Size:     <bytes> (cap <MAX_BYTES>)
    python3 hooks/adversarial_review_lib.py prereq --backend <resolved backend> [--headless]
    ```
 2. If the prerequisite check fails (exit 2), **STOP** and print the message verbatim:
-   - gpt — install: `curl -fsSL https://codex.openai.com/install.sh | bash`; authenticate: `codex login` (headless/CI: `printenv OPENAI_API_KEY | codex login --with-api-key`)
+   - gpt — install: `npm install -g @openai/codex`; authenticate: `codex login` (headless/CI: `printenv OPENAI_API_KEY | codex login --with-api-key`)
    - glm — install: `pip install "zhipuai>=2.1.5"`; credential: export `ZHIPUAI_API_KEY` (a z.ai Coding Plan subscription key works)
 3. **`both` is DEGRADE-AND-WARN (#403):** passes when ≥1 backend is ready; the message names both results; an unready backend degrades the run (exit 5), it does not block. Zero-ready fails.
 4. **Headless note:** ChatGPT OAuth login is interactive-only — headless gpt auth failure is a terminal ERROR. The glm credential is an env var; same export instruction headless.

--- a/skills/setup/references/integrations.md
+++ b/skills/setup/references/integrations.md
@@ -100,7 +100,7 @@ Check the active project's entry for the `adversarialReview` field.
     because WF1 is a lean drafting workflow (no multi-agent critique), so most
     projects don't need a cross-model pass on issue specs — offer it as an opt-in
     add ("also enable for create-issue? (y/n) [default: n]"). Remind them the Codex CLI must be installed
-    and authenticated (`curl -fsSL https://codex.openai.com/install.sh | bash`
+    and authenticated (`npm install -g @openai/codex`
     then `codex login`); if Codex is absent at run time the gate fails closed and
     is skipped (no error, just no cross-model pass). WF4 (refactor) was removed at v3.0.0 (#161); a configured refactor entry is inert and only fires on
     the Extract/Restructure path (Rename/Simplify skips it).

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -39,7 +39,7 @@ def test_marketplace_registers_skill():
 
 def test_plugin_version_bumped():
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["version"] == "3.90.1"
+    assert plugin["version"] == "3.90.2"
 
 
 def test_descriptions_consistent_count():

--- a/tests/test_codex_install_drift.py
+++ b/tests/test_codex_install_drift.py
@@ -1,0 +1,55 @@
+"""Drift guard for the Codex CLI install command (#580).
+
+The documented install URL went NXDOMAIN once already. The canonical install
+command lives in ONE place — CODEX_INSTALL_CMD in hooks/adversarial_review_lib.py
+— and every documentation site must carry it verbatim, so the sites cannot
+silently diverge again. The dead domain must not reappear on any surface where
+the install command is documented.
+"""
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "hooks"))
+
+import adversarial_review_lib as arl  # noqa: E402
+
+# split so this guard never trips on its own source
+DEAD_DOMAIN = "codex.openai" + ".com"
+
+DOC_SITES = [
+    "README.md",
+    "skills/adversarial-review/SKILL.md",
+    "skills/peer-consult/SKILL.md",
+    "skills/setup/references/integrations.md",
+    "docs/design/workflow-adversarial-review.md",
+    "docs/config-reference.md",
+]
+
+
+def test_canonical_install_cmd_pinned():
+    assert arl.CODEX_INSTALL_CMD == "npm install -g @openai/codex"
+
+
+def test_install_msg_uses_canonical_cmd():
+    assert arl.CODEX_INSTALL_CMD in arl._INSTALL_MSG
+
+
+def test_every_doc_site_carries_canonical_cmd():
+    missing = [
+        site for site in DOC_SITES
+        if arl.CODEX_INSTALL_CMD not in (REPO_ROOT / site).read_text(encoding="utf-8")
+    ]
+    assert not missing, f"doc sites missing the canonical Codex install command: {missing}"
+
+
+def test_dead_install_domain_absent():
+    surfaces = [REPO_ROOT / "README.md"]
+    surfaces += sorted((REPO_ROOT / "skills").rglob("*.md"))
+    surfaces += sorted((REPO_ROOT / "docs").rglob("*.md"))
+    surfaces += sorted((REPO_ROOT / "hooks").rglob("*.py"))
+    hits = [
+        str(p.relative_to(REPO_ROOT)) for p in surfaces
+        if DEAD_DOMAIN in p.read_text(encoding="utf-8")
+    ]
+    assert not hits, f"dead Codex install domain still referenced at: {hits}"


### PR DESCRIPTION
## Summary

The documented Codex CLI install command pointed at a retired domain (NXDOMAIN) — the exact self-fix text printed when the Codex prereq gate STOPs, so a user blocked on a missing Codex CLI could not recover by following it (#580).

## Changes

- **7 sites fixed, not 6** — the issue's 6 plus `README.md:548`, found by the full-repo sweep. All now carry `npm install -g @openai/codex`.
- **Replacement verified against the live openai/codex README** (acceptance criterion 1): the primary curl installer is now `chatgpt.com/codex/install.sh` — i.e. the curl URL churned domains once already. Picked the npm form deliberately: the package name is the stable surface, and it is listed as an official install method. npm registry confirms `@openai/codex` latest = 0.145.0.
- **Single-sourced** (acceptance criterion 2): canonical string lives in ONE place, `CODEX_INSTALL_CMD` in `hooks/adversarial_review_lib.py`; the STOP remediation `_INSTALL_MSG` builds from it.
- **Drift guard** `tests/test_codex_install_drift.py` (4 tests, red before green): pins the constant's exact value, requires it verbatim at every doc site, and asserts the dead domain is absent across README/skills/docs/hooks.
- Version **3.90.2** across all 4 surfaces (`plugin.json` ×2, `canary.py` `EXPECTED_PLUGIN_VERSION`, registration-test pin) + README changelog entry.

## Gates

| Gate | Result |
|---|---|
| pytest whole suite | 4574 passed / 18 skipped → **4578 passed / 18 skipped**, exit 0 (+4 = new drift tests, 0 regressions) |
| pylint hooks + tests lanes | 10.00/10 both, exit 0 |
| security scan (vs origin/main) | PASS — visible skip: `iac` not applicable |
| version-surface guard | `test_plugin_version_bumped` green |

No workflow-spine change → no diagram REV.

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)
