### PR TITLE
feat(evals): behavioural selection gate for skill evals (#928)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.128.4",
+  "version": "3.129.0",
   "description": "9 SDLC workflow skills + 9 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -732,7 +732,7 @@ For major changes, please open an issue first to discuss the approach.
   (`skill_name`+`evals` and the `peer-consult` stub's `skill`+`cases`), `classify_intent` separates
   the three intents already in the corpus, `skills_selected` parses a transcript for `Skill`
   `tool_use` blocks, and `judge` scores a case — with a **refuse** case counting the skill *firing*
-  as the failure. The live `claude -p` spawn is an INJECTED seam, so all 30 new tests
+  as the failure. The live `claude -p` spawn is an INJECTED seam, so all 33 new tests
   (`tests/hooks/test_skill_evals.py`) run in the ordinary lane; the transcript shape is measured
   against a real 1.5 MB session transcript, not guessed. Two classifier defects were found by
   running the real 38-case corpus rather than fixtures: a whole-text "does not" match called
@@ -747,7 +747,7 @@ For major changes, please open an issue first to discuss the approach.
   selection runs from the installed plugin cache and reinstalling while hook-using sessions live is
   prohibited (§7, mistake #5) — the same wall that stopped #909. The live end-to-end run is
   explicitly deferred, with the reason and the follow-up recorded in that doc. No workflow-spine
-  change → no diagram REV. Suite 5254→5284.
+  change → no diagram REV. Suite 5254→5287.
 
 ### v3.128.4 (2026-08-05)
 - **Milestone epics referenced from the plan (#756 follow-through, part 2).** The five milestone

--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ pytest tests/hooks/test_wal_guard.py -v
 
 **Impact measurement:** `scripts/wf2_impact_metrics.py` computes deterministic Tier-1 impact metrics (test growth, fail-closed coverage, dedup, diff volume) for a skill-extraction effort over a `--baseline`/`--head` git range. See [docs/measurements/2026-06-15-wf2-extraction-impact.md](docs/measurements/2026-06-15-wf2-extraction-impact.md) for the WF2 extraction analysis.
 
-Skills are tested via the `/skill-creator` eval pipeline (10/21 skills have evals.json files, in `skills/<skill>-workspace/evals/` or the skill's own `evals/` directory; the lightweight `add-exception`, `epic-post-mortem`, `epic-run`, `housekeeping`, `interview`, `revalidate-children`, `run-feedback`, `scan`, `session-mining`, and `session-recall` skills have none, and `peer-consult` ships an empty stub — `skills/peer-consult/evals.json` — pending eval authoring). The fraction and the have-none list are computed from disk by a drift guard.
+Skills are tested via the `/skill-creator` eval pipeline (11/21 skills have evals.json files, in `skills/<skill>-workspace/evals/` or the skill's own `evals/` directory; the lightweight `add-exception`, `epic-post-mortem`, `housekeeping`, `interview`, `revalidate-children`, `run-feedback`, `scan`, `session-mining`, and `session-recall` skills have none, and `peer-consult` ships an empty stub — `skills/peer-consult/evals.json` — pending eval authoring). The fraction and the have-none list are computed from disk by a drift guard. The eval data is also read by the **behavioural selection gate** (`hooks/skill_evals.py`, #928): `discover` reports every file's cases and their intents (`trigger` / `slash` / `refuse`), and a live verdict is a documented manual gate — see `docs/skill-evals.md`.
 
 **Workspace directories:** Some skills have a corresponding `*-workspace/` directory (e.g., `skills/setup-workspace/`) used for internal skill iteration and evaluation. These contain `evals/`, `iteration-N/`, and `skill-snapshot/` subdirectories. They are **excluded from marketplace installs** via the `skills` whitelist in `marketplace.json`. If you add a new workspace directory, never name a file `SKILL.md` inside it — the marketplace validator scans for that filename recursively and will reject duplicates.
 
@@ -724,6 +724,30 @@ For major changes, please open an issue first to discuss the approach.
 ---
 
 ## Changelog
+
+### v3.129.0 (2026-08-05)
+- **Behavioural selection gate for skill evals (#928, epic #906).** `hooks/skill_evals.py` turns
+  eleven `evals.json` files from inert data into a runnable gate: `discover_eval_files` finds both
+  sanctioned locations plus the skill-root spelling, `load_cases` accepts both on-disk schemas
+  (`skill_name`+`evals` and the `peer-consult` stub's `skill`+`cases`), `classify_intent` separates
+  the three intents already in the corpus, `skills_selected` parses a transcript for `Skill`
+  `tool_use` blocks, and `judge` scores a case — with a **refuse** case counting the skill *firing*
+  as the failure. The live `claude -p` spawn is an INJECTED seam, so all 30 new tests
+  (`tests/hooks/test_skill_evals.py`) run in the ordinary lane; the transcript shape is measured
+  against a real 1.5 MB session transcript, not guessed. Two classifier defects were found by
+  running the real 38-case corpus rather than fixtures: a whole-text "does not" match called
+  `pane-handoff` cases 1/4/5 refusals (inverting the gate for three dominant real phrasings — those
+  negations are about what the skill does not do *internally*), and reading `slash` from
+  `expected_output` matched any path-shaped token, mislabelling natural-language cases across five
+  skills; `slash` now comes from the prompt, keyed on the skill's own name. Adds
+  `skills/epic-run/evals/evals.json` — six cases covering the 403 description characters #909
+  restored, which had never been exercised for selection, including both of that description's
+  NOT-for-this-skill boundaries. Evals fraction 10/21 → 11/21. `docs/skill-evals.md` records the
+  fourth AC's decision: a live verdict is a documented MANUAL gate, not a CI lane, because
+  selection runs from the installed plugin cache and reinstalling while hook-using sessions live is
+  prohibited (§7, mistake #5) — the same wall that stopped #909. The live end-to-end run is
+  explicitly deferred, with the reason and the follow-up recorded in that doc. No workflow-spine
+  change → no diagram REV. Suite 5254→5284.
 
 ### v3.128.4 (2026-08-05)
 - **Milestone epics referenced from the plan (#756 follow-through, part 2).** The five milestone

--- a/README.md
+++ b/README.md
@@ -732,7 +732,7 @@ For major changes, please open an issue first to discuss the approach.
   (`skill_name`+`evals` and the `peer-consult` stub's `skill`+`cases`), `classify_intent` separates
   the three intents already in the corpus, `skills_selected` parses a transcript for `Skill`
   `tool_use` blocks, and `judge` scores a case — with a **refuse** case counting the skill *firing*
-  as the failure. The live `claude -p` spawn is an INJECTED seam, so all 33 new tests
+  as the failure. The live `claude -p` spawn is an INJECTED seam, so all 49 new tests
   (`tests/hooks/test_skill_evals.py`) run in the ordinary lane; the transcript shape is measured
   against a real 1.5 MB session transcript, not guessed. Two classifier defects were found by
   running the real 38-case corpus rather than fixtures: a whole-text "does not" match called
@@ -746,8 +746,17 @@ For major changes, please open an issue first to discuss the approach.
   fourth AC's decision: a live verdict is a documented MANUAL gate, not a CI lane, because
   selection runs from the installed plugin cache and reinstalling while hook-using sessions live is
   prohibited (§7, mistake #5) — the same wall that stopped #909. The live end-to-end run is
-  explicitly deferred, with the reason and the follow-up recorded in that doc. No workflow-spine
-  change → no diagram REV. Suite 5254→5287.
+  explicitly deferred, with the reason and the follow-up recorded in that doc. The Step-11
+  cross-model pass (gpt-5.6-sol) returned 7 findings and all 7 were fixed, not deferred: `discover`
+  now FAILS on an empty corpus instead of reporting `total cases: 0` and exiting 0; `load_cases`
+  refuses a file with neither case key (truncation used to read as a deliberate stub); skill
+  matching is namespace-aware, so `other-plugin:pane-handoff` can no longer satisfy a gate on
+  `rawgentic:pane-handoff`; a refusal no longer passes on a dead session, and one that names the
+  correct route requires that route to fire; the refusal regex is bound to clause order, so
+  "Invokes pane-handoff but does not invoke clear-prep" is a trigger; and the manual procedure
+  gained real containment (disposable workspace-less cwd + `--disallowed-tools`) because the corpus
+  prompts are live requests and this CLI has no `--max-turns`. No workflow-spine change → no
+  diagram REV. Suite 5254→5303.
 
 ### v3.128.4 (2026-08-05)
 - **Milestone epics referenced from the plan (#756 follow-through, part 2).** The five milestone

--- a/README.md
+++ b/README.md
@@ -755,8 +755,8 @@ For major changes, please open an issue first to discuss the approach.
   correct route requires that route to fire; the refusal regex is bound to clause order, so
   "Invokes pane-handoff but does not invoke clear-prep" is a trigger; and the manual procedure
   gained real containment (disposable workspace-less cwd + `--disallowed-tools`) because the corpus
-  prompts are live requests and this CLI has no `--max-turns`. No workflow-spine change → no
-  diagram REV. Suite 5254→5303.
+  prompts are live requests and this CLI has no `--max-turns`.
+  No workflow-spine change → no diagram REV. Suite 5254→5303.
 
 ### v3.128.4 (2026-08-05)
 - **Milestone epics referenced from the plan (#756 follow-through, part 2).** The five milestone

--- a/docs/skill-evals.md
+++ b/docs/skill-evals.md
@@ -71,12 +71,43 @@ python3 hooks/skill_evals.py run --file skills/epic-run/evals/evals.json
 
 `run --live` deliberately **refuses** and points here, rather than pretending an automated verdict.
 
+### Containment first — the prompts are real requests
+
+**Read this before running anything.** The corpus prompts are not inert strings. They include
+"Implement issue #42 for me", "cycle through all issues in epic #906" and
+"Run /rawgentic:new-project my-app". Submitted to a real installed plugin inside a real checkout,
+a correct selection is followed by the skill *doing its job* — branching, committing, filing
+issues, standing up a campaign. Observing selection must not become performing the work.
+
+There is **no turn cap to lean on**: Claude Code as installed here (2.x) has no `--max-turns` flag
+(checked against `claude --help`), so "stop immediately after the `Skill` event" cannot be
+enforced by the CLI. Containment is therefore two things you must do yourself:
+
+1. **Run from a disposable scratch directory, never a real project checkout** — and one with no
+   reachable `.rawgentic_workspace.json`. Every rawgentic workflow skill loads config as its first
+   act and STOPS when the workspace file is missing, which is exactly the behaviour you want: the
+   skill is selected (the observation lands) and then declines to proceed.
+2. **Deny the mutating tools**, so a fired skill cannot change anything even if it tries:
+
+   ```bash
+   claude -p "<the case prompt, verbatim>" \
+     --disallowed-tools "Bash Edit Write NotebookEdit" \
+     --output-format stream-json
+   ```
+
+   `--disallowed-tools` takes a comma- or space-separated list of tool names to deny. Selection is
+   recorded before any denial matters, so the verdict survives the containment.
+
+Treat any case whose prompt names a real issue or epic number as the highest-risk case, and
+consider rewriting it to an obviously fictional number before running it live.
+
 ### The manual gate, step by step
 
 1. Exit every session using rawgentic hooks (`CLAUDE.md` §7 step 1).
 2. `claude plugin remove rawgentic@rawgentic && claude plugin install rawgentic@rawgentic`.
-3. Start a fresh session per case and submit the case's `prompt` verbatim, with no other context —
-   context contaminates selection, which is the behaviour under test.
+3. From the contained scratch directory above, start a fresh session per case and submit the case's
+   `prompt` verbatim, with no other context — context contaminates selection, which is the
+   behaviour under test.
 4. Read the verdict from the transcript, not from the reply. A selection appears as an `assistant`
    line carrying a `tool_use` block named `Skill`:
 
@@ -88,8 +119,17 @@ python3 hooks/skill_evals.py run --file skills/epic-run/evals/evals.json
    `skills_selected(transcript_text)` parses exactly that. The shape was verified on 2026-08-05
    against a real 1.5 MB transcript under `~/.claude/projects/<slug>/<session-id>.jsonl` — it is
    measured, not guessed.
-5. Judge with `judge(case, selected, skill_name)`. For a `refuse` case, the skill **firing** is the
-   failure.
+5. Judge with `judge(case, selected, skill_name, responded=transcript_responded(text))`. Three
+   rules that are easy to get backwards:
+   - For a `refuse` case, the skill **firing** is the failure.
+   - A `refuse` case does **not** pass on a dead session. `responded=False` fails it, because "the
+     skill was absent" and "nothing came back" are the same observation and only the first is
+     success.
+   - A `refuse` case that names the correct route instead (`expect_skill`) requires **that** skill
+     to fire. `epic-run` case 5 is not satisfied by epic-run merely being absent — the request must
+     actually reach `implement-feature`. Two such redirects are derived from the corpus today
+     (`epic-run` cases 5 and 6); a case may also state `expect_skill` explicitly, which wins over
+     inference.
 
 ## Why the `peer-consult` stub is skipped, and why discovery still reads it
 
@@ -101,10 +141,18 @@ spellings; reading a file is not the same as counting it.
 
 ## Deferred verification
 
-The live end-to-end run — steps 1-5 above against a freshly installed build — has **not** been
-executed for this change, and could not be: the epic #906 auto-run that shipped it is itself a
-long-lived session using these hooks, so the reinstall in step 2 was prohibited throughout. Every
-component below the spawn is covered by `tests/hooks/test_skill_evals.py`; the spawn boundary is
-covered only by that fake. The first person able to run step 2 on a quiet host should execute the
-gate for `epic-run` (its 403 restored description characters are the case with no prior selection
-evidence at all) and record the result here.
+**The live end-to-end run has NOT been executed for this change, and could not be.** The epic #906
+auto-run that shipped it is itself a long-lived session using these hooks, so the reinstall in step
+2 was prohibited throughout — the same prohibition that stopped #909.
+
+| | |
+|---|---|
+| **Deferred** | the live gate: steps 1-5 against a freshly installed build |
+| **Why** | `CLAUDE.md` §7 / mistake #5 — no reinstall while hook-using sessions are live |
+| **Local proxy that DID run** | all 49 tests in `tests/hooks/test_skill_evals.py`, plus `discover` over the real 44-case corpus, with the transcript parser pinned against a real 1.5 MB transcript |
+| **What the proxy cannot show** | that a real session, given a corpus prompt, selects the skill the case expects. Every component *below* the spawn is covered; the spawn itself is covered only by a fake |
+| **Target check** | run the gate for `rawgentic:epic-run` first — its 403 restored description characters have never been exercised for selection at all — then record the per-case verdicts in this section |
+
+Whoever runs it should also confirm the containment above behaves as described: that a workflow
+skill selected inside a workspace-less scratch directory really does stop at its config gate. That
+claim is reasoned from the skills' documented `<config-loading>` contract, **not** measured.

--- a/docs/skill-evals.md
+++ b/docs/skill-evals.md
@@ -1,0 +1,110 @@
+# Skill-selection evals — the behavioural gate (#928)
+
+A skill's `description` is exactly what selection keys on, and a selection regression is
+**silent**: no error, no failing test — the skill simply never fires. #700 recorded seven such
+misses for `pane-handoff` in 36 hours.
+
+Eleven `evals.json` files have sat in this repo as data for a harness that did not exist here. The
+tests that mention them check *existence*, the computed README fraction and membership
+(`tests/hooks/test_adversarial_review_registration.py:345-372`), or pin trigger phrasings as plain
+substrings (`tests/test_skill_description_budget.py:438-499`). **None of them exercised selection.**
+`hooks/skill_evals.py` is the missing piece.
+
+## The three intents, and where each signal comes from
+
+The corpus already carries three distinct intents. They are read from **different places**, and
+getting that wrong inverts the gate:
+
+| Intent | Signal | Read from |
+|---|---|---|
+| `slash` | the prompt carries an explicit `/…` command for **this** skill | the **prompt** |
+| `refuse` | the leading clause negates an invocation verb | the **expected output** |
+| `trigger` | neither of the above — natural language must select the skill | default |
+
+Two measured reasons the naive readings fail:
+
+- **`slash` must not come from `expected_output`.** A first cut matched any path-shaped token, so
+  `./projects/my-app`, `docs/reviews` and `wrong-org/wrong-repo` all read as slash commands,
+  mislabelling natural-language cases across five skills. Note also that **not one prompt in the
+  corpus starts with `/`** — all twelve command-driven cases embed it mid-sentence ("Run
+  `/rawgentic:switch backend-api`. The working directory is …"), so `startswith("/")` finds nothing.
+- **`refuse` must be scoped to the leading clause and bound to an invocation verb.** A whole-text
+  "does not" match called `pane-handoff` cases 1, 4 and 5 refusals — i.e. asserted the skill must
+  **not** fire for three of its dominant real phrasings. Those cases are positive; their prose
+  merely says what the skill does not do *internally* ("It does NOT issue herdr terminal
+  primitives itself"). Only case 6 negates the invocation, and it does so in its first sentence.
+
+`slash` takes precedence over `refuse`: an explicit command selects the skill by construction, so a
+command-driven case is never a *selection* refusal. `adversarial-review` case 2 opens "Refuses: the
+artifact path resolves outside the project root" — that is the skill running and then rejecting its
+**argument**, which for a selection gate is a successful selection.
+
+## Where it runs — the decision (#928's fourth checkbox)
+
+**A live verdict is a documented MANUAL gate, not a CI lane.** Not for cost — for a hard
+prerequisite:
+
+- Selection runs from the **installed plugin cache**
+  (`~/.claude/plugins/cache/rawgentic/rawgentic/<version>/`), never from this repo.
+- Proving a **not-yet-installed** build still selects correctly therefore needs that build
+  installed, and reinstalling while sessions using its hooks are live is prohibited
+  (`CLAUDE.md` §7, mistake #5). That is precisely what stopped #909 from building this.
+- CI cannot install a plugin build and start real sessions, so a `pytest` lane cannot produce the
+  verdict without faking the very thing under test.
+
+What IS automated, in the ordinary suite: discovery, both on-disk schemas, intent classification
+(pinned against the real corpus), transcript parsing, and every verdict rule — because the live
+spawn is an **injected seam**. `tests/hooks/test_skill_evals.py` passes a fake submitter.
+
+**One distinction worth keeping straight:** *observing* a verdict needs no reinstall — the
+already-installed build answers fine. Only validating a build that is not yet installed does.
+
+## Running it
+
+```bash
+# Every eval file, its case count and its intent mix. Exit 1 on an unreadable file.
+python3 hooks/skill_evals.py discover --skills-root skills
+
+# One skill's cases and their classified intents.
+python3 hooks/skill_evals.py run --file skills/epic-run/evals/evals.json
+```
+
+`run --live` deliberately **refuses** and points here, rather than pretending an automated verdict.
+
+### The manual gate, step by step
+
+1. Exit every session using rawgentic hooks (`CLAUDE.md` §7 step 1).
+2. `claude plugin remove rawgentic@rawgentic && claude plugin install rawgentic@rawgentic`.
+3. Start a fresh session per case and submit the case's `prompt` verbatim, with no other context —
+   context contaminates selection, which is the behaviour under test.
+4. Read the verdict from the transcript, not from the reply. A selection appears as an `assistant`
+   line carrying a `tool_use` block named `Skill`:
+
+   ```json
+   {"type": "assistant", "message": {"content": [
+       {"type": "tool_use", "name": "Skill", "input": {"skill": "rawgentic:epic-run"}}]}}
+   ```
+
+   `skills_selected(transcript_text)` parses exactly that. The shape was verified on 2026-08-05
+   against a real 1.5 MB transcript under `~/.claude/projects/<slug>/<session-id>.jsonl` — it is
+   measured, not guessed.
+5. Judge with `judge(case, selected, skill_name)`. For a `refuse` case, the skill **firing** is the
+   failure.
+
+## Why the `peer-consult` stub is skipped, and why discovery still reads it
+
+`skills/peer-consult/evals.json` is `{"skill": "peer-consult", "cases": []}` — an empty stub, and
+the README documents it as such. It contributes no cases. But it uses a **different schema** from
+every real file (`skill` + `cases` instead of `skill_name` + `evals`), so a loader that assumes one
+shape either crashes or silently reports zero cases for a *real* file. `load_cases` accepts both
+spellings; reading a file is not the same as counting it.
+
+## Deferred verification
+
+The live end-to-end run — steps 1-5 above against a freshly installed build — has **not** been
+executed for this change, and could not be: the epic #906 auto-run that shipped it is itself a
+long-lived session using these hooks, so the reinstall in step 2 was prohibited throughout. Every
+component below the spawn is covered by `tests/hooks/test_skill_evals.py`; the spawn boundary is
+covered only by that fake. The first person able to run step 2 on a quiet host should execute the
+gate for `epic-run` (its 403 restored description characters are the case with no prior selection
+evidence at all) and record the result here.

--- a/hooks/skill_evals.py
+++ b/hooks/skill_evals.py
@@ -1,0 +1,318 @@
+"""#928 — the behavioural gate that proves a skill still gets SELECTED.
+
+**Why this exists.** Skill `description` text is exactly what selection keys on, and a
+selection regression is SILENT: no error, no failing test — the skill simply never fires.
+#700 recorded seven such misses for `pane-handoff` in 36 hours. Eleven real `evals.json`
+files sat in this repo as data for a harness that did not exist; the tests that mention
+them check EXISTENCE, the computed README fraction, or pin trigger phrasings as plain
+substrings (`tests/test_skill_description_budget.py:438-499`). None exercised selection.
+
+**The seam, and why it is where it is.** Selection runs from the INSTALLED plugin cache
+(`~/.claude/plugins/cache/rawgentic/rawgentic/<version>/`), not from this repo, so a real
+verdict needs a live session. Reinstalling the plugin while sessions using its hooks are
+live is prohibited (repo `CLAUDE.md` §7, mistake #5) — that is what stopped #909 from
+building this. So `submit` is INJECTED: every classification, parse and verdict is pure
+and runs in the ordinary pytest lane, and only the live spawn sits behind the seam.
+
+Note what this means and does not mean, because the distinction is the whole design:
+observing a verdict needs no reinstall — the ALREADY-installed build answers fine. Only
+proving a NOT-YET-INSTALLED build still selects correctly needs one. That is a manual
+gate by nature, not a CI lane, which resolves the issue's fourth checkbox.
+
+**The transcript shape is measured, not guessed.** A selection appears as an `assistant`
+line carrying a `tool_use` block named `Skill`:
+
+    {"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "name": "Skill", "input": {"skill": "rawgentic:switch"}}]}}
+
+Verified 2026-08-05 against a real 1.5 MB session transcript under
+`~/.claude/projects/<slug>/<session-id>.jsonl`.
+
+Fail-mode: this is a GATE, so it fails CLOSED — an unreadable eval file raises, and a
+dead submitter scores its case as FAILED, never as a pass (repo mistake #9: a vacuous
+result is a failed dispatch).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+# Both sanctioned eval locations, plus the skill-root spelling that really occurs
+# (`skills/peer-consult/evals.json`). The first two are what
+# `tests/hooks/test_adversarial_review_registration.py` computes the README fraction
+# from; the third is a file that exists and must be READ rather than crashed on. Reading
+# it is not the same as counting it — it holds zero cases, which the README documents as
+# a deliberate stub, so it contributes nothing to a run either way.
+_EVAL_GLOBS = ("*/evals/evals.json", "*/evals.json")
+
+# Refusal is tested FIRST and wins, because a negative case routinely names the skill it
+# must not run (`pane-handoff` case 6 does exactly that). Checking "mentions the skill"
+# first is how a harness gets negative cases backwards — the failure mode the issue
+# explicitly warns about.
+#
+# But a bare negation anywhere in the prose is NOT the signal, and getting that wrong
+# inverts the gate. Measured against the real corpus: `pane-handoff` cases 1, 4 and 5 are
+# POSITIVE cases whose prose also says what the skill does not do INTERNALLY — "It does
+# NOT issue herdr terminal primitives itself", "pane-handoff does not itself invoke
+# clear-prep", "Does not claim to read a meter directly". A whole-text match called all
+# three refusals, i.e. asserted the skill must NOT fire for three of its dominant real
+# phrasings. So refusal is scoped to the LEADING CLAUSE and must negate an INVOCATION
+# verb: every positive case in this corpus opens with what the skill DOES ("Invokes…",
+# "Runs…", "Offers or performs…"), and the one true negative opens with "Does NOT run".
+_INVOKE_VERB = r"(?:invoke|invokes|run|runs|trigger|triggers|fire|fires|use|uses|call|calls)"
+_REFUSE_LEAD = re.compile(
+    r"\b(?:does\s+not|doesn'?t|do\s+not|don'?t|must\s+not|should\s+not|never|will\s+not|"
+    r"won'?t|refuses?\s+to)\s+" + _INVOKE_VERB + r"\b", re.I)
+# A leading clause that is *only* a refusal statement, e.g. "No skill fires here."
+_REFUSE_BARE = re.compile(r"^\s*(?:no\s+skill|nothing)\b.{0,40}?\b"
+                          r"(?:fires?|runs?|invoked|selected)\b", re.I)
+
+# The leading clause: up to the first sentence break. `—` counts as a break because this
+# corpus routinely uses an em-dash to start the qualifying half of a sentence, which is
+# where the internal negations live.
+_LEAD_SPLIT = re.compile(r"(?<=[.!?])\s|\s+—\s+|\n")
+
+
+class EvalError(ValueError):
+    """Raised on an eval file this module cannot trust. Fails closed, never silently."""
+
+
+def discover_eval_files(skills_root) -> list[Path]:
+    """Every eval file under `skills_root`, de-duplicated, in stable sorted order."""
+    root = Path(skills_root)
+    seen: dict[Path, None] = {}
+    for pattern in _EVAL_GLOBS:
+        for p in sorted(root.glob(pattern)):
+            seen.setdefault(p.resolve(), None)
+    return sorted(seen, key=lambda p: p.as_posix())
+
+
+def load_cases(path) -> tuple[str, list[dict]]:
+    """`(skill_name, cases)` from one eval file. Accepts BOTH key spellings on disk.
+
+    The real files use `skill_name` + `evals`; the `peer-consult` stub uses `skill` +
+    `cases`. Assuming one shape either crashes or silently reports zero cases for a real
+    file, so both are read and each case is normalised to
+    `{"id", "prompt", "expected_output", "intent"}`.
+    """
+    p = Path(path)
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise EvalError(f"{p}: unreadable or malformed eval file: {e}") from e
+    if not isinstance(raw, dict):
+        raise EvalError(f"{p}: top level must be an object, got {type(raw).__name__}")
+
+    name = raw.get("skill_name") or raw.get("skill")
+    if not isinstance(name, str) or not name.strip():
+        raise EvalError(f"{p}: no usable skill name (`skill_name` or `skill`)")
+
+    entries = raw.get("evals")
+    if entries is None:
+        entries = raw.get("cases")
+    if entries is None:
+        entries = []
+    if not isinstance(entries, list):
+        raise EvalError(f"{p}: `evals`/`cases` must be a list")
+
+    cases = []
+    for i, e in enumerate(entries):
+        if not isinstance(e, dict):
+            raise EvalError(f"{p}: case {i} is not an object")
+        prompt = e.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise EvalError(f"{p}: case {e.get('id', i)} has no prompt")
+        expected = e.get("expected_output") or ""
+        cases.append({"id": e.get("id", i + 1), "prompt": prompt,
+                      "expected_output": expected,
+                      "intent": classify_intent(expected, prompt, name)})
+    return name.strip(), cases
+
+
+def _slash_command_for(prompt: str, skill_name: str) -> bool:
+    """Does `prompt` carry an explicit `/…` command invoking THIS skill?
+
+    Measured against the corpus: not one prompt starts with `/`. All twelve
+    command-driven cases embed it mid-sentence — "Run /rawgentic:switch backend-api. The
+    working directory is …" — so a `startswith("/")` test finds nothing.
+
+    Keyed on the skill's own name, deliberately. `implement-feature` case 2 expects the
+    skill to STOP and tell the user to run `/rawgentic:setup`; that is a different
+    skill's command appearing in the OUTPUT, and treating any command as this case's
+    invocation would relabel a natural-language case as a slash one.
+    """
+    bare = (skill_name or "").split(":")[-1].strip()
+    if not bare:
+        return False
+    pattern = re.compile(r"/(?:[a-z0-9_-]+:)?" + re.escape(bare) + r"\b", re.I)
+    return bool(pattern.search(prompt or ""))
+
+
+def classify_intent(expected_output: str, prompt: str = "", skill_name: str = "") -> str:
+    """One of `refuse`, `slash`, `trigger` — the three intents already in the data.
+
+    The signals come from DIFFERENT places, which is the correction that made this agree
+    with the corpus:
+
+    - `slash` is a property of the PROMPT (an explicit command for this skill). Reading
+      it from `expected_output` matched any path-shaped token — `./projects/my-app`,
+      `docs/reviews`, `wrong-org/wrong-repo` — and mislabelled natural-language cases
+      across five skills.
+    - `refuse` is a property of the expected OUTPUT, scoped to the leading clause and
+      requiring a negated invocation verb (see `_REFUSE_LEAD`).
+
+    Precedence: `slash` first. An explicit command selects the skill by construction, so
+    a command-driven case is never a selection refusal — `adversarial-review` case 2
+    opens "Refuses: the artifact path resolves outside the project root", but that is the
+    skill running and then rejecting its ARGUMENT, which for a selection gate is a
+    successful selection.
+    """
+    text = (expected_output or "").strip()
+    if _slash_command_for(prompt, skill_name):
+        return "slash"
+    if not text:
+        return "trigger"
+    lead = _LEAD_SPLIT.split(text)[0]
+    if _REFUSE_LEAD.search(lead) or _REFUSE_BARE.search(lead):
+        return "refuse"
+    return "trigger"
+
+
+def skills_selected(transcript_text: str) -> list[str]:
+    """Skills the session actually invoked, in order, from a transcript's JSONL text.
+
+    Tolerant by design: a transcript is an append-only log that can hold partial or
+    non-JSON lines, and a parse error on one line must not hide the selections on the
+    others. An empty list is a real answer — it is the silent-regression signature.
+    """
+    out: list[str] = []
+    for line in (transcript_text or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(rec, dict):
+            continue
+        content = (rec.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        for blk in content:
+            if (isinstance(blk, dict) and blk.get("type") == "tool_use"
+                    and blk.get("name") == "Skill"):
+                chosen = (blk.get("input") or {}).get("skill")
+                if isinstance(chosen, str) and chosen.strip():
+                    out.append(chosen.strip())
+    return out
+
+
+def _same_skill(selected: str, wanted: str) -> bool:
+    """`rawgentic:pane-handoff` and `pane-handoff` name the same skill.
+
+    Eval files spell the prefixed form; `SKILL.md` frontmatter carries the bare name
+    (#552), so a comparison keyed on either spelling alone would misjudge half the corpus.
+    """
+    return selected.split(":")[-1] == wanted.split(":")[-1]
+
+
+def judge(case: dict, selected, skill_name: str) -> dict:
+    """Verdict for one case: did the RIGHT thing happen for this case's intent?"""
+    chosen = list(selected or [])
+    fired = any(_same_skill(s, skill_name) for s in chosen)
+    intent = case.get("intent", "trigger")
+    cid = case.get("id")
+
+    if intent == "refuse":
+        passed = not fired
+        why = ("correctly did not invoke it" if passed
+               else f"{skill_name} fired, but this case requires it NOT to")
+    else:
+        passed = fired
+        if fired:
+            why = "invoked as required"
+        elif not chosen:
+            why = "no skill was invoked at all (the silent-regression signature)"
+        else:
+            why = f"the wrong skill fired: {', '.join(chosen)}"
+    return {"id": cid, "intent": intent, "passed": passed, "why": why,
+            "selected": chosen, "skill": skill_name}
+
+
+def run(cases, skill_name: str, submit) -> list[dict]:
+    """Judge every case, submitting each prompt through the INJECTED `submit`.
+
+    `submit(prompt) -> transcript_text`. A submitter that raises scores its case as
+    FAILED and keeps going: a dead spawn is a failed dispatch, never a clean pass, and
+    one dead case must not discard the verdicts already earned.
+    """
+    results = []
+    for case in cases or []:
+        try:
+            transcript = submit(case["prompt"])
+        except Exception as e:  # noqa: BLE001 — any submitter failure is a case failure
+            results.append({"id": case.get("id"), "intent": case.get("intent", "trigger"),
+                            "passed": False, "why": f"submitter failed: {e}",
+                            "selected": [], "skill": skill_name})
+            continue
+        results.append(judge(case, skills_selected(transcript), skill_name))
+    return results
+
+
+def _main(argv: list[str]) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        prog="skill_evals.py",
+        description="Discover skill eval files and report their cases and intents. "
+                    "Selection itself is a MANUAL gate — see --live.")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_d = sub.add_parser("discover", help="list eval files with case counts and intents")
+    p_d.add_argument("--skills-root", default="skills")
+
+    p_r = sub.add_parser("run", help="judge one skill's cases")
+    p_r.add_argument("--file", required=True, help="an evals.json path")
+    p_r.add_argument("--live", action="store_true",
+                     help="actually spawn `claude -p` per prompt against the INSTALLED "
+                          "build. Refused here: it needs a live session and, to test an "
+                          "unreleased build, a reinstall that is prohibited while "
+                          "hook-using sessions run (CLAUDE.md §7).")
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "discover":
+        total = 0
+        for f in discover_eval_files(args.skills_root):
+            try:
+                name, cases = load_cases(f)
+            except EvalError as e:
+                print(f"INVALID {f}: {e}")
+                return 1
+            total += len(cases)
+            intents = {}
+            for c in cases:
+                intents[c["intent"]] = intents.get(c["intent"], 0) + 1
+            shape = ", ".join(f"{k}={v}" for k, v in sorted(intents.items())) or "none"
+            print(f"{f}  skill={name}  cases={len(cases)}  [{shape}]")
+        print(f"total cases: {total}")
+        return 0
+
+    name, cases = load_cases(args.file)
+    if args.live:
+        print("REFUSED: --live is a documented manual gate, not an automated lane.\n"
+              "  A verdict needs a real session started against the installed build.\n"
+              "  See docs/skill-evals.md for the exact procedure and why CI cannot run it.")
+        return 2
+    print(f"skill={name} cases={len(cases)}")
+    for c in cases:
+        print(f"  case {c['id']}: intent={c['intent']}  prompt={c['prompt'][:60]!r}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    import sys as _sys
+    raise SystemExit(_main(_sys.argv[1:]))

--- a/hooks/skill_evals.py
+++ b/hooks/skill_evals.py
@@ -69,10 +69,24 @@ _REFUSE_LEAD = re.compile(
 _REFUSE_BARE = re.compile(r"^\s*(?:no\s+skill|nothing)\b.{0,40}?\b"
                           r"(?:fires?|runs?|invoked|selected)\b", re.I)
 
+# A positive invocation, used only to decide whether a refusal in the same clause comes
+# FIRST (review finding 6). Present participles and third-person forms both occur.
+_POSITIVE_LEAD = re.compile(
+    r"\b(?:invokes?|invoking|runs?|running|fires?|triggers?|uses?|calls?|"
+    r"offers\s+or\s+performs|performs)\b", re.I)
+
 # The leading clause: up to the first sentence break. `—` counts as a break because this
 # corpus routinely uses an em-dash to start the qualifying half of a sentence, which is
 # where the internal negations live.
 _LEAD_SPLIT = re.compile(r"(?<=[.!?])\s|\s+—\s+|\n")
+
+# A refusal often names where the request SHOULD go instead. Rather than parse English,
+# look for a NAMESPACE-QUALIFIED skill name — `rawgentic:create-issue`, optionally
+# slash-prefixed — because that spelling only appears in this corpus when a specific skill
+# is being named. The target skill itself is excluded by the caller. Deliberately narrow:
+# an unqualified bare word is NOT treated as a redirect, since inferring an assertion from
+# ordinary prose is how an oracle starts failing for reasons nobody can read.
+_QUALIFIED_SKILL = re.compile(r"/?\b([a-z0-9_-]+):([a-z0-9-]{3,})\b", re.I)
 
 
 class EvalError(ValueError):
@@ -109,11 +123,19 @@ def load_cases(path) -> tuple[str, list[dict]]:
     if not isinstance(name, str) or not name.strip():
         raise EvalError(f"{p}: no usable skill name (`skill_name` or `skill`)")
 
-    entries = raw.get("evals")
-    if entries is None:
-        entries = raw.get("cases")
-    if entries is None:
-        entries = []
+    # Cross-model review finding 3: absence of BOTH keys used to collapse to zero cases,
+    # so a truncated file or a misspelled key produced a silent empty corpus for that
+    # skill — indistinguishable from a deliberate stub. A DECLARED empty list is still
+    # fine (the `peer-consult` stub declares `cases: []`); an absent key is not.
+    if "evals" in raw:
+        entries = raw["evals"]
+    elif "cases" in raw:
+        entries = raw["cases"]
+    else:
+        raise EvalError(
+            f"{p}: neither `evals` nor `cases` is present. A file declaring no cases must "
+            f"say so explicitly (`\"cases\": []`); an absent key is indistinguishable from "
+            f"truncation or a misspelling, and this is a gate.")
     if not isinstance(entries, list):
         raise EvalError(f"{p}: `evals`/`cases` must be a list")
 
@@ -125,9 +147,17 @@ def load_cases(path) -> tuple[str, list[dict]]:
         if not isinstance(prompt, str) or not prompt.strip():
             raise EvalError(f"{p}: case {e.get('id', i)} has no prompt")
         expected = e.get("expected_output") or ""
-        cases.append({"id": e.get("id", i + 1), "prompt": prompt,
-                      "expected_output": expected,
-                      "intent": classify_intent(expected, prompt, name)})
+        intent = classify_intent(expected, prompt, name)
+        case = {"id": e.get("id", i + 1), "prompt": prompt,
+                "expected_output": expected, "intent": intent}
+        # A refusal that names the CORRECT route must require that route (review
+        # finding 2): epic-run case 5's absence of epic-run is not success if nothing
+        # fired at all. An explicit `expect_skill` in the data wins over inference.
+        redirect = e.get("expect_skill") or (
+            redirect_skill(expected, name) if intent == "refuse" else None)
+        if redirect:
+            case["expect_skill"] = redirect
+        cases.append(case)
     return name.strip(), cases
 
 
@@ -178,9 +208,18 @@ def classify_intent(expected_output: str, prompt: str = "", skill_name: str = ""
     if not text:
         return "trigger"
     lead = _LEAD_SPLIT.split(text)[0]
-    if _REFUSE_LEAD.search(lead) or _REFUSE_BARE.search(lead):
-        return "refuse"
-    return "trigger"
+    refusal = _REFUSE_LEAD.search(lead) or _REFUSE_BARE.search(lead)
+    if not refusal:
+        return "trigger"
+    # Cross-model review finding 6: the negation was never bound to the target skill, so
+    # a single sentence that BOTH invokes it and declines a different one — "Invokes
+    # pane-handoff but does not invoke clear-prep." — inverted the oracle. A real refusal
+    # leads with the negation; a positive invocation appearing FIRST means the skill is
+    # expected to fire and the negation is about something else.
+    positive = _POSITIVE_LEAD.search(lead)
+    if positive and positive.start() < refusal.start():
+        return "trigger"
+    return "refuse"
 
 
 def skills_selected(transcript_text: str) -> list[str]:
@@ -214,25 +253,91 @@ def skills_selected(transcript_text: str) -> list[str]:
 
 
 def _same_skill(selected: str, wanted: str) -> bool:
-    """`rawgentic:pane-handoff` and `pane-handoff` name the same skill.
+    """Do these name the same skill? NAMESPACE-AWARE (review finding 5).
 
-    Eval files spell the prefixed form; `SKILL.md` frontmatter carries the bare name
-    (#552), so a comparison keyed on either spelling alone would misjudge half the corpus.
+    `rawgentic:pane-handoff` and the bare `pane-handoff` are the same skill — eval files
+    spell the prefixed form while `SKILL.md` frontmatter carries the bare name (#552), so
+    a comparison keyed on either spelling alone misjudges half the corpus.
+
+    But comparing ONLY the bare tail made `other-plugin:pane-handoff` satisfy a gate on
+    `rawgentic:pane-handoff`, so a same-named skill from another plugin could hide a real
+    rawgentic selection failure. Namespaces are therefore compared whenever BOTH sides
+    carry one; the tail-only fallback applies only when one side is unqualified.
     """
-    return selected.split(":")[-1] == wanted.split(":")[-1]
+    sel, want = (selected or "").strip(), (wanted or "").strip()
+    if not sel or not want:
+        return False
+    sel_ns, _, sel_bare = sel.rpartition(":")
+    want_ns, _, want_bare = want.rpartition(":")
+    if sel_bare != want_bare:
+        return False
+    if sel_ns and want_ns:
+        return sel_ns.lower() == want_ns.lower()
+    return True
 
 
-def judge(case: dict, selected, skill_name: str) -> dict:
-    """Verdict for one case: did the RIGHT thing happen for this case's intent?"""
+def redirect_skill(expected_output: str, skill_name: str) -> str | None:
+    """The skill a refusal says should run INSTEAD, or None.
+
+    Only a namespace-qualified name counts (see `_QUALIFIED_SKILL`), and the target skill
+    itself never counts as its own redirect.
+    """
+    if not isinstance(expected_output, str):
+        return None
+    for m in _QUALIFIED_SKILL.finditer(expected_output):
+        candidate = f"{m.group(1)}:{m.group(2)}"
+        if not _same_skill(candidate, skill_name):
+            return candidate
+    return None
+
+
+def transcript_responded(transcript_text: str) -> bool:
+    """Did the session actually produce an assistant turn?
+
+    This is the difference between "it answered, and chose no skill" and "nothing came
+    back". Review finding 2: without it, a refusal case PASSED on a dead spawn or an
+    unparseable transcript — reporting the very silent-failure mode the gate exists to
+    catch as a success.
+    """
+    for line in (transcript_text or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(rec, dict) and rec.get("type") == "assistant":
+            return True
+    return False
+
+
+def judge(case: dict, selected, skill_name: str, responded: bool = True) -> dict:
+    """Verdict for one case: did the RIGHT thing happen for this case's intent?
+
+    `responded` says the session produced an assistant turn at all. It is required for a
+    refusal to pass, because "the skill was absent" and "nothing happened" are the same
+    observation and only the first is success.
+    """
     chosen = list(selected or [])
     fired = any(_same_skill(s, skill_name) for s in chosen)
     intent = case.get("intent", "trigger")
     cid = case.get("id")
+    redirect = case.get("expect_skill")
 
     if intent == "refuse":
-        passed = not fired
-        why = ("correctly did not invoke it" if passed
-               else f"{skill_name} fired, but this case requires it NOT to")
+        if not responded:
+            passed, why = False, ("no usable transcript — the session did not respond, so "
+                                  "absence of the skill is not evidence of refusal")
+        elif fired:
+            passed, why = False, f"{skill_name} fired, but this case requires it NOT to"
+        elif redirect and not any(_same_skill(s, redirect) for s in chosen):
+            passed, why = False, (f"{skill_name} correctly did not fire, but this case "
+                                  f"requires {redirect} instead and it did not fire "
+                                  f"(selected: {', '.join(chosen) or 'nothing'})")
+        else:
+            passed, why = True, ("correctly did not invoke it" if not redirect
+                                 else f"correctly routed to {redirect} instead")
     else:
         passed = fired
         if fired:
@@ -271,7 +376,8 @@ def run(cases, skill_name: str, submit) -> list[dict]:
         except Exception as e:  # noqa: BLE001 — any submitter failure is a case failure
             results.append(_fail(f"submitter failed: {e}"))
             continue
-        results.append(judge(case, skills_selected(transcript), skill_name))
+        results.append(judge(case, skills_selected(transcript), skill_name,
+                             responded=transcript_responded(transcript)))
     return results
 
 
@@ -298,8 +404,15 @@ def _main(argv: list[str]) -> int:
     args = ap.parse_args(argv)
 
     if args.cmd == "discover":
+        files = discover_eval_files(args.skills_root)
+        # Review finding 1: this used to print `total cases: 0` and exit 0, so a mistyped
+        # --skills-root read as a successful coverage check over an empty corpus.
+        if not files:
+            print(f"FAILED: no eval files under {args.skills_root!r}. A gate cannot report "
+                  f"success over a corpus it did not find — check the path.")
+            return 1
         total = 0
-        for f in discover_eval_files(args.skills_root):
+        for f in files:
             try:
                 name, cases = load_cases(f)
             except EvalError as e:

--- a/hooks/skill_evals.py
+++ b/hooks/skill_evals.py
@@ -169,7 +169,10 @@ def classify_intent(expected_output: str, prompt: str = "", skill_name: str = ""
     skill running and then rejecting its ARGUMENT, which for a selection gate is a
     successful selection.
     """
-    text = (expected_output or "").strip()
+    # Not a string is not a refusal. `expected_output` is hand-authored per skill, so a
+    # dict or a null there must classify as a plain trigger rather than raise out of a
+    # classifier — the caller is a gate, and crashing it is worse than reading no signal.
+    text = expected_output.strip() if isinstance(expected_output, str) else ""
     if _slash_command_for(prompt, skill_name):
         return "slash"
     if not text:
@@ -251,12 +254,22 @@ def run(cases, skill_name: str, submit) -> list[dict]:
     """
     results = []
     for case in cases or []:
+        def _fail(why: str) -> dict:
+            return {"id": case.get("id"), "intent": case.get("intent", "trigger"),
+                    "passed": False, "why": why, "selected": [], "skill": skill_name}
+
+        # Read the prompt OUTSIDE the spawn guard. Reading it inside attributed a
+        # KeyError in our own data to "submitter failed", which misdirects whoever is
+        # debugging a live spawn — and it would have called the submitter's failure path
+        # without ever calling the submitter.
+        prompt = case.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            results.append(_fail("malformed case: no usable `prompt`"))
+            continue
         try:
-            transcript = submit(case["prompt"])
+            transcript = submit(prompt)
         except Exception as e:  # noqa: BLE001 — any submitter failure is a case failure
-            results.append({"id": case.get("id"), "intent": case.get("intent", "trigger"),
-                            "passed": False, "why": f"submitter failed: {e}",
-                            "selected": [], "skill": skill_name})
+            results.append(_fail(f"submitter failed: {e}"))
             continue
         results.append(judge(case, skills_selected(transcript), skill_name))
     return results

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.128.4",
+  "version": "3.129.0",
   "description": "9 SDLC workflow skills + 9 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/skills/epic-run/evals/evals.json
+++ b/skills/epic-run/evals/evals.json
@@ -1,0 +1,36 @@
+{
+  "skill_name": "rawgentic:epic-run",
+  "_note": "#928. These cases exist for one reason: the 403 characters #909 restored to this skill's description were DEAD TEXT before that PR and had never been exercised for selection. Every prompt below is one of the description's own trigger phrasings, so a future description edit that drops one fails here instead of failing silently in a live session. Cases 5 and 6 are the description's two explicit NOT-for-this-skill boundaries; they matter because a single-issue request routed to the epic driver would set up a whole campaign for one issue. Selection only — none of these starts a campaign, drafts a real /goal, or touches .driver-state.",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "cycle through all issues in epic #906",
+      "expected_output": "Invokes the rawgentic:epic-run skill. This is the dominant real phrasing for an epic auto-run and appears verbatim in the skill's description. The skill derives the queue from the epic's task-list checkboxes, asks for the merge policy, and drafts the /goal condition — it does not implement any child itself."
+    },
+    {
+      "id": 2,
+      "prompt": "write me a goal for the epic",
+      "expected_output": "Invokes the rawgentic:epic-run skill, whose Step 3 owns drafting the campaign /goal condition. A goal request scoped to an EPIC belongs here rather than to a per-issue workflow, because a per-issue goal lets the session quit after any single child."
+    },
+    {
+      "id": 3,
+      "prompt": "auto-run these children",
+      "expected_output": "Invokes the rawgentic:epic-run skill. A terse request naming 'children' is still an epic-run request; the skill establishes the queue order and the per-child contract before anything executes."
+    },
+    {
+      "id": 4,
+      "prompt": "Sequence WF2 across the epic's task list, one child at a time.",
+      "expected_output": "Invokes the rawgentic:epic-run skill. Sequencing WF2 over an epic's task list is this skill's subject, and it terminates each child at that child's own Step 16 rather than reaching into a WF2 step."
+    },
+    {
+      "id": 5,
+      "prompt": "Implement issue #731 for me.",
+      "expected_output": "Does NOT invoke the rawgentic:epic-run skill. The description excludes a single issue explicitly, and routing one issue through the epic driver would stand up a campaign, a driver-state file and a revalidation gate for work that /rawgentic:implement-feature handles directly. Invokes rawgentic:implement-feature instead."
+    },
+    {
+      "id": 6,
+      "prompt": "Help me define epic #906 and write out what its children should be.",
+      "expected_output": "Does NOT invoke the rawgentic:epic-run skill. Defining or planning the epic itself is /rawgentic:create-issue's job per this skill's own description; epic-run consumes an epic that already has a task list and would find no queue to derive."
+    }
+  ]
+}

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.128.4"
+EXPECTED_PLUGIN_VERSION = "3.129.0"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_skill_evals.py
+++ b/tests/hooks/test_skill_evals.py
@@ -320,3 +320,37 @@ def test_run_records_a_submitter_failure_as_a_failed_case_not_a_pass():
 
 def test_run_on_zero_cases_is_an_empty_result_not_a_vacuous_pass():
     assert skill_evals.run([], "peer-consult", lambda p: "") == []
+
+
+# --- inline self-review findings (mechanical + bug_logic lens) ------------------------
+
+def test_a_malformed_case_is_not_blamed_on_the_submitter():
+    """A case missing `prompt` must not be reported as 'submitter failed'.
+
+    The first version read `case["prompt"]` INSIDE the try that guards the spawn, so a
+    KeyError in our own data was attributed to the submitter — misdirecting whoever reads
+    the failure at exactly the moment they are debugging a live spawn.
+    """
+    calls = []
+    results = skill_evals.run([{"id": 1, "intent": "trigger"}], "s",
+                              lambda p: calls.append(p) or "")
+    assert results[0]["passed"] is False
+    assert "prompt" in results[0]["why"].lower()
+    assert "submitter" not in results[0]["why"].lower()
+    assert calls == [], "a malformed case must never reach the submitter"
+
+
+def test_a_non_string_expected_output_does_not_crash_the_loader(tmp_path):
+    """`expected_output` is authored by hand per skill; a dict there must not raise
+    AttributeError out of `classify_intent`. It carries no refusal signal, so the case
+    is a trigger."""
+    p = tmp_path / "evals.json"
+    _write(p, {"skill_name": "s", "evals": [
+        {"id": 1, "prompt": "go", "expected_output": {"unexpected": "shape"}}]})
+    name, cases = skill_evals.load_cases(p)
+    assert cases[0]["intent"] == "trigger"
+
+
+def test_classify_intent_tolerates_a_non_string_argument():
+    assert skill_evals.classify_intent(None) == "trigger"
+    assert skill_evals.classify_intent({"a": 1}) == "trigger"

--- a/tests/hooks/test_skill_evals.py
+++ b/tests/hooks/test_skill_evals.py
@@ -1,0 +1,322 @@
+"""#928 — the behavioural selection gate for skill evals.
+
+Everything here is unit-testable BECAUSE the live spawn is an injected seam. The one
+thing that genuinely needs an installed build and a real session — actually starting
+`claude -p` — is the `submit` callable, and these tests pass a fake. What is NOT faked
+is the transcript SHAPE: `skills_selected` is tested against the exact block shape
+observed in a real 1.5 MB session transcript on 2026-08-05,
+
+    {"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "name": "Skill", "input": {"skill": "rawgentic:switch", ...}}]}}
+
+so the parser is not written against a guessed format.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "hooks"))
+
+import skill_evals  # noqa: E402
+
+
+# --- discovery -----------------------------------------------------------------------
+
+def _write(p: Path, obj) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def test_discover_finds_both_sanctioned_locations(tmp_path):
+    """A skill's own evals/ dir AND its -workspace sibling both count.
+
+    These are the two locations `tests/hooks/test_adversarial_review_registration.py`
+    computes the README fraction from, so discovery must agree with that guard.
+    """
+    root = tmp_path / "skills"
+    _write(root / "alpha" / "evals" / "evals.json", {"skill_name": "a", "evals": []})
+    _write(root / "beta-workspace" / "evals" / "evals.json", {"skill_name": "b", "evals": []})
+    found = {p.relative_to(root).as_posix() for p in skill_evals.discover_eval_files(root)}
+    assert found == {"alpha/evals/evals.json", "beta-workspace/evals/evals.json"}
+
+
+def test_discover_also_finds_a_skill_root_evals_file(tmp_path):
+    """`skills/peer-consult/evals.json` really exists, at the skill ROOT.
+
+    Discovery must SEE it (a runner that cannot read a file is not the same thing as a
+    count guard that deliberately excludes it — see the zero-case test below).
+    """
+    root = tmp_path / "skills"
+    _write(root / "peer-consult" / "evals.json", {"skill": "peer-consult", "cases": []})
+    found = {p.relative_to(root).as_posix() for p in skill_evals.discover_eval_files(root)}
+    assert found == {"peer-consult/evals.json"}
+
+
+# --- loading ------------------------------------------------------------------------
+
+def test_load_cases_reads_the_real_schema(tmp_path):
+    p = tmp_path / "evals.json"
+    _write(p, {"skill_name": "rawgentic:pane-handoff",
+               "evals": [{"id": 1, "prompt": "hand it over",
+                          "expected_output": "Invokes the rawgentic:pane-handoff skill."}]})
+    name, cases = skill_evals.load_cases(p)
+    assert name == "rawgentic:pane-handoff"
+    assert [c["id"] for c in cases] == [1]
+    assert cases[0]["prompt"] == "hand it over"
+
+
+def test_load_cases_tolerates_the_peer_consult_stub_schema(tmp_path):
+    """The stub is `{"skill": ..., "cases": []}` — a DIFFERENT spelling of both keys.
+
+    A loader that assumes one shape crashes or silently reports zero cases for a real
+    file. Zero cases here is correct, but it must be reached by reading the file, not by
+    failing to parse it.
+    """
+    p = tmp_path / "evals.json"
+    _write(p, {"skill": "peer-consult", "cases": []})
+    name, cases = skill_evals.load_cases(p)
+    assert name == "peer-consult"
+    assert cases == []
+
+
+def test_load_cases_refuses_a_malformed_file(tmp_path):
+    p = tmp_path / "evals.json"
+    p.write_text("{not json", encoding="utf-8")
+    with pytest.raises(skill_evals.EvalError):
+        skill_evals.load_cases(p)
+
+
+# --- intent classification ----------------------------------------------------------
+
+@pytest.mark.parametrize("expected, intent", [
+    # The real pane-handoff case 6 — a NEGATIVE case. This is the one a naive
+    # "prompt must trigger skill" harness gets backwards, which the issue calls out.
+    ("Does NOT run the ad-hoc handoff. That command LAUNCHES a successor;", "refuse"),
+    ("Does not invoke the skill; points at the runbook instead.", "refuse"),
+    # Plain natural-language triggering.
+    ("Invokes the rawgentic:pane-handoff skill. 'pass off' is the dominant phrasing.",
+     "trigger"),
+])
+def test_classify_intent(expected, intent):
+    assert skill_evals.classify_intent(expected) == intent
+
+
+# --- slash intent comes from the PROMPT, which the corpus settles -------------------
+#
+# Measured: NOT ONE prompt in the corpus starts with "/". All 12 slash-invocation cases
+# phrase it as "Run /rawgentic:<skill> <args>. The working directory is …". And deriving
+# slash from `expected_output` was actively wrong — the first version matched any
+# path-shaped token, so "./projects/my-app", "docs/reviews" and "wrong-org/wrong-repo"
+# all read as slash commands, mislabelling natural-language cases across five skills.
+
+def test_slash_intent_is_read_from_an_embedded_command_not_a_leading_one():
+    """The real phrasing: the command sits mid-sentence after 'Run'."""
+    assert skill_evals.classify_intent(
+        "Prints the notice, invokes the engine, writes a report.",
+        prompt="Run /rawgentic:adversarial-review docs/plan.md plan. The working directory is /tmp",
+        skill_name="rawgentic:adversarial-review") == "slash"
+
+
+def test_a_path_in_the_expected_output_is_not_a_slash_command():
+    """The regression that mislabelled five skills' natural-language cases."""
+    assert skill_evals.classify_intent(
+        "Creates ./projects/my-app directory, runs git init, writes docs/reviews/x.md.",
+        prompt="Set up a new project called my-app for me.",
+        skill_name="rawgentic:new-project") == "trigger"
+
+
+def test_a_slash_command_for_a_DIFFERENT_skill_is_not_this_skill_s_slash_case():
+    """`implement-feature` case 2's prompt is natural language; its OUTPUT mentions
+    /rawgentic:setup — the skill telling the user to run something else. That must not
+    make it a slash-invocation case for implement-feature."""
+    assert skill_evals.classify_intent(
+        "Agent detects missing .rawgentic.json, STOPs, and tells user to run /rawgentic:setup",
+        prompt="Implement issue #10 for me. The workspace file is at /tmp/x.json",
+        skill_name="rawgentic:implement-feature") == "trigger"
+
+
+def test_corpus_slash_membership_is_exactly_the_four_command_driven_skills():
+    """Corpus-level guard on the whole 38-case set.
+
+    adversarial-review, new-project, setup and switch phrase every case as an explicit
+    command; nothing else in the corpus does. This pins the issue's own claim that all
+    three adversarial-review cases are slash invocations.
+    """
+    repo = Path(__file__).resolve().parents[2]
+    by_skill = {}
+    for f in skill_evals.discover_eval_files(repo / "skills"):
+        name, cases = skill_evals.load_cases(f)
+        if not cases:
+            continue
+        for c in cases:
+            by_skill.setdefault(name, []).append(c["intent"])
+
+    assert by_skill["rawgentic:adversarial-review"] == ["slash", "slash", "slash"]
+    for name in ("rawgentic:new-project", "rawgentic:setup", "rawgentic:switch"):
+        assert set(by_skill[name]) == {"slash"}, f"{name}: {by_skill[name]}"
+    # And the natural-language skills carry NO slash cases at all.
+    for name in ("rawgentic:pane-handoff", "rawgentic:fix-bug",
+                 "rawgentic:sync-security-patterns", "rawgentic:incident"):
+        assert "slash" not in by_skill[name], f"{name}: {by_skill[name]}"
+
+
+def test_refusal_wins_over_a_skill_mention():
+    """Case 6 names the skill AND says it must not run. Refusal must not be masked."""
+    text = ("Does NOT run the ad-hoc handoff. Points at docs/runbooks/herdr.md 7.1.2 "
+            "instead of invoking rawgentic:pane-handoff.")
+    assert skill_evals.classify_intent(text) == "refuse"
+
+
+# --- the real corpus, which broke the first classifier -------------------------------
+#
+# Verbatim `expected_output` strings from skills/pane-handoff-workspace/evals/evals.json.
+# The first classifier matched "does not" ANYWHERE and so called cases 1, 4 and 5
+# refusals — asserting that pane-handoff must NOT fire for three of its dominant real
+# phrasings, which is the exact inversion #928 warns a naive harness produces. The
+# distinction these pin: a POSITIVE case may still say what the skill does not do
+# INTERNALLY; only a negated INVOCATION in the leading clause is a refusal.
+
+_CASE_1 = ("Invokes the rawgentic:pane-handoff skill. 'pass off' is the dominant phrasing in "
+           "real requests, not 'handoff', so this must trigger. The skill assembles the anchor "
+           "pane from $HERDR_PANE_ID and the project from the session-registry row, and drives "
+           "launcher_lib.py ad-hoc-handoff. It does NOT issue herdr terminal primitives itself.")
+_CASE_4 = ("Runs clear-prep first to produce the handoff payload, then invokes "
+           "rawgentic:pane-handoff CONSUMING its resume-prompt file and goal text. pane-handoff "
+           "does not itself invoke clear-prep — clear-prep lives outside this repository.")
+_CASE_5 = ("Offers or performs the pass-off unprompted, because the directive tier is the "
+           "trigger the user expects to act on without asking. Does not claim to read a meter "
+           "directly — it reacts to the hook's reminder, whose threshold and window belong to "
+           "contextMeter (#687/#701).")
+_CASE_6 = ("Does NOT run the ad-hoc handoff. That command LAUNCHES a successor; an "
+           "already-running pane is not a herdr-registered agent, so its gates do not apply. "
+           "Points at docs/runbooks/herdr.md section 7.1.2 for the by-hand case instead.")
+
+
+@pytest.mark.parametrize("text, intent, why", [
+    (_CASE_1, "trigger", "negation is about herdr primitives, not about invoking"),
+    (_CASE_4, "trigger", "negation is about not invoking clear-prep, a DIFFERENT skill"),
+    (_CASE_5, "trigger", "negation is about not reading a meter directly"),
+    (_CASE_6, "refuse", "the leading clause negates the invocation itself"),
+])
+def test_real_pane_handoff_corpus_classifies_correctly(text, intent, why):
+    assert skill_evals.classify_intent(text) == intent, why
+
+
+def test_only_one_real_pane_handoff_case_is_a_refusal():
+    """Corpus-level guard: 5 triggers + 1 refusal. A drift here inverts the gate."""
+    repo = Path(__file__).resolve().parents[2]
+    _, cases = skill_evals.load_cases(
+        repo / "skills" / "pane-handoff-workspace" / "evals" / "evals.json")
+    intents = [c["intent"] for c in cases]
+    assert intents.count("refuse") == 1, f"expected exactly 1 refusal, got {intents}"
+    assert intents.count("trigger") == 5, f"expected 5 triggers, got {intents}"
+    # And it must be case 6 specifically, not merely one-of-six.
+    assert next(c["id"] for c in cases if c["intent"] == "refuse") == 6
+
+
+# --- transcript parsing (shape verified against a real transcript) -------------------
+
+def _transcript(*skills) -> str:
+    lines = [json.dumps({"type": "user", "message": {"content": "hi"}})]
+    for s in skills:
+        lines.append(json.dumps({"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "sure"},
+            {"type": "tool_use", "name": "Skill", "input": {"skill": s, "args": ""}}]}}))
+    return "\n".join(lines) + "\n"
+
+
+def test_skills_selected_reads_the_observed_block_shape():
+    text = _transcript("rawgentic:switch", "rawgentic:implement-feature")
+    assert skill_evals.skills_selected(text) == [
+        "rawgentic:switch", "rawgentic:implement-feature"]
+
+
+def test_skills_selected_ignores_other_tools_and_bad_lines():
+    lines = [
+        "not json at all",
+        json.dumps({"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}]}}),
+        json.dumps({"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "name": "Skill", "input": {"skill": "dataviz"}}]}}),
+    ]
+    assert skill_evals.skills_selected("\n".join(lines)) == ["dataviz"]
+
+
+def test_skills_selected_empty_when_nothing_fired():
+    """The silent-regression signature: no error, no skill. Must read as empty, not crash."""
+    assert skill_evals.skills_selected(_transcript()) == []
+
+
+# --- judging ------------------------------------------------------------------------
+
+def test_trigger_case_passes_when_the_skill_fired():
+    v = skill_evals.judge({"id": 1, "intent": "trigger"}, ["rawgentic:pane-handoff"],
+                          "rawgentic:pane-handoff")
+    assert v["passed"] is True
+
+
+def test_trigger_case_fails_when_nothing_fired():
+    v = skill_evals.judge({"id": 1, "intent": "trigger"}, [], "rawgentic:pane-handoff")
+    assert v["passed"] is False
+    assert "no skill" in v["why"].lower()
+
+
+def test_trigger_case_fails_when_the_wrong_skill_fired():
+    v = skill_evals.judge({"id": 1, "intent": "trigger"}, ["rawgentic:switch"],
+                          "rawgentic:pane-handoff")
+    assert v["passed"] is False
+
+
+def test_refuse_case_passes_when_the_skill_did_not_fire():
+    v = skill_evals.judge({"id": 6, "intent": "refuse"}, ["rawgentic:switch"],
+                          "rawgentic:pane-handoff")
+    assert v["passed"] is True
+
+
+def test_refuse_case_fails_when_the_skill_fired():
+    """Backwards-harness regression guard: firing is a FAILURE for a negative case."""
+    v = skill_evals.judge({"id": 6, "intent": "refuse"}, ["rawgentic:pane-handoff"],
+                          "rawgentic:pane-handoff")
+    assert v["passed"] is False
+
+
+def test_bare_name_matches_a_prefixed_selection():
+    """Eval files spell `rawgentic:pane-handoff`; a file may spell the bare name."""
+    v = skill_evals.judge({"id": 1, "intent": "trigger"}, ["rawgentic:pane-handoff"],
+                          "pane-handoff")
+    assert v["passed"] is True
+
+
+# --- the run loop, with the live spawn injected --------------------------------------
+
+def test_run_uses_the_injected_submitter_and_never_spawns():
+    """The whole point of the seam: this runs in an ordinary pytest lane."""
+    calls = []
+
+    def fake_submit(prompt):
+        calls.append(prompt)
+        return _transcript("rawgentic:pane-handoff")
+
+    cases = [{"id": 1, "prompt": "hand it over", "intent": "trigger"},
+             {"id": 6, "prompt": "send to pane w1:pQ7", "intent": "refuse"}]
+    results = skill_evals.run(cases, "rawgentic:pane-handoff", fake_submit)
+    assert calls == ["hand it over", "send to pane w1:pQ7"]
+    assert [r["passed"] for r in results] == [True, False]
+
+
+def test_run_records_a_submitter_failure_as_a_failed_case_not_a_pass():
+    """A dead spawn is a FAILED dispatch, never a clean pass (repo mistake #9)."""
+    def broken_submit(prompt):
+        raise RuntimeError("claude -p died")
+
+    results = skill_evals.run([{"id": 1, "prompt": "x", "intent": "trigger"}],
+                              "s", broken_submit)
+    assert results[0]["passed"] is False
+    assert "died" in results[0]["why"]
+
+
+def test_run_on_zero_cases_is_an_empty_result_not_a_vacuous_pass():
+    assert skill_evals.run([], "peer-consult", lambda p: "") == []

--- a/tests/hooks/test_skill_evals.py
+++ b/tests/hooks/test_skill_evals.py
@@ -354,3 +354,112 @@ def test_a_non_string_expected_output_does_not_crash_the_loader(tmp_path):
 def test_classify_intent_tolerates_a_non_string_argument():
     assert skill_evals.classify_intent(None) == "trigger"
     assert skill_evals.classify_intent({"a": 1}) == "trigger"
+
+
+# --- Step-11 cross-model review findings ---------------------------------------------
+# Seven findings from the gpt-5.6-sol pass. Each was reproduced against the code before
+# being fixed; these pin the fixes. The theme is that this is a GATE, so every
+# "nothing to see" path must be distinguishable from "looked and it was fine".
+
+def test_F1_discover_refuses_an_empty_or_missing_corpus(tmp_path, capsys):
+    """A mistyped --skills-root printed `total cases: 0` and exited 0.
+
+    For a coverage gate that is a vacuous success: the one command meant to establish
+    that a corpus exists reported fine when there was no corpus at all.
+    """
+    assert skill_evals._main(["discover", "--skills-root", str(tmp_path / "nope")]) == 1
+    assert "no eval files" in capsys.readouterr().out.lower()
+
+
+def test_F3_a_file_with_neither_case_key_is_refused(tmp_path):
+    """Truncation or a misspelled key silently produced a zero-case corpus."""
+    p = tmp_path / "evals.json"
+    _write(p, {"skill_name": "truncated"})
+    with pytest.raises(skill_evals.EvalError, match="neither"):
+        skill_evals.load_cases(p)
+
+
+def test_F3_an_explicit_empty_case_list_is_still_accepted(tmp_path):
+    """The peer-consult stub declares `cases: []`. Declared-empty != key-absent."""
+    p = tmp_path / "evals.json"
+    _write(p, {"skill": "peer-consult", "cases": []})
+    assert skill_evals.load_cases(p) == ("peer-consult", [])
+
+
+@pytest.mark.parametrize("selected, wanted, same", [
+    ("rawgentic:pane-handoff", "rawgentic:pane-handoff", True),
+    # F5: a same-named skill from ANOTHER plugin must not satisfy this gate.
+    ("other-plugin:pane-handoff", "rawgentic:pane-handoff", False),
+    # One side unqualified still matches — eval files spell the prefixed form while
+    # SKILL.md frontmatter carries the bare name (#552).
+    ("rawgentic:pane-handoff", "pane-handoff", True),
+    ("pane-handoff", "rawgentic:pane-handoff", True),
+    ("rawgentic:switch", "rawgentic:pane-handoff", False),
+])
+def test_F5_skill_matching_is_namespace_aware(selected, wanted, same):
+    assert skill_evals._same_skill(selected, wanted) is same
+
+
+def test_F6_a_negation_after_a_positive_invocation_is_not_a_refusal():
+    """`_REFUSE_LEAD` was not bound to the target skill, so a single sentence that both
+    invokes it and declines a DIFFERENT skill inverted the oracle."""
+    assert skill_evals.classify_intent(
+        "Invokes pane-handoff but does not invoke clear-prep.") == "trigger"
+
+
+def test_F6_a_leading_refusal_is_still_a_refusal():
+    assert skill_evals.classify_intent(
+        "Does NOT run the ad-hoc handoff, and does not invoke clear-prep.") == "refuse"
+
+
+def test_F2_a_refusal_does_not_pass_on_an_unusable_transcript():
+    """The sharpest finding: `passed = not fired` made a dead session look like correct
+    refusal — the exact silent-failure mode this gate exists to catch."""
+    v = skill_evals.judge({"id": 6, "intent": "refuse"}, [], "rawgentic:pane-handoff",
+                          responded=False)
+    assert v["passed"] is False
+    assert "no usable" in v["why"].lower() or "did not respond" in v["why"].lower()
+
+
+def test_F2_a_refusal_passes_when_the_session_responded_and_chose_otherwise():
+    v = skill_evals.judge({"id": 6, "intent": "refuse"}, ["rawgentic:switch"],
+                          "rawgentic:pane-handoff", responded=True)
+    assert v["passed"] is True
+
+
+def test_F2_a_refusal_that_names_a_redirect_requires_that_skill_to_fire():
+    """epic-run case 5 says "Invokes rawgentic:implement-feature instead". Absence of
+    epic-run is not enough — the correct route must actually be taken."""
+    case = {"id": 5, "intent": "refuse", "expect_skill": "rawgentic:implement-feature"}
+    assert skill_evals.judge(case, [], "rawgentic:epic-run", responded=True)["passed"] is False
+    ok = skill_evals.judge(case, ["rawgentic:implement-feature"], "rawgentic:epic-run",
+                           responded=True)
+    assert ok["passed"] is True
+
+
+def test_F2_the_redirect_is_derived_from_the_real_epic_run_corpus():
+    repo = Path(__file__).resolve().parents[2]
+    _, cases = skill_evals.load_cases(repo / "skills" / "epic-run" / "evals" / "evals.json")
+    by_id = {c["id"]: c for c in cases}
+    assert by_id[5]["expect_skill"] == "rawgentic:implement-feature"
+    assert by_id[6]["expect_skill"] == "rawgentic:create-issue"
+    # A plain trigger case carries no redirect.
+    assert by_id[1].get("expect_skill") is None
+
+
+def test_transcript_responded_distinguishes_dead_from_quiet():
+    assert skill_evals.transcript_responded(_transcript("dataviz")) is True
+    # An assistant turn that chose no skill is a real answer.
+    assert skill_evals.transcript_responded(
+        json.dumps({"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "I will not do that."}]}})) is True
+    # Nothing, or unparseable noise, is NOT.
+    assert skill_evals.transcript_responded("") is False
+    assert skill_evals.transcript_responded("not json\nalso not json") is False
+
+
+def test_run_passes_the_responded_signal_through():
+    """A submitter returning an empty transcript must fail a refusal case end-to-end."""
+    results = skill_evals.run([{"id": 6, "prompt": "x", "intent": "refuse"}], "s",
+                              lambda p: "")
+    assert results[0]["passed"] is False


### PR DESCRIPTION
## What this does

Turns eleven `evals.json` files from inert data into a runnable **behavioural selection gate**.

A skill's `description` is exactly what selection keys on, and a selection regression is **silent**:
no error, no failing test — the skill simply never fires. #700 recorded seven such misses for
`pane-handoff` in 36 hours. The tests that mention evals today check *existence*, the computed
README fraction, or pin trigger phrasings as plain substrings. None exercised selection.

New `hooks/skill_evals.py`:

| Function | Job |
|---|---|
| `discover_eval_files` | both sanctioned locations plus the skill-root spelling; **fails** on an empty corpus |
| `load_cases` | accepts both on-disk schemas; refuses a file with neither case key |
| `classify_intent` | `trigger` / `slash` / `refuse`, each from its correct signal |
| `skills_selected` | parses a transcript for `Skill` `tool_use` blocks |
| `transcript_responded` | distinguishes "answered, chose nothing" from "nothing came back" |
| `redirect_skill` | the route a refusal says to take instead |
| `judge` / `run` | per-case verdict; `submit` is injected |

## The design decision that made it testable

Selection runs from the **installed plugin cache**, not this repo, so a real verdict needs a live
session against an installed build — and reinstalling while hook-using sessions are live is
prohibited (`CLAUDE.md` §7, mistake #5). That is exactly what stopped #909 from building this.

So the live spawn is an **injected seam**: all 49 tests run in the ordinary lane against a fake
submitter, and the live run is a documented manual gate (`docs/skill-evals.md`) — which is this
issue's fourth acceptance criterion, decided rather than left open.

The transcript shape is **measured, not guessed** — verified against a real 1.5 MB session
transcript.

## Two defects found by running the real corpus instead of fixtures

Both would have inverted the gate:

1. A whole-text `"does not"` match called `pane-handoff` cases **1, 4 and 5** refusals — asserting
   the skill must *not* fire for three of its dominant real phrasings. Those negations describe what
   the skill does not do *internally* ("It does NOT issue herdr terminal primitives itself").
2. Reading `slash` from `expected_output` matched any path-shaped token, so `./projects/my-app`,
   `docs/reviews` and `wrong-org/wrong-repo` read as slash commands, mislabelling natural-language
   cases across **five** skills. `slash` now comes from the prompt, keyed on the skill's own name.
   (Not one prompt in the corpus starts with `/` — all twelve embed the command mid-sentence.)

## Step 11 — 7 findings, all 7 fixed

Cross-model pass (`gpt-5.6-sol`, `status: success`, `diagnostic: false`): **5 High, 2 Medium**. Each
was reproduced against the code before being fixed; none was deferred.

| # | Sev | Finding | Fix |
|---|---|---|---|
| F1 | High | `discover` exited 0 on a mistyped root, printing `total cases: 0` | fails with the path it tried |
| F2 | High | a refusal passed on a dead session, and on absence alone | requires `responded`; a named redirect must actually fire |
| F3 | High | neither case key ⇒ silent zero-case corpus | declared `[]` fine, absent key raises |
| F4 | High | live verification not run, yet shipped | recorded as a proper deferral (below) |
| F5 | High | `other-plugin:pane-handoff` satisfied `rawgentic:pane-handoff` | namespace-aware matching |
| F6 | Med | negation not bound to clause order, inverting a one-sentence case | positive invocation first ⇒ trigger |
| F7 | Med | the manual procedure ran live requests with no isolation | real containment, residual risk named |

**F7 is worth reading.** The corpus prompts are live requests — "Implement issue #42 for me",
"cycle through all issues in epic #906". I checked: this CLI has **no `--max-turns`**, so
"stop after selection" cannot be enforced by a flag. Containment is stated as what it actually is —
a disposable workspace-less cwd plus `--disallowed-tools` — rather than implied.

## Also

- `skills/epic-run/evals/evals.json` — six cases over the **403 description characters #909
  restored**, which had never been exercised for selection, including both of that description's
  NOT-for-this-skill boundaries (AC3).
- Evals fraction 10/21 → 11/21, README have-none list updated (both drift-guarded).
- Version 3.128.4 → **3.129.0** on all three surfaces.

## Deferred verification

| | |
|---|---|
| **Deferred** | the live gate: a real session per case against a freshly installed build |
| **Why** | `CLAUDE.md` §7 / mistake #5 — no reinstall while hook-using sessions are live. The epic #906 auto-run shipping this **is** such a session. |
| **Local proxy that ran** | 49 tests + `discover` over the real 44-case corpus + parser pinned to a real transcript |
| **What the proxy cannot show** | that a real session, given a corpus prompt, selects what the case expects. Everything *below* the spawn is covered; the spawn is covered only by a fake. |
| **Target check** | run the gate for `rawgentic:epic-run` first, then record per-case verdicts in `docs/skill-evals.md` |

One further claim is **reasoned, not measured**: that a workflow skill selected inside a
workspace-less scratch directory stops at its config gate. It follows from the documented
`<config-loading>` contract; it was not run.

## Verification

- **Full suite: 5254 → 5303, exit 0** (baseline recorded before any work; +49 all from this change)
- **Both lint lanes: 10.00/10, exit 0**
- **Security scan: PASS** (`iac` recorded as a visible skip — not applicable to this project)
- Real entry path exercised: `python3 hooks/skill_evals.py discover --skills-root skills` → 12 files,
  44 cases, intents stable across every fix
- No workflow-spine change → **no diagram REV**

Closes #928
Part of #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)
