### PR TITLE
test(context_meter): isolate the RAWGENTIC_CONTEXT_* env twins module-wide

### DIFF
--- a/tests/hooks/test_context_meter.py
+++ b/tests/hooks/test_context_meter.py
@@ -85,6 +85,27 @@ SID = "abcd1234-0000-1111-2222-333344445555"
 FAST = {"RAWGENTIC_CONTEXT_EVERY_TURNS": "1"}
 
 
+@pytest.fixture(autouse=True)
+def _scrub_context_env(monkeypatch):
+    """Neutralize every `RAWGENTIC_CONTEXT_*` env twin for the whole module.
+
+    `_run` already scrubs these for the SUBPROCESS it spawns, but tests that drive `cmd_hook`
+    IN-PROCESS read the real `os.environ` — so the harness was inconsistent with itself, and a
+    developer who legitimately exports one of the twins got a failure the code did not have.
+
+    Found the hard way: setting `RAWGENTIC_CONTEXT_WINDOW=1000000` in `~/.claude/settings.json`
+    (the correct fix for a 1M-context host — env beats project config per key) made
+    `test_cmd_hook_releases_the_reservation_when_delivery_fails` fail deterministically, because its
+    in-process half then computed a 1M window and never reached the tier the test needs. CI never saw
+    it: CI exports none of these. A suite whose result depends on the developer's shell is not a gate.
+
+    Autouse and module-wide rather than per-test: any future in-process test would inherit the same
+    fragility, and the fixture costs nothing where the twin is absent.
+    """
+    for key in [k for k in os.environ if k.startswith("RAWGENTIC_CONTEXT_")]:
+        monkeypatch.delenv(key, raising=False)
+
+
 # --------------------------------------------------------------------------
 # T1 — usage totals and the reader (AC1, probe 2)
 # --------------------------------------------------------------------------


### PR DESCRIPTION
A test-only fix, found by making a legitimate configuration change.

## How it surfaced

The owner's models are all 1M-context, so `RAWGENTIC_CONTEXT_WINDOW=1000000` went into `~/.claude/settings.json`'s `env` block — the correct fix, since env beats project config per key and it covers every project at once without editing 24 files.

`test_cmd_hook_releases_the_reservation_when_delivery_fails` then failed **deterministically**, in isolation, three runs out of three. **The code was never wrong.**

## The harness was inconsistent with itself

`_run` already scrubs every `RAWGENTIC_CONTEXT_*` key for the **subprocess** it spawns (`tests/hooks/test_context_meter.py:62-64`). But tests that drive `cmd_hook` **in-process** read the real `os.environ`. With a 1M window the test's 159,415-token fixture is ~16% rather than ~80%, so it never reaches the directive tier the assertion depends on.

**CI never saw it, because CI exports none of these twins.** A suite whose result depends on the developer's shell is a gate for some people and not others, which is the property that makes it worthless as a gate.

## The fix

An autouse, module-wide fixture rather than a per-test `delenv`: any future in-process test would inherit the same fragility, and the fixture costs nothing where the twin is absent.

## Verification

| Check | Result |
|---|---|
| The file, **with `RAWGENTIC_CONTEXT_WINDOW=1000000` exported** | **137 passed** |
| Full suite, under the same env | **6109 passed, 21 skipped, rc=0** |
| `pylint tests/` | 10.00/10, rc=0 |
| Version | **none** — test-only |
| Diagram | **No workflow-spine change → no diagram REV** |

Red-before-green is inverted here and worth stating plainly: the test failed on unmodified `main` **under the new env**, and passes both with and without it after the fix. I verified the pre-fix failure was environmental rather than a real break by clearing the var and watching the same test pass on the same code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)