### PR TITLE
chore(docs): trim CLAUDE.md §5 to the quality-bar pointer + drop cross-tier duplicates (#908)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,10 @@ load-bearing for resume. Never edit or truncate an existing entry.
 19. **Putting a `SKILL.md` in a workspace dir or a `version` on the marketplace plugin
     entry.** The org-marketplace validator walks ALL `skills/**/SKILL.md` and rejects
     both (`docs/skill-development.md:141-160`; snapshots use `SKILL.snapshot.md`).
-20. **Treating `estimate_agents` or lane thresholds as tunable prose.** Constants
+20. *(Retired — `git reset --hard` under auto-mode. It now lives ONLY at workspace mistake #7,
+    which owns it by its own argument. The number is held rather than reused so existing
+    citations to "project mistake #20" still resolve to the entry they meant.)*
+21. **Treating `estimate_agents` or lane thresholds as tunable prose.** Constants
     mirrored between `hooks/plan_lib.py` and SKILL.md `<constants>` have drift-guard
     tests asserting equality — change the Python source of truth and the mirror together.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,11 +189,10 @@ load-bearing for resume. Never edit or truncate an existing entry.
   `model_routing_lib.py`); data you can't classify → fail-safe KEEP
   (`registry_prune.py:6-8`); repeated user-facing nag → record-before-emit
   (`security-guard-check.sh:49-55`).
-- **One helper, one home.** Before writing any new script, check `hooks/` — `plan_lib`,
-  `work_summary`, `capabilities_lib`, `security_scan`,
-  `registry_prune`, `driver_lib`, `resume_lib`, `review_runner` cover most needs.
-- **Timeout ≠ failure for mutating calls** (gh/API): check the resource's real state
-  before retrying — the write may have landed; a blind retry double-creates.
+- **One helper, one home** — the rule is workspace §3's; this is the repo's helper list.
+  Before writing any new script check `hooks/`: `plan_lib`, `work_summary`,
+  `capabilities_lib`, `security_scan`, `registry_prune`, `driver_lib`, `resume_lib`,
+  `review_runner`.
 - **`quality-bar.md` is single-sourced (since #276).** The one source is
   `shared/blocks/quality-bar.md`; `sync_shared_blocks.py`'s `FILE_MANIFEST` copies it
   into the three references/ dirs and `--check` (CI-run) flags drift. Edit the source,
@@ -241,9 +240,10 @@ load-bearing for resume. Never edit or truncate an existing entry.
    Critical vulnerabilities on a run judged "too simple to review"
    (`skills/implement-feature/SKILL.md:80`). Rule: Steps 1–5, 7–9, 11, 11.5, 12, 16
    never get skipped; low context → checkpoint per the skill's protocol and resume.
-9. **Trusting a subagent's "COMPLETE".** Agents die on session limits and return
-   vacuous results (`confirmedCount: 0`, empty body). Rule: check `<failures>`/content;
-   re-run the gate yourself for anything load-bearing.
+9. **The vacuous-result signature, which is repo-specific:** an agent killed by a session
+   limit returns `confirmedCount: 0` with an empty body. That is a FAILED dispatch, never a
+   clean pass — check `<failures>`/content and re-run the gate yourself. (That a subagent's
+   verdict is only a hypothesis until confirmed is universal-tier.)
 10. **Misreading CI lanes** — treating advisory red as a blocker or hard red as noise.
     Rule: lane doctrine + OAuth signature in §2; read the failed log before theorizing.
 11. **Guessing a hook's behavior from its name.** Rule: §3 fail-mode convention — read
@@ -275,76 +275,19 @@ load-bearing for resume. Never edit or truncate an existing entry.
 19. **Putting a `SKILL.md` in a workspace dir or a `version` on the marketplace plugin
     entry.** The org-marketplace validator walks ALL `skills/**/SKILL.md` and rejects
     both (`docs/skill-development.md:141-160`; snapshots use `SKILL.snapshot.md`).
-20. **`git reset --hard` under auto-mode** — the permission classifier denies it (no
-    rawgentic hook is involved — wal-guard deliberately does not block destructive local
-    commands). Rule: inspect `git status` / `git diff` first — `git checkout -- <path>` also
-    discards uncommitted changes; run it only against named files whose state you've checked.
-21. **Treating `estimate_agents` or lane thresholds as tunable prose.** Constants
+20. **Treating `estimate_agents` or lane thresholds as tunable prose.** Constants
     mirrored between `hooks/plan_lib.py` and SKILL.md `<constants>` have drift-guard
     tests asserting equality — change the Python source of truth and the mirror together.
 
-## 5. Quality bar per deliverable — checkable criteria
+## 5. Quality bar per deliverable
 
-**A merged-ready PR** (all boxes; the `pr-preflight` workspace skill executes this):
-- [ ] Branch from fresh `origin/main`; conventional title matching branch prefix
-- [ ] Red-before-green evidence for any behavior change (the new test failed first)
-- [ ] Full suite exit 0; delta vs recorded baseline stated ("<old> → <new>, 0 failing")
-- [ ] Both pylint lanes green (§2 commands, verbatim)
-- [ ] `python3 hooks/security_scan.py scan --project-root . --project-type library
-      --base-ref origin/main` — findings fixed or user-decided; absent scanners noted as
-      a visible skip in the PR body
-- [ ] Version ×3 surfaces; `test_plugin_version_bumped` passes
-- [ ] README updated INCLUDING a changelog entry in the exact §2 shape (diagram decision
-      + `Suite old→new` tail); count strings still true
-- [ ] Relevant `docs/*.md` updated for the area touched
-- [ ] Diagram decision recorded (REV appended per §2 recipe, or explicit no-change line)
-- [ ] Only task files staged; `.claude/` and `.rawgentic/review-state/` untracked
-
-**A new/changed hook (`hooks/*.py`):**
-- [ ] Pure core + thin CLI (`registry_prune.py` is the exemplar): logic in pure
-      functions returning values; all I/O, exit codes, clock, and subprocess runner
-      injected or confined to `main(argv)`
-- [ ] Failure mode chosen per §3 decision guide, stated in the docstring, asserted by a test
-- [ ] Shared-file writes atomic: `tempfile.mkstemp(dir=target)` → `os.replace`; temp
-      unlinked on exception; a test asserts no stray `*.tmp` survives
-- [ ] Env-var config fail-safe: strict parse, clamp, safe default, stderr warning
-- [ ] Any path/name from config hardened against traversal (canonicalize + containment)
-- [ ] Tests: happy path, malformed input, boundary, AND the CLI via
-      `subprocess.run([sys.executable, CLI, ...])`
-- [ ] Bash hooks: loggers = `set -euo pipefail` inside a function + `|| true; exit 0`;
-      guards deny via JSON `permissionDecision`, still exit 0; jq resolved
-      `~/.local/bin/jq` then PATH
-
-**A new/changed skill:** the mistake-#2 surface list complete; description = triggering
-symptoms not workflow summary; every command in the body executed once against this
-repo; step markers for resumability; evals (if any) in
-`skills/<name>-workspace/evals/evals.json` shaped
-`{skill_name, evals:[{id,prompt,expected_output}]}` with ≥3 cases.
-
-**A drift-guard test:** anchors ONE canonical sentence in ONE file; section isolated by
-header-index slicing; whitespace-normalized if prose can wrap; corpus vs direct-file
-choice matches pin kind (content vs location); exact `==` count only where the count IS
-the contract, `>=` where multi-site presence is the point.
-
-**A bug fix:** reported symptom reproduced FIRST via the reporter's entry path; root
-cause named with file:line; fix where all callers route through (grep the callers); the
-failing case is a committed red-before-green test; parallel paths to the same effect
-enumerated and checked.
-
-**An investigation:** verdict first (confirmed/refuted/inconclusive) from PRIMARY
-sources; every load-bearing claim marked confirmed-with-evidence or
-inferred-with-what-would-confirm; a drift-guard added when the verdict pins external
-behavior; what was NOT checked, named.
-
-**A diagram REV** (spine change): new key in `revs` newest-first + `versions` entry;
-full `steps` snapshot (or `steps:null` + `overrides` for small deltas); changed stations
-carry `rev:{delta, refs}`; prior rev `superseded`; provenance footer `@ plugin X.Y.Z`;
-snapshots regenerated (serve over `python3 -m http.server` — headless browsers block
-`file:`; **FULL-PAGE** screenshot light+dark at 1440px-wide viewport, device scale →
-`docs/assets/` — a viewport-only 1440×1200 capture clips the sheet to ~6 of 19
-stations and passes CI, #337 review catch);
-`pytest tests/test_workflow_diagram.py` green —
-`test_diagram_newest_rev_matches_plugin_version` guards the version linkage.
+The checkable acceptance criteria for the six deliverable kinds shipped here — a PR in
+this repo, a bug fix, a design/architecture doc, an investigation, a new skill, a deploy —
+live in the **`quality-bar` workspace skill** (`.claude/skills/quality-bar/`), which loads
+when a deliverable is being finished instead of in every session. Invoke it when finishing
+any of them. `pr-preflight` is the executable runner for the PR gate; `quality-bar` is the
+bar. The repo-specific hook, drift-guard-test and workflow-diagram-REV checklists that used
+to be inlined here now live in that skill too — relocated, not dropped.
 
 ## 6. When uncertain — exact escalation rules
 

--- a/tests/hooks/test_wf_review_sites.py
+++ b/tests/hooks/test_wf_review_sites.py
@@ -83,7 +83,9 @@ _WINDOW = 2500
 
 
 def _norm(text: str) -> str:
-    """Whitespace-normalize so a wrapped sentence still matches (CLAUDE.md §5 prose-pin rule)."""
+    """Whitespace-normalize so a wrapped sentence still matches (the drift-guard-test rule,
+    now in the `quality-bar` workspace skill; repo CLAUDE.md §4 mistake #6 carries the
+    corpus-regex half)."""
     return re.sub(r"\s+", " ", text)
 
 

--- a/tests/test_run_feedback_clarity.py
+++ b/tests/test_run_feedback_clarity.py
@@ -10,7 +10,8 @@ weak spots, the dispatches[] consume-when-present rule, the mempalace tri-state
 surface line, the artifact-publish failure line, the marker-acceptance boundaries,
 and the rubric version stamp every report must quote.
 
-House pattern (repo mistake #6 / CLAUDE.md §5): section- or file-sliced, ONE
+House pattern (repo CLAUDE.md §4 mistake #6, plus the drift-guard-test checklist in the
+`quality-bar` workspace skill): section- or file-sliced, ONE
 canonical sentence per guard, whitespace-normalized — never whole-corpus regex,
 never substring counts. Companion to tests/test_wf3_clarity.py.
 """


### PR DESCRIPTION
## What and why

`CLAUDE.md` is the repo operating manual and loads in **every** rawgentic-bound session, so every
line in it is paid for on every run. Part of it duplicated content that already has an on-demand or
wider-tier home. This trims those, per the audit's C1+C2 findings.

**27,469 → 24,022 bytes, 393 → 339 lines (−12.5%).**

## AC1 — §5 becomes a pointer, and the pre-step ran first

§5's per-deliverable checklists duplicated the `quality-bar` workspace skill, which was split out on
2026-07-27 *specifically* so those checklists load when a deliverable is being finished rather than
in every session. §5 is now a pointer to that skill, with `pr-preflight` named as the executable
runner.

**The AC1 pre-step was done before shrinking anything.** I diffed §5 against the skill and moved
everything §5 had that the skill lacked **into the skill first**:

| Moved into the skill | Was |
|---|---|
| the entire repo-specific **hook checklist** | absent from the skill |
| the entire **drift-guard-test checklist** | absent from the skill |
| the entire **workflow-diagram-REV checklist** | absent from the skill |
| the exact changelog shape (diagram decision + `Suite old→new` tail) | skill said only "README updated including Changelog" |
| `.rawgentic/review-state/` as a second untracked path | skill named only `.claude/` |
| skill step-markers + the evals-file shape and ≥3-case rule | absent |
| "add a drift guard when the verdict pins external behaviour" | absent |

Verified afterwards by checking eleven distinctive phrases from the old §5 (`registry_prune.py`,
`tempfile.mkstemp`, `permissionDecision`, `header-index slicing`, `1440`, `#337`,
`test_diagram_newest_rev_matches_plugin_version`, `Suite <old>→<new>`, `.rawgentic/review-state/`,
`evals.json`, `pins external behaviour`) are all present in the skill afterwards. The skill went
62 → 104 lines.

> **Stated limitation, not hidden:** that skill lives at
> `~/rawgentic/.claude/skills/quality-bar/SKILL.md` — the workspace root, which is **not a git
> repository**. So the relocation is **not in this diff and cannot be verified by CI**. The
> "nothing is lost" claim rests on the phrase check above, run locally. A backup of the pre-edit
> skill was taken before the change.

## AC2 — four cross-tier duplicates, each verified to have a wider home

Per the tier map's own rule: the narrower copy that adds nothing dies, because that is how copies
drift apart and the staler one wins. **I verified each rule genuinely survives elsewhere before
deleting it** — a "duplicate" that isn't one would be a silent loss:

| Removed / thinned here | Verified surviving home |
|---|---|
| mistake #20 (`git reset --hard` under auto-mode) — **deleted** | workspace `CLAUDE.md:258` mistake #7, whose own text says it is kept at workspace level *because* the project manual may not load — making the repo copy redundant by its own argument |
| §3 "Timeout ≠ failure for mutating calls" — **deleted** | workspace `CLAUDE.md:234` **and** universal `operating-instructions.md:75` (it had three homes) |
| mistake #9 (subagent "COMPLETE") — **thinned** to the repo-specific `confirmedCount: 0` + empty-body signature | universal `operating-instructions.md:21` — "A finding is a hypothesis until you confirm it. A subagent's 'COMPLETE'…" names this exact case |
| §3 "One helper, one home" — **thinned** to the repo's helper list | workspace `CLAUDE.md:230` carries the rule |

**Numbering: #20 is held, not reused.** My first commit renumbered #21 → #20 and accepted that the
dated audit report `docs/reviews/2026-08-04-doctor-plus-context-audit.md`, which cites "project
mistake #20" meaning the deleted entry, would silently retarget an unrelated rule. The Step-11
reviewer proposed better and I took it: #20 is now an explicit *retired* marker naming its surviving
home, and the lane-threshold entry stays at #21. Every existing citation still resolves to the entry
it meant. (That report also cites line numbers this change shifts — normal ageing for a dated
snapshot; it is not being rewritten.)

I kept the §3 bullet **named** "One helper, one home" on purpose: §4 mistake #12 cites it by that
exact phrase.

## AC3 — no test regression, re-verified at this head

The audit's claim was that no test pins the manual's prose. Re-verified here rather than trusted:
**no test opens or reads the repo `CLAUDE.md` at all.** Every mention across `tests/` is a comment
or docstring, or a *location* pin on a **project** manual (`test_switch_loads_project_manual.py`,
`test_wal_bind_guard.py`). The one comment reading "CLAUDE.md now reads …" explains why a version
constant is pinned; it asserts nothing about the manual.

**Suite 5079 → 5079, 0 failing, exit 0.** Both pylint lanes 10.00/10, exit 0.

**Two test comments updated** because this change made them stale — both pointed at §5 as the home
of the drift-guard-test rule, which now lives in the skill:
`tests/hooks/test_wf_review_sites.py`, `tests/test_run_feedback_clarity.py`. Comment-only.

## AC4 — companion edits to the two non-git tiers

The workspace root and the user tier are not git repositories, so these are direct file edits
recorded here (same pattern as #875's D179 non-child task). **Both files were backed up before
editing**, to the session scratch directory.

1. **`~/rawgentic/CLAUDE.md` — the duplicate `git add` statement.** The workspace manual carried the
   staging rule twice (§2 conventions and §4 mistake #2) while the universal tier
   (`operating-instructions.md:53`) already owns it. The §2 bullet is thinned to the only thing it
   added — "leave `.claude/` untracked" — and mistake #2 keeps its mistake-catalog framing, which
   the tier map explicitly sanctions as a legitimate narrower-tier entry.
2. **`~/.claude/CLAUDE.md` — rawgentic mechanics in the Vercel block.** The user tier's own rule is
   that nothing rawgentic-specific lives there, but its design-doc block carried
   `design-doc-publish`'s `publish_doc.py` mechanics and a
   `~/rawgentic/projects/claude-skills/...` path. Those moved **down** into the workspace manual;
   the user tier keeps the standing preference only.

## Step 11 review + Step 11.5 security scan

Cross-model diff review (`gpt-5.6-sol`, actionable — reopen token minted and consumed) returned
4 findings: 1 High, 3 Medium.

- **Adopted — the reviewer improved on my choice.** I had renumbered mistake #21 → #20 and accepted
  that the dated audit report's "project mistake #20" citation would silently retarget. The reviewer
  proposed holding #20 as an explicit *retired* marker and leaving the lane-threshold entry at #21.
  Two lines, and every existing citation still resolves to the entry it meant. Applied.
- **Declined with evidence (the reviewer could only see the diff, so three findings feared losses
  that I verified had not occurred):** the deleted "Timeout ≠ failure" rule survives at workspace
  `CLAUDE.md:234` and universal `operating-instructions.md:75`; the `wal-guard` safety fact from
  mistake #20 is present verbatim in workspace mistake #7 at `CLAUDE.md:258`.
- **Declined and ledgered (High):** the reviewer is right that a fresh clone has no in-repo quality
  bar and CI cannot verify the relocation. Its recommendation — keep canonical criteria in a tracked
  repo file plus a CI sync check — directly contradicts AC1. Recorded in
  `claude_docs/.wf2-state/908/dispositions.jsonl` and raised as a follow-up rather than accepted in
  silence.

**Security scan (Step 11.5): PASS**, exit 0. One visible skip, which is not a pass: `iac — not
applicable to this project`.

## Follow-up this PR does not do

The repo can no longer state its own quality bar without the workspace skill, and CI cannot check
that the skill still carries the relocated checklists. Worth an issue: either track the canonical
criteria in-repo and have the skill sync from them, or add a guard that fails when the skill is
missing the repo-specific sections.

## Release surfaces

- **No version bump** — docs-only, matching the precedent this issue names (PRs #655, #757, #907).
- **No changelog entry** — same reason.
- **No workflow-spine change, so no diagram REV.**

## Undo

Revert this commit for the in-repo half. The three non-git edits are separate and each reversible on
its own: restore `~/rawgentic/.claude/skills/quality-bar/SKILL.md`, `~/rawgentic/CLAUDE.md`, and
`~/.claude/CLAUDE.md` from the backups taken before the edits.

Closes #908
Part of #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)
