### PR TITLE
feat(wf2,telemetry): run-records land exactly once — idempotent persist + persist-before-merge (#888)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.129.1",
+  "version": "3.130.0",
   "description": "9 SDLC workflow skills + 9 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -736,11 +736,16 @@ For major changes, please open an issue first to discuss the approach.
   run fingerprint (`run_id`, else a digest excluding `generated_at`/`schema_version`/`timing` —
   `timing` because `_auto_embed_timing` recomputes it on a recovery re-run), no-ops with a
   one-line stderr notice at rc 0, and falls open to appending on an unreadable store since losing
-  a record beats duplicating one. Step 16 gains the `--no-persist` render-only path. 20 tests
-  added in `tests/hooks/test_work_summary.py` + `tests/test_wf2_clarity.py`; the existing
+  a record beats duplicating one — and the check plus the append now run under one `flock`, the
+  shape `decision_log.append_record` already uses, so two writers cannot both miss and both
+  append. Only a line that VALIDATES as a record can shadow a record, after review showed a
+  `{"run_id": …}` stub could otherwise suppress the real one. Step 16 gains the `--no-persist`
+  render-only path, and Step 14 proves this run's line landed with `git show --numstat` rather
+  than the issue-scoped `find`, which an earlier run's record satisfies. 26 tests added in
+  `tests/hooks/test_work_summary.py` + `tests/test_wf2_clarity.py`; the existing
   `test_each_line_is_independent_json` was repaired, as the guard would have left it passing on a
   single line while testing nothing it names; `references/step-14.md`'s prose ceiling was raised
-  trim-first (4_727 + 256) for the genuinely new gated sub-step. No workflow-spine change → no diagram REV. Suite 5340→5360.
+  trim-first (4_975 + 256) for the genuinely new gated sub-step. No workflow-spine change → no diagram REV. Suite 5340→5366.
 
 ### v3.129.1 (2026-08-05)
 - **Ad-hoc pane handoff failures now name their cause (#731, epic #906).** `perform_handoff`

--- a/README.md
+++ b/README.md
@@ -725,6 +725,23 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.130.0 (2026-08-05)
+- **Run-records now land exactly once (#888, epic #871).** Closes both measured halves of the
+  telemetry-loss problem this issue absorbed. Dropped (#588): WF2 Step 14 gains the merge-grant
+  sub-step — assemble, `usage_capture`, `summarize`, commit the JSONL line as `chore(telemetry)`,
+  re-verify CI per-sha on the new head, prove it landed with `work_summary.py find --issue`, and
+  only then merge — because Step 16 ran after the merge and orphaned the record when anything
+  interrupted the gap (saystory epic #204 persisted 1 of 6 children). Duplicated (#355):
+  `persist_record` blind-appended, so a Step-16 re-run double-recorded; it is now idempotent on a
+  run fingerprint (`run_id`, else a digest excluding `generated_at`/`schema_version`/`timing` —
+  `timing` because `_auto_embed_timing` recomputes it on a recovery re-run), no-ops with a
+  one-line stderr notice at rc 0, and falls open to appending on an unreadable store since losing
+  a record beats duplicating one. Step 16 gains the `--no-persist` render-only path. 20 tests
+  added in `tests/hooks/test_work_summary.py` + `tests/test_wf2_clarity.py`; the existing
+  `test_each_line_is_independent_json` was repaired, as the guard would have left it passing on a
+  single line while testing nothing it names; `references/step-14.md`'s prose ceiling was raised
+  trim-first (4_727 + 256) for the genuinely new gated sub-step. No workflow-spine change → no diagram REV. Suite 5340→5360.
+
 ### v3.129.1 (2026-08-05)
 - **Ad-hoc pane handoff failures now name their cause (#731, epic #906).** `perform_handoff`
   derives `failure_detail` for every `failed_step` (`record()` auto-notes failed steps from the

--- a/docs/planning/2026-08-05-888-run-records-land-exactly-once.md
+++ b/docs/planning/2026-08-05-888-run-records-land-exactly-once.md
@@ -1,0 +1,113 @@
+# #888 — Run-records that land exactly once (brief design note)
+
+**Date:** 2026-08-05 · **Lane:** small-standard (5 impl files ≤ 7, `standard_feature`)
+**Epic:** #871 (M4 wave, records-first) · **Absorbs:** #588 (dropped) + #355 (duplicated)
+
+## Problem
+
+A run-record must land in `docs/measurements/run_records.jsonl` **exactly once**. Today it can
+land zero times or twice, and both were measured live:
+
+- **Zero (#588).** WF2 Step 16 persists the record *after* Step 14 merges, so a run that merges
+  its own PR orphans its record — a crash, compaction, or context exhaustion between the two
+  loses it. Measured: saystory epic #204, **1 of 6 children** persisted a record. #879 needed a
+  separate backfill PR (#882).
+- **Twice (#355).** `persist_record` (`hooks/work_summary.py:1069`) opens the store `"a"` and
+  writes unconditionally — no idempotency guard. A re-run of Step 16 (the documented
+  crash-recovery path) silently double-records. Observed live on the WF2 #340 run: a duplicate
+  line the orchestrator had to notice in `git diff` and hand-discard.
+
+The #880 run dodged the drop by improvising the right order; this issue makes that order the
+contract and closes the duplicate hole structurally.
+
+## Fix — one transactional persistence contract
+
+**1. Cannot be duplicated — `persist_record` gains an idempotency guard (code).**
+
+Identity is a **run fingerprint**:
+
+- the record's `run_id` when present (#473's grammar-safe I3↔I2 join key), else
+- SHA-256 over the record's canonical JSON with the **writer-stamped and auto-computed** keys
+  removed: `generated_at`, `schema_version`, `timing`.
+
+Removing those three is the load-bearing part, and `timing` is there for a reason the first draft
+of this design missed (Step-4 self-review finding 1, High): `_auto_embed_timing` computes `timing`
+from the per-run step-state history at persist time whenever the record file omits it. A recovery
+re-run happens later, against a history that has grown, so its `timing` differs — a fingerprint
+that included it would differ too, and the guard would fail to fire in **exactly** the
+crash-recovery case it exists for. `generated_at` is the same class of problem, one clock tick
+wide. `usage` is *not* excluded: it is read from the record file, so it is stable across re-runs of
+the same file.
+
+Before appending, the store's existing lines are fingerprinted; a match means the run is already
+recorded, so nothing is appended and the caller is told. The CLI prints a loud stderr notice
+naming the workflow, issue and store — never the record body — and still exits **0**: the desired
+end state (this run's record is in the store) holds, and a recovery re-run must not look like a
+failure.
+
+A genuinely different record for the same issue (a later re-run with different findings) has a
+different fingerprint and appends normally. That is correct: the guard deduplicates *runs*, not
+issues.
+
+**Fail-open, deliberately.** If the store cannot be read at dedupe time, the guard warns and
+appends anyway. Losing a record is the worse failure — that is this issue's own priority ranking
+(#588's measured 1-in-6 drop against #355's single hand-discarded duplicate), and it matches the
+repo's fail-mode convention: data you cannot classify is kept, never dropped.
+
+**2. Cannot be dropped — Step 14 codifies persist-before-merge (prose).**
+
+When a merge grant is live, Step 14's new sub-step is the #880 sequence, in order: assemble the
+record → `usage_capture.py capture` → `work_summary.py summarize` (persists) → commit the
+persisted JSONL line into the PR as a `chore(telemetry)` commit → **re-verify CI on the new head,
+per-sha** → merge. `work_summary.py find --issue <n>` (rc 0 = landed, rc 1 = missing) is the
+mechanical proof the record exists before the merge is attempted. The record's shape on this path
+is documented: `outcome.merged: null` (the merge had not happened when the record was written)
+plus a `follow_ups` entry naming the ordering.
+
+**3. Never summarized twice — Step 16 gains the render-only path (prose).**
+
+Step 16 notes that on the merge-grant path the record is already persisted, so that run renders
+from it with `--no-persist` instead of calling `summarize` a second time. The guard in (1) is the
+backstop, not the plan.
+
+**4. Clarity pin.** `tests/test_wf2_clarity.py` pins the canonical Step-14 sentence, anchored to
+one sentence in one file per the repo's drift-guard convention.
+
+## Files
+
+| File | Change |
+|---|---|
+| `hooks/work_summary.py` | `record_fingerprint()` + idempotency guard in `persist_record`; CLI notice |
+| `skills/implement-feature/references/step-14.md` | merge-grant sub-step (AC i) |
+| `skills/implement-feature/references/step-16.md` | render-only path note (AC iii) |
+| `tests/hooks/test_work_summary.py` | fingerprint + guard + CLI-notice tests; **repair `test_each_line_is_independent_json`** |
+| `tests/test_wf2_clarity.py` | canonical-sentence pin (AC ii) |
+
+Plus the three version surfaces and the README changelog entry.
+
+## A test the guard would silently hollow out
+
+`tests/hooks/test_work_summary.py::TestPersistRecord::test_each_line_is_independent_json`
+persists `_valid_record()` **twice** and then asserts every line parses as JSON. Under the new
+guard the second call no-ops, so the test sees one line, still passes, and quietly stops testing
+what its name claims (Step-4 self-review finding 2, Medium). It is repaired in the same commit:
+the two records are made distinguishable so the multi-line property is genuinely exercised, and
+the dedupe behaviour gets its own explicit tests rather than riding on a test that was written
+for a different contract.
+
+## Failure modes considered
+
+- **Store read cost.** The guard reads the whole store per persist. The store is ~90 lines; O(n)
+  on a file that grows one line per run is not worth an index.
+- **Corrupt legacy line.** Unparseable lines are skipped, never fatal — they cannot match a valid
+  fingerprint.
+- **Concurrent writers.** Two sessions persisting different runs at the same instant can both
+  read a store that lacks the other's line. Neither is a duplicate of the other, so the outcome is
+  correct. Two sessions persisting the *same* run concurrently is not a case that occurs (one run,
+  one Step 16), and the append itself stays a single `write` call.
+
+## platform_apis
+
+None new. `hashlib` and `json` are stdlib; `json` is already imported in the module, `hashlib` is
+added. No network, no subprocess, no new dependency. No egress and no secret handling — the
+fingerprint is computed over a record that already passed `validate_record`.

--- a/hooks/work_summary.py
+++ b/hooks/work_summary.py
@@ -27,6 +27,7 @@ their Step 16 output. main() exits 1 in that case so the skill surfaces the gap.
 """
 import argparse
 import copy
+import fcntl
 import hashlib
 import json
 import math
@@ -1076,6 +1077,15 @@ def load_record_file(path) -> dict:
 # it is stable across re-runs of the same file and belongs to identity.
 _FINGERPRINT_VOLATILE_KEYS = ("generated_at", "schema_version", "timing")
 
+# ...except for the two `usage` members `summarize` DERIVES after validation, which
+# is how volatile state reached identity anyway on the first cut of this guard:
+# `derive_wall_clock_s` copies `timing.total_s` into `usage.wall_clock_s`, so
+# excluding `timing` at the top level while keeping the value it feeds left the
+# recovery re-run fingerprinting differently. `worker_token_share` is config-derived
+# and joins it for the same reason — neither is supplied by the run, so neither
+# identifies it.
+_FINGERPRINT_VOLATILE_USAGE_KEYS = ("wall_clock_s", "worker_token_share")
+
 
 def record_fingerprint(record) -> str:
     """Stable identity for one RUN, used to keep its record from landing twice (#888).
@@ -1094,17 +1104,28 @@ def record_fingerprint(record) -> str:
     body = record
     if isinstance(record, dict):
         body = {k: v for k, v in record.items() if k not in _FINGERPRINT_VOLATILE_KEYS}
+        usage = body.get("usage")
+        if isinstance(usage, dict):
+            body["usage"] = {k: v for k, v in usage.items()
+                             if k not in _FINGERPRINT_VOLATILE_USAGE_KEYS}
     # sort_keys so a re-serialized record with reordered keys is the same run.
     blob = json.dumps(body, sort_keys=True, separators=(",", ":"), default=str)
     return "sha256:" + hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
 
 def _store_fingerprints(store_path) -> set:
-    """Fingerprints of every record already in the store. Missing store -> empty set.
+    """Fingerprints of every VALID record already in the store. Missing -> empty set.
 
     A line that will not parse is SKIPPED, never fatal: it cannot be the duplicate of
     a valid record, and refusing the write over someone else's corrupt line would turn
     a cosmetic problem into the data loss this whole issue is about.
+
+    A line that parses but is not a RECORD is skipped too (Step-11 cross-model finding
+    1). Fingerprinting anything parseable let a stub like ``{"run_id": "..."}`` match a
+    complete record carrying that run id, so the real record was called a duplicate and
+    dropped while the CLI reported success. Only a record can shadow a record. The skip
+    direction is the safe one: an entry we cannot vouch for causes an append, never a
+    silent drop.
     """
     seen = set()
     p = Path(store_path)
@@ -1116,7 +1137,10 @@ def _store_fingerprints(store_path) -> set:
             if not line:
                 continue
             try:
-                seen.add(record_fingerprint(json.loads(line)))
+                obj = json.loads(line)
+                if validate_record(obj):        # non-empty == list of errors
+                    continue
+                seen.add(record_fingerprint(obj))
             except (ValueError, TypeError):
                 continue
     return seen
@@ -1136,14 +1160,41 @@ def persist_record(record, store_path) -> str:
     """
     p = Path(store_path)
     p.parent.mkdir(parents=True, exist_ok=True)
+    data = (json.dumps(record, separators=(",", ":")) + "\n").encode("utf-8")
+    # flock + O_APPEND + one write(), the shape `decision_log.append_record` already
+    # uses for this repo's other append-only JSONL store. The lock spans the CHECK and
+    # the APPEND together: without it two writers can both read a store missing the
+    # other's line and both append (Step-11 cross-model finding 4).
+    fd = os.open(str(p), os.O_CREAT | os.O_WRONLY | os.O_APPEND, 0o600)
     try:
-        if record_fingerprint(record) in _store_fingerprints(p):
-            return "duplicate"
-    except OSError as exc:
-        print(f"warning: could not read {p} to check for a duplicate run-record "
-              f"({exc}); appending rather than risk losing it", file=sys.stderr)
-    with open(p, "a", encoding="utf-8") as f:
-        f.write(json.dumps(record, separators=(",", ":")) + "\n")
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            if record_fingerprint(record) in _store_fingerprints(p):
+                return "duplicate"
+        except (OSError, ValueError) as exc:
+            # ValueError covers UnicodeDecodeError: iterating a non-UTF-8 store
+            # raises during decode, outside the per-line guard, and would otherwise
+            # surface as a traceback instead of either documented behaviour.
+            print(f"warning: could not read {p} to check for a duplicate run-record "
+                  f"({exc}); appending rather than risk losing it — exactly-once is "
+                  f"degraded to at-least-once for this write", file=sys.stderr)
+        # A writer that died mid-record leaves no trailing newline; appending onto it
+        # would join the two and destroy both (decision_log.py's own reasoning).
+        if p.stat().st_size:
+            with open(p, "rb") as probe:
+                probe.seek(-1, os.SEEK_END)
+                if probe.read(1) != b"\n":
+                    os.write(fd, b"\n")
+        written = 0
+        while written < len(data):
+            n = os.write(fd, data[written:])
+            if n <= 0:
+                raise OSError(f"short write to {p}: {written}/{len(data)} bytes")
+            written += n
+        os.fsync(fd)
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
     return "appended"
 
 

--- a/hooks/work_summary.py
+++ b/hooks/work_summary.py
@@ -27,6 +27,7 @@ their Step 16 output. main() exits 1 in that case so the skill surfaces the gap.
 """
 import argparse
 import copy
+import hashlib
 import json
 import math
 import os
@@ -1066,13 +1067,84 @@ def load_record_file(path) -> dict:
         raise WorkSummaryError(f"record file {path} is not valid JSON: {exc}")
 
 
-def persist_record(record, store_path) -> None:
-    """Append one compact JSON line (one record per line) to the JSONL store,
-    creating the parent directory if needed."""
+# Writer-stamped or tool-computed at persist time, so they say nothing about WHICH
+# run this is. `timing` is the subtle one: `_auto_embed_timing` derives it from the
+# step-state history whenever the record file omits it, so a crash-recovery re-run
+# reads a GROWN history and produces a different value — an identity carrying it
+# would differ on exactly the re-run the guard exists to catch (#888).
+# `usage` is deliberately absent from this set: it is read from the record file, so
+# it is stable across re-runs of the same file and belongs to identity.
+_FINGERPRINT_VOLATILE_KEYS = ("generated_at", "schema_version", "timing")
+
+
+def record_fingerprint(record) -> str:
+    """Stable identity for one RUN, used to keep its record from landing twice (#888).
+
+    `run_id` (#473) wins when present — it is the explicit join key, so a run that
+    declares one is identified by it and by nothing else. Otherwise the identity is a
+    digest over the record's content with `_FINGERPRINT_VOLATILE_KEYS` removed.
+
+    Deduplicates RUNS, not issues: a later run over the same issue with different
+    findings has different content, so it appends normally.
+    """
+    if isinstance(record, dict):
+        run_id = record.get("run_id")
+        if _is_str(run_id) and run_id.strip():
+            return "run_id:" + run_id.strip()
+    body = record
+    if isinstance(record, dict):
+        body = {k: v for k, v in record.items() if k not in _FINGERPRINT_VOLATILE_KEYS}
+    # sort_keys so a re-serialized record with reordered keys is the same run.
+    blob = json.dumps(body, sort_keys=True, separators=(",", ":"), default=str)
+    return "sha256:" + hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _store_fingerprints(store_path) -> set:
+    """Fingerprints of every record already in the store. Missing store -> empty set.
+
+    A line that will not parse is SKIPPED, never fatal: it cannot be the duplicate of
+    a valid record, and refusing the write over someone else's corrupt line would turn
+    a cosmetic problem into the data loss this whole issue is about.
+    """
+    seen = set()
+    p = Path(store_path)
+    if not p.exists():
+        return seen
+    with open(p, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                seen.add(record_fingerprint(json.loads(line)))
+            except (ValueError, TypeError):
+                continue
+    return seen
+
+
+def persist_record(record, store_path) -> str:
+    """Append one compact JSON line to the JSONL store, ONCE (#888/#355).
+
+    Returns ``"appended"`` or ``"duplicate"``. A duplicate is not an error: the caller
+    asked for this run to be in the store and it is, so the desired end state holds and
+    a documented crash-recovery re-run must not look like a failure.
+
+    **Fail-OPEN on a store it cannot read** — it warns and appends. Losing a record is
+    the worse failure of the two this issue closes (#588 measured 1 of 6 children
+    dropped; #355 cost one hand-discarded duplicate line), and it matches the repo's
+    convention that data you cannot classify is kept.
+    """
     p = Path(store_path)
     p.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        if record_fingerprint(record) in _store_fingerprints(p):
+            return "duplicate"
+    except OSError as exc:
+        print(f"warning: could not read {p} to check for a duplicate run-record "
+              f"({exc}); appending rather than risk losing it", file=sys.stderr)
     with open(p, "a", encoding="utf-8") as f:
         f.write(json.dumps(record, separators=(",", ":")) + "\n")
+    return "appended"
 
 
 def _now() -> str:
@@ -1646,11 +1718,18 @@ def main(argv=None) -> int:
         if not args.no_persist:
             store = resolve_store_path(args.store, os.environ, args.project_root)
             try:
-                persist_record(record, store)
+                outcome = persist_record(record, store)
             except OSError as exc:
                 print(f"failed to persist run-record to {store}: {exc}",
                       file=sys.stderr)
                 return 1
+            if outcome == "duplicate":
+                # rc stays 0: re-running Step 16 is the documented crash-recovery
+                # path, and the end state it asked for holds (#888).
+                issue = record.get("issue") or {}
+                print(f"run-record for {record.get('workflow')} "
+                      f"#{issue.get('number')} is already in {store} — not appended "
+                      f"again", file=sys.stderr)
         return 0
 
     if args.cmd == "find":

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.129.1",
+  "version": "3.130.0",
   "description": "9 SDLC workflow skills + 9 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/skills/implement-feature/references/step-14.md
+++ b/skills/implement-feature/references/step-14.md
@@ -6,6 +6,29 @@
 
 **Quarantine × protection contradiction check (#139):** before attempting the merge, call `plan_lib.quarantine_protection_contradiction(capabilities.ci_quarantined, <protection state from Step 1 item 9>, <required_checks>)`. A non-None message means CI is quarantined (WF2 non-gating) but branch protection REQUIRES a status check — the squash-merge below would hit a server-side wall. Surface the message to the user and STOP rather than merging into the wall.
 
+**Merge-grant path — persist the run-record BEFORE the merge (#888).** When this run holds a
+merge grant, it is the run that will merge its own PR, and Step 16 comes *after* that merge — so a
+crash, compaction, or context exhaustion in between orphans the record. Measured: saystory epic
+#204 persisted 1 of 6 children, and #879 needed the separate #882 backfill PR. **The run-record is
+therefore persisted, committed and CI-re-verified before the merge is attempted, in this order:**
+
+1. Assemble the run-record per `references/run-record.md`, then populate `usage` FIRST via
+   `python3 hooks/usage_capture.py capture --session-id "$CLAUDE_CODE_SESSION_ID"`.
+2. Persist it with `python3 hooks/work_summary.py summarize --record-file <f> --project-root .`
+   (rc 0 = persisted).
+3. Commit the appended `docs/measurements/run_records.jsonl` line into the PR as a
+   `chore(telemetry):` commit, staged BY NAME.
+4. Re-verify CI **on the new head, per-sha** — a rollup queried by PR number can still show the
+   previous head's green.
+5. Confirm the record actually landed: `python3 hooks/work_summary.py find --issue <issue>`
+   (rc 0 = landed, rc 1 = missing). **rc 1 means do not merge yet** — fix the persist first.
+6. Only now perform the merge in item 1 below.
+
+On this path the record is written before the merge exists, so its shape is
+`outcome.merged: null` with a `follow_ups` entry naming the ordering — `null` here means "not yet
+merged when the record was written", never "the merge failed". Step 16 then renders from the
+already-persisted record instead of summarizing a second time (§16 item 3a).
+
 1. **Merge PR (squash merge):**
    ```bash
    gh pr merge <pr_number> --repo ${capabilities.repo} --squash --delete-branch

--- a/skills/implement-feature/references/step-14.md
+++ b/skills/implement-feature/references/step-14.md
@@ -6,28 +6,26 @@
 
 **Quarantine × protection contradiction check (#139):** before attempting the merge, call `plan_lib.quarantine_protection_contradiction(capabilities.ci_quarantined, <protection state from Step 1 item 9>, <required_checks>)`. A non-None message means CI is quarantined (WF2 non-gating) but branch protection REQUIRES a status check — the squash-merge below would hit a server-side wall. Surface the message to the user and STOP rather than merging into the wall.
 
-**Merge-grant path — persist the run-record BEFORE the merge (#888).** When this run holds a
-merge grant, it is the run that will merge its own PR, and Step 16 comes *after* that merge — so a
-crash, compaction, or context exhaustion in between orphans the record. Measured: saystory epic
-#204 persisted 1 of 6 children, and #879 needed the separate #882 backfill PR. **The run-record is
+**Merge-grant path — persist the run-record BEFORE the merge (#888).** Step 16 runs *after* the
+merge, so a run merging its own PR orphans its record if anything interrupts the gap (saystory
+epic #204: 1 of 6 children persisted; #879 needed the #882 backfill). **The run-record is
 therefore persisted, committed and CI-re-verified before the merge is attempted, in this order:**
 
-1. Assemble the run-record per `references/run-record.md`, then populate `usage` FIRST via
+1. Assemble it per `references/run-record.md`; populate `usage` FIRST via
    `python3 hooks/usage_capture.py capture --session-id "$CLAUDE_CODE_SESSION_ID"`.
-2. Persist it with `python3 hooks/work_summary.py summarize --record-file <f> --project-root .`
-   (rc 0 = persisted).
+2. `python3 hooks/work_summary.py summarize --record-file <f> --project-root .` (rc 0 = persisted).
 3. Commit the appended `docs/measurements/run_records.jsonl` line into the PR as a
    `chore(telemetry):` commit, staged BY NAME.
-4. Re-verify CI **on the new head, per-sha** — a rollup queried by PR number can still show the
+4. Re-verify CI **on the new head, per-sha** — a rollup queried by PR number can still report the
    previous head's green.
-5. Confirm the record actually landed: `python3 hooks/work_summary.py find --issue <issue>`
-   (rc 0 = landed, rc 1 = missing). **rc 1 means do not merge yet** — fix the persist first.
-6. Only now perform the merge in item 1 below.
+5. `python3 hooks/work_summary.py find --issue <issue>` proves it landed.
+   **rc 1 means do not merge yet** — fix the persist first.
+6. Only now merge (item 1 below).
 
-On this path the record is written before the merge exists, so its shape is
-`outcome.merged: null` with a `follow_ups` entry naming the ordering — `null` here means "not yet
-merged when the record was written", never "the merge failed". Step 16 then renders from the
-already-persisted record instead of summarizing a second time (§16 item 3a).
+The record is written before the merge exists, so its shape is `outcome.merged: null` plus a
+`follow_ups` entry naming the ordering — `null` here means "not yet merged when the record was
+written", never "the merge failed". Step 16 then renders from it rather than summarizing twice
+(§16 item 3a).
 
 1. **Merge PR (squash merge):**
    ```bash

--- a/skills/implement-feature/references/step-14.md
+++ b/skills/implement-feature/references/step-14.md
@@ -8,24 +8,27 @@
 
 **Merge-grant path — persist the run-record BEFORE the merge (#888).** Step 16 runs *after* the
 merge, so a run merging its own PR orphans its record if anything interrupts the gap (saystory
-epic #204: 1 of 6 children persisted; #879 needed the #882 backfill). **The run-record is
+epic #204: 1 of 6 persisted; #879 needed the #882 backfill). **The run-record is
 therefore persisted, committed and CI-re-verified before the merge is attempted, in this order:**
 
 1. Assemble it per `references/run-record.md`; populate `usage` FIRST via
    `python3 hooks/usage_capture.py capture --session-id "$CLAUDE_CODE_SESSION_ID"`.
 2. `python3 hooks/work_summary.py summarize --record-file <f> --project-root .` (rc 0 = persisted).
-3. Commit the appended `docs/measurements/run_records.jsonl` line into the PR as a
+3. Commit the appended `docs/measurements/run_records.jsonl` line as a
    `chore(telemetry):` commit, staged BY NAME.
 4. Re-verify CI **on the new head, per-sha** — a rollup queried by PR number can still report the
    previous head's green.
-5. `python3 hooks/work_summary.py find --issue <issue>` proves it landed.
-   **rc 1 means do not merge yet** — fix the persist first.
-6. Only now merge (item 1 below).
+5. Prove THIS run's line is in the commit: `git show --numstat HEAD --
+   docs/measurements/run_records.jsonl` must show one added line. **No added line means do not
+   merge yet.** (`find --issue` is issue-scoped — an earlier run's record returns rc 0 while this
+   one's is missing.)
+6. Only now merge (below).
 
-The record is written before the merge exists, so its shape is `outcome.merged: null` plus a
-`follow_ups` entry naming the ordering — `null` here means "not yet merged when the record was
-written", never "the merge failed". Step 16 then renders from it rather than summarizing twice
-(§16 item 3a).
+Its shape is `outcome.merged: null` plus a `follow_ups` entry naming the ordering — `null` here
+means "not yet merged when the record was written", never "the merge failed". **`usage` is
+pre-merge too**: it omits what the merge, CI re-verify and wrap-up still spend, so say so in that
+same note rather than let a consumer read it as full-run cost. Step 16 then renders from it
+rather than summarizing twice (§16 item 3a).
 
 1. **Merge PR (squash merge):**
    ```bash

--- a/skills/implement-feature/references/step-16.md
+++ b/skills/implement-feature/references/step-16.md
@@ -110,6 +110,21 @@ measurable signal — not just a sentence the user reads once.
    (optional-additive in `validate_record`, absent on legacy records). The
    seat-Observation sidecar harvest retired with the executor.
 
+3a. **The record may ALREADY be persisted — render only, never summarize twice (#888).** On the
+   merge-grant path, Step 14 assembled, persisted, committed and CI-re-verified the record before
+   merging (§14, "Merge-grant path"). That run reaches here with its record already in the store,
+   so it renders from it with `--no-persist` rather than calling `summarize` a second time:
+   ```bash
+   python3 hooks/work_summary.py summarize \
+     --record-file /tmp/wf2-run-record-<issue>-<session-id>.json \
+     --project-root <activeProject.path> --no-persist
+   ```
+   Check with `python3 hooks/work_summary.py find --issue <issue>` (rc 0 = already there) when
+   unsure — a resumed session cannot tell from context alone. Since #888 `persist_record` is
+   idempotent, so a second summarize no-ops with a stderr notice and rc 0 instead of duplicating
+   the line; that guard is the BACKSTOP, not the plan. Every other run (no merge grant, PR
+   terminal) persists here as item 3 describes.
+
 3. **Render + persist.** Carry `activeProject.path` in as a literal (shell vars
    do not persist across Bash tool calls):
    ```bash

--- a/skills/implement-feature/references/step-16.md
+++ b/skills/implement-feature/references/step-16.md
@@ -110,20 +110,12 @@ measurable signal — not just a sentence the user reads once.
    (optional-additive in `validate_record`, absent on legacy records). The
    seat-Observation sidecar harvest retired with the executor.
 
-3a. **The record may ALREADY be persisted — render only, never summarize twice (#888).** On the
-   merge-grant path, Step 14 assembled, persisted, committed and CI-re-verified the record before
-   merging (§14, "Merge-grant path"). That run reaches here with its record already in the store,
-   so it renders from it with `--no-persist` rather than calling `summarize` a second time:
-   ```bash
-   python3 hooks/work_summary.py summarize \
-     --record-file /tmp/wf2-run-record-<issue>-<session-id>.json \
-     --project-root <activeProject.path> --no-persist
-   ```
-   Check with `python3 hooks/work_summary.py find --issue <issue>` (rc 0 = already there) when
-   unsure — a resumed session cannot tell from context alone. Since #888 `persist_record` is
-   idempotent, so a second summarize no-ops with a stderr notice and rc 0 instead of duplicating
-   the line; that guard is the BACKSTOP, not the plan. Every other run (no merge grant, PR
-   terminal) persists here as item 3 describes.
+3a. **May ALREADY be persisted — render only, never summarize twice (#888).** On the merge-grant
+   path, Step 14 assembled, persisted, committed and CI-re-verified the record before merging
+   (§14). That run adds `--no-persist` to item 3's command rather than summarizing twice.
+   `persist_record` is idempotent since #888, so a second summarize no-ops at rc 0 with a stderr
+   notice instead of duplicating the line — that guard is the BACKSTOP, not the plan. Every other
+   run persists per item 3.
 
 3. **Render + persist.** Carry `activeProject.path` in as a literal (shell vars
    do not persist across Bash tool calls):

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.129.1"
+EXPECTED_PLUGIN_VERSION = "3.130.0"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_work_summary.py
+++ b/tests/hooks/test_work_summary.py
@@ -802,6 +802,27 @@ class TestRecordFingerprint:
         b["issue"]["number"] = 92
         assert record_fingerprint(a) != record_fingerprint(b)
 
+    def test_usage_fields_derived_at_persist_time_are_excluded(self):
+        """The leak that excluding `timing` alone did not close.
+
+        `summarize` mutates the record after validation: `derive_wall_clock_s`
+        copies `timing.total_s` into `usage.wall_clock_s`, and `worker_token_share`
+        is computed from the project config. So on a recovery re-run the volatile
+        `timing` reaches identity THROUGH `usage` even though `timing` itself is
+        excluded — and the guard misses exactly the duplicate it exists to catch.
+        """
+        from work_summary import record_fingerprint
+        a = _valid_record()
+        b = _valid_record()
+        base_usage = {"capture_status": "captured", "input_tokens": 100,
+                      "output_tokens": 200, "model_mix": {"claude-fable-5": 300},
+                      "wall_clock_s": None}
+        a["usage"] = dict(base_usage)
+        b["usage"] = dict(base_usage)
+        a["usage"].update({"wall_clock_s": 900, "worker_token_share": 0.25})
+        b["usage"].update({"wall_clock_s": 4200, "worker_token_share": 0.31})
+        assert record_fingerprint(a) == record_fingerprint(b)
+
     def test_usage_is_part_of_identity(self):
         """`usage` is read from the record FILE, so it is stable across re-runs of
         the same file — it stays in identity rather than being excluded."""
@@ -877,6 +898,65 @@ class TestPersistIdempotency:
         assert work_summary.persist_record(_valid_record(), str(store)) == "appended"
         assert len(store.read_text().splitlines()) == 1
 
+    def test_a_junk_store_line_cannot_shadow_a_valid_record(self, tmp_path):
+        """Step-11 cross-model finding 1 (High).
+
+        A store line that merely PARSES was fingerprinted as if it were a record.
+        A stub like `{"run_id": "..."}` then matched a complete record carrying the
+        same run id, so the real record was classified duplicate and dropped while
+        the CLI reported success — the one outcome that would make this guard worse
+        than the defect it fixes.
+        """
+        from work_summary import persist_record
+        store = tmp_path / "run_records.jsonl"
+        store.write_text('{"run_id":"wf2-888-alpha"}\n')
+        record = _valid_record()
+        record["run_id"] = "wf2-888-alpha"
+        assert persist_record(record, str(store)) == "appended"
+        assert len(store.read_text().splitlines()) == 2
+
+    def test_an_undecodable_store_does_not_crash(self, tmp_path):
+        """Iterating the store decodes it, and UnicodeDecodeError is a ValueError,
+        not an OSError — so a non-UTF-8 store escaped the dedupe guard entirely and
+        reached the CLI as a traceback."""
+        from work_summary import persist_record
+        store = tmp_path / "run_records.jsonl"
+        store.write_bytes(b"\xff\xfe not utf-8 at all\n")
+        assert persist_record(_valid_record(), str(store)) == "appended"
+
+    def test_check_and_append_happen_under_one_exclusive_lock(self, tmp_path,
+                                                              monkeypatch):
+        """Step-11 cross-model finding 4 (High).
+
+        Read-check-append is only exactly-once if nothing can interleave between
+        the check and the append. Asserting the lock is HELD during the check is
+        deterministic, where racing two writers and hoping to observe the bug is
+        not. Same flock + O_APPEND + single-write shape `decision_log.append_record`
+        already uses for this repo's other append-only JSONL store.
+        """
+        import fcntl
+        import work_summary
+        store = tmp_path / "run_records.jsonl"
+        store.write_text("")
+        observed = {}
+        real = work_summary._store_fingerprints
+
+        def _probe(path):
+            with open(store, "a", encoding="utf-8") as other:
+                try:
+                    fcntl.flock(other.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    observed["locked"] = False      # nobody was holding it
+                    fcntl.flock(other.fileno(), fcntl.LOCK_UN)
+                except BlockingIOError:
+                    observed["locked"] = True
+            return real(path)
+
+        monkeypatch.setattr(work_summary, "_store_fingerprints", _probe)
+        work_summary.persist_record(_valid_record(), str(store))
+        assert observed.get("locked") is True, (
+            "persist_record must hold an exclusive lock across the duplicate check "
+            "and the append, or two writers can both miss and both append")
+
     def test_missing_store_is_not_a_duplicate(self, tmp_path):
         from work_summary import persist_record
         store = tmp_path / "nested" / "run_records.jsonl"
@@ -908,6 +988,43 @@ class TestSummarizeIsIdempotent:
         assert "already" in cap.err.lower()
         assert "91" in cap.err                 # names the issue
         assert str(store) in cap.err           # and where it already is
+
+    def test_drifting_autocomputed_timing_still_dedupes_end_to_end(
+            self, tmp_path, capsys, monkeypatch):
+        """The real chain, not just the fingerprint function.
+
+        A record file that omits `timing` gets one computed at persist time from a
+        step-state history that has GROWN by the time a recovery re-run happens.
+        That timing then feeds `usage.wall_clock_s`. Both hops have to be neutral
+        to identity or the guard misses the duplicate — this drives summarize twice
+        with different auto-computed timing and asserts one stored line.
+        """
+        import work_summary
+        record = _valid_record()
+        record["usage"] = {
+            "capture_status": "captured", "input_tokens": 100, "output_tokens": 200,
+            "model_mix": {"claude-fable-5": {"input_tokens": 100,
+                                             "output_tokens": 200}},
+            "cost_estimate_usd": None, "wall_clock_s": None}
+        path = _write_record(tmp_path, record)
+        store = tmp_path / "store.jsonl"
+        totals = iter((900, 4200))
+
+        def _drifting(raw, _project_root):
+            raw.setdefault("timing", {
+                "status": "complete", "total_s": next(totals),
+                "idle_gap_threshold_s": 1800, "steps": [], "phases": {}})
+
+        monkeypatch.setattr(work_summary, "_auto_embed_timing", _drifting)
+        rcs = [work_summary.main(["summarize", "--record-file", path,
+                                  "--project-root", str(tmp_path),
+                                  "--store", str(store)]) for _ in range(2)]
+        capsys.readouterr()
+        assert rcs == [0, 0]
+        stored = store.read_text().splitlines()
+        assert len(stored) == 1
+        # ...and the drift the guard had to ignore was genuinely present.
+        assert json.loads(stored[0])["timing"]["total_s"] == 900
 
     def test_notice_does_not_echo_the_record_body(self, tmp_path, capsys):
         """The notice is for a human reading a terminal, not a record dump."""

--- a/tests/hooks/test_work_summary.py
+++ b/tests/hooks/test_work_summary.py
@@ -756,12 +756,168 @@ class TestPersistRecord:
         assert [json.loads(l)["n"] for l in lines] == [1, 2]
 
     def test_each_line_is_independent_json(self, tmp_path):
+        # #888: the two records must be DISTINGUISHABLE. This test used to persist
+        # `_valid_record()` twice; once persist_record became idempotent that wrote a
+        # single line, and the loop below passed while testing nothing it names. Two
+        # different runs also make it a live check that the guard never collapses
+        # records that are genuinely distinct.
         from work_summary import persist_record
         store = tmp_path / "run_records.jsonl"
-        persist_record(_valid_record(), str(store))
-        persist_record(_valid_record(), str(store))
-        for line in store.read_text().splitlines():
+        first = _valid_record()
+        second = _valid_record()
+        second["issue"]["number"] = 92
+        persist_record(first, str(store))
+        persist_record(second, str(store))
+        lines = store.read_text().splitlines()
+        assert len(lines) == 2
+        for line in lines:
             json.loads(line)   # must not raise
+
+
+# --- #888: run-records land exactly once -----------------------------------
+
+class TestRecordFingerprint:
+    def test_ignores_writer_stamped_and_autocomputed_keys(self):
+        """`generated_at`, `schema_version` and `timing` must not enter identity.
+
+        `timing` is the one that matters most: `_auto_embed_timing` computes it at
+        persist time from the step-state history whenever the record file omits it,
+        so a crash-recovery re-run sees a GROWN history and a different value. A
+        fingerprint carrying it would differ on exactly the re-run the guard exists
+        to catch.
+        """
+        from work_summary import record_fingerprint
+        a = _valid_record()
+        b = _valid_record()
+        a.update({"generated_at": "2026-08-05T10:00:00Z", "schema_version": 1,
+                  "timing": {"status": "absent"}})
+        b.update({"generated_at": "2026-08-05T23:59:59Z", "schema_version": 2,
+                  "timing": {"status": "ok", "total_s": 1234}})
+        assert record_fingerprint(a) == record_fingerprint(b)
+
+    def test_substantive_difference_changes_the_fingerprint(self):
+        from work_summary import record_fingerprint
+        a = _valid_record()
+        b = _valid_record()
+        b["issue"]["number"] = 92
+        assert record_fingerprint(a) != record_fingerprint(b)
+
+    def test_usage_is_part_of_identity(self):
+        """`usage` is read from the record FILE, so it is stable across re-runs of
+        the same file — it stays in identity rather than being excluded."""
+        from work_summary import record_fingerprint
+        a = _valid_record()
+        b = _valid_record()
+        b["usage"] = {"capture_status": "unavailable", "input_tokens": None,
+                      "output_tokens": None, "model_mix": None, "wall_clock_s": None}
+        assert record_fingerprint(a) != record_fingerprint(b)
+
+    def test_run_id_takes_precedence_over_content(self):
+        from work_summary import record_fingerprint
+        a = _valid_record()
+        b = _valid_record()
+        a["run_id"] = "wf2-888-alpha"
+        b["run_id"] = "wf2-888-alpha"
+        b["changes"]["files_changed"] = 999          # content differs...
+        assert record_fingerprint(a) == record_fingerprint(b)   # ...run_id wins
+
+    def test_different_run_ids_never_collide(self):
+        from work_summary import record_fingerprint
+        a = _valid_record()
+        b = _valid_record()
+        a["run_id"] = "wf2-888-alpha"
+        b["run_id"] = "wf2-888-beta"
+        assert record_fingerprint(a) != record_fingerprint(b)
+
+    def test_key_order_does_not_matter(self):
+        from work_summary import record_fingerprint
+        a = {"workflow": "implement-feature", "issue": {"number": 1, "type": "feature"}}
+        b = {"issue": {"type": "feature", "number": 1}, "workflow": "implement-feature"}
+        assert record_fingerprint(a) == record_fingerprint(b)
+
+
+class TestPersistIdempotency:
+    def test_re_persisting_the_same_run_no_ops(self, tmp_path):
+        from work_summary import persist_record
+        store = tmp_path / "run_records.jsonl"
+        first = _valid_record()
+        first["generated_at"] = "2026-08-05T10:00:00Z"
+        again = _valid_record()
+        again["generated_at"] = "2026-08-05T10:07:00Z"    # a later re-summarize
+        assert persist_record(first, str(store)) == "appended"
+        assert persist_record(again, str(store)) == "duplicate"
+        assert len(store.read_text().splitlines()) == 1
+
+    def test_a_different_run_still_appends(self, tmp_path):
+        from work_summary import persist_record
+        store = tmp_path / "run_records.jsonl"
+        first = _valid_record()
+        second = _valid_record()
+        second["issue"]["number"] = 92
+        assert persist_record(first, str(store)) == "appended"
+        assert persist_record(second, str(store)) == "appended"
+        assert len(store.read_text().splitlines()) == 2
+
+    def test_corrupt_store_line_is_skipped_not_fatal(self, tmp_path):
+        from work_summary import persist_record
+        store = tmp_path / "run_records.jsonl"
+        store.write_text("{not json at all\n")
+        assert persist_record(_valid_record(), str(store)) == "appended"
+        assert len(store.read_text().splitlines()) == 2
+
+    def test_unreadable_store_falls_open_to_appending(self, tmp_path, monkeypatch):
+        """Losing a record is worse than duplicating one (#588's measured 1-in-6 drop
+        against #355's single hand-discarded duplicate), so a store the guard cannot
+        read must never swallow the write."""
+        import work_summary
+        store = tmp_path / "run_records.jsonl"
+        store.write_text("")
+        monkeypatch.setattr(work_summary, "_store_fingerprints",
+                            lambda _p: (_ for _ in ()).throw(OSError("boom")))
+        assert work_summary.persist_record(_valid_record(), str(store)) == "appended"
+        assert len(store.read_text().splitlines()) == 1
+
+    def test_missing_store_is_not_a_duplicate(self, tmp_path):
+        from work_summary import persist_record
+        store = tmp_path / "nested" / "run_records.jsonl"
+        assert persist_record(_valid_record(), str(store)) == "appended"
+        assert len(store.read_text().splitlines()) == 1
+
+
+class TestSummarizeIsIdempotent:
+    """Re-running Step 16 is the documented crash-recovery path (#888/#355)."""
+
+    def _run(self, tmp_path, store, capsys):
+        from work_summary import main
+        rc = main(["summarize", "--record-file", _write_record(tmp_path, _valid_record()),
+                   "--project-root", str(tmp_path), "--store", str(store)])
+        return rc, capsys.readouterr()
+
+    def test_second_summarize_does_not_duplicate_the_line(self, tmp_path, capsys):
+        store = tmp_path / "store.jsonl"
+        rc_one, _ = self._run(tmp_path, store, capsys)
+        rc_two, cap = self._run(tmp_path, store, capsys)
+        assert (rc_one, rc_two) == (0, 0)      # recovery re-run is not a failure
+        assert len(store.read_text().splitlines()) == 1
+        assert "WF2 COMPLETE" in cap.out       # the summary still renders
+
+    def test_duplicate_is_announced_on_stderr(self, tmp_path, capsys):
+        store = tmp_path / "store.jsonl"
+        self._run(tmp_path, store, capsys)
+        _, cap = self._run(tmp_path, store, capsys)
+        assert "already" in cap.err.lower()
+        assert "91" in cap.err                 # names the issue
+        assert str(store) in cap.err           # and where it already is
+
+    def test_notice_does_not_echo_the_record_body(self, tmp_path, capsys):
+        """The notice is for a human reading a terminal, not a record dump."""
+        store = tmp_path / "store.jsonl"
+        self._run(tmp_path, store, capsys)
+        _, cap = self._run(tmp_path, store, capsys)
+        notice = [l for l in cap.err.splitlines() if "already" in l.lower()]
+        assert len(notice) == 1                                   # one line, not a dump
+        assert "wire work_summary into WF3 Step" not in notice[0]  # a follow_ups string
+        assert "insertions" not in notice[0]
 
 
 # --- main (CLI) ------------------------------------------------------------

--- a/tests/test_wf2_clarity.py
+++ b/tests/test_wf2_clarity.py
@@ -1893,3 +1893,62 @@ class TestClosingKeywordGuardWF2:
         assert "only the LAST PR declares `--closes`" in sec, (
             "the multi-PR convention (earlier PRs are Part of) must ride with "
             "the gate, since that is exactly when the defect fires")
+
+
+class TestRunRecordLandsExactlyOnce:
+    """#888: a run-record must land exactly ONCE.
+
+    Two measured failure modes, one contract. It could land zero times — Step 16
+    persists after Step 14 merges, so a run that merges its own PR orphans its
+    record (saystory epic #204: 1 of 6 children persisted, #879 needed the #882
+    backfill). It could land twice — `persist_record` blind-appended, so a Step-16
+    re-run double-recorded (WF2 #340, hand-discarded from `git diff`).
+
+    Location pins, whitespace-normalized: the ordering sentence belongs in Step 14
+    (where the merge happens) and the render-only sentence in Step 16 (where the
+    second summarize would have been). A corpus-wide search would pass on either
+    one being in the wrong file, which is exactly the drift worth catching.
+    """
+
+    REFS = (Path(__file__).resolve().parent.parent
+            / "skills" / "implement-feature" / "references")
+
+    def _norm(self, name: str) -> str:
+        return " ".join((self.REFS / name).read_text().split())
+
+    def test_step14_orders_persist_before_merge(self):
+        """The canonical sentence. If this ordering is ever softened, #588 reopens."""
+        assert ("The run-record is therefore persisted, committed and CI-re-verified "
+                "before the merge is attempted") in self._norm("step-14.md")
+
+    def test_step14_names_the_merged_null_shape(self):
+        step14 = self._norm("step-14.md")
+        assert "`outcome.merged: null`" in step14, (
+            "the merge-grant record shape must be documented where the ordering is")
+        assert ('`null` here means "not yet merged when the record was written", '
+                'never "the merge failed"') in step14, (
+            "null is ambiguous without this gloss — a reader repairing telemetry "
+            "would otherwise read it as a failed merge")
+
+    def test_step14_requires_the_record_landed_before_merging(self):
+        step14 = self._norm("step-14.md")
+        assert "hooks/work_summary.py find --issue <issue>" in step14, (
+            "the ordering needs a mechanical proof, not just prose order")
+        assert "**rc 1 means do not merge yet**" in step14
+
+    def test_step14_reverifies_ci_per_sha(self):
+        assert ("Re-verify CI **on the new head, per-sha**") in self._norm("step-14.md"), (
+            "the telemetry commit moves the head; a rollup queried by PR number "
+            "can still report the previous head's green")
+
+    def test_step16_renders_only_when_already_persisted(self):
+        step16 = self._norm("step-16.md")
+        assert ("On the merge-grant path, Step 14 assembled, persisted, committed "
+                "and CI-re-verified the record before merging") in step16
+        assert "--no-persist" in step16, (
+            "the render-only path is what keeps summarize from running twice")
+
+    def test_step16_calls_the_idempotency_guard_a_backstop(self):
+        """The guard must not be presented as the plan — prose that leans on it
+        would restore the blind double-summarize this issue removed."""
+        assert "that guard is the BACKSTOP, not the plan" in self._norm("step-16.md")

--- a/tests/test_wf2_clarity.py
+++ b/tests/test_wf2_clarity.py
@@ -1931,10 +1931,25 @@ class TestRunRecordLandsExactlyOnce:
             "would otherwise read it as a failed merge")
 
     def test_step14_requires_the_record_landed_before_merging(self):
+        """The proof must be THIS run's line, not any line for the issue.
+
+        Step-11 cross-model finding 6: `find --issue` is issue-scoped, so an
+        earlier run's record on the same issue returns rc 0 while this run's is
+        missing — it cannot prove what the ordering needs proven.
+        """
         step14 = self._norm("step-14.md")
-        assert "hooks/work_summary.py find --issue <issue>" in step14, (
-            "the ordering needs a mechanical proof, not just prose order")
-        assert "**rc 1 means do not merge yet**" in step14
+        assert ("`git show --numstat HEAD -- docs/measurements/run_records.jsonl` "
+                "must show one added line") in step14, (
+            "the ordering needs a mechanical proof scoped to THIS run's line")
+        assert "**No added line means do not merge yet.**" in step14
+        assert "`find --issue` is issue-scoped" in step14, (
+            "say why the cheaper issue-scoped check is not the proof, or a later "
+            "editor will swap it back in")
+
+    def test_step14_flags_usage_as_pre_merge(self):
+        """Capturing usage before the merge omits the run's tail; a consumer that
+        reads it as full-run cost is measuring a systematically low number."""
+        assert "**`usage` is pre-merge too**" in self._norm("step-14.md")
 
     def test_step14_reverifies_ci_per_sha(self):
         assert ("Re-verify CI **on the new head, per-sha**") in self._norm("step-14.md"), (

--- a/tests/test_wf2_prose_budget.py
+++ b/tests/test_wf2_prose_budget.py
@@ -91,7 +91,15 @@ PER_FILE_CEILING_BYTES = {
     "references/step-11_5.md": 4_543,
     "references/step-12.md": 14_999,
     "references/step-13.md": 3_621,
-    "references/step-14.md": 3_614,
+        # #888 raised this one, trim-first per the #903 precedent: the merge-grant
+    # sub-step (persist -> commit -> per-sha CI re-verify -> prove-landed -> merge)
+    # is genuinely NEW gated prose, not commentary — Step 14 had no run-record
+    # ordering at all before, and the gap it closes cost 5 of 6 records on saystory
+    # epic #204. The draft was compressed 1_365 -> 1_113 bytes over the old ceiling
+    # before raising, and step-16.md's companion edit was trimmed to fit under its
+    # existing ceiling rather than raised alongside.
+    #   references/step-14.md  actual 4_727 + headroom 256 -> ceiling 4_983
+    "references/step-14.md": 4_983,
     "references/step-15.md": 1_520,
     "references/step-16.md": 11_545,
     "references/whole-issue-delegation.md": 8_236,

--- a/tests/test_wf2_prose_budget.py
+++ b/tests/test_wf2_prose_budget.py
@@ -98,8 +98,8 @@ PER_FILE_CEILING_BYTES = {
     # epic #204. The draft was compressed 1_365 -> 1_113 bytes over the old ceiling
     # before raising, and step-16.md's companion edit was trimmed to fit under its
     # existing ceiling rather than raised alongside.
-    #   references/step-14.md  actual 4_727 + headroom 256 -> ceiling 4_983
-    "references/step-14.md": 4_983,
+    #   references/step-14.md  actual 4_975 + headroom 256 -> ceiling 5_231
+    "references/step-14.md": 5_231,
     "references/step-15.md": 1_520,
     "references/step-16.md": 11_545,
     "references/whole-issue-delegation.md": 8_236,


### PR DESCRIPTION
## Summary

A WF2 run-record is one JSON line in `docs/measurements/run_records.jsonl` — the Tier-2 telemetry
substrate. It must land **exactly once**, and both ways of getting that wrong were measured live:

- **Zero times (#588).** Step 16 persists the record *after* Step 14 merges, so a run that merges
  its own PR orphans the record whenever anything interrupts the gap. Saystory epic #204 persisted
  **1 of 6** children; #879 needed the separate #882 backfill PR.
- **Twice (#355).** `persist_record` opened the store `"a"` and wrote unconditionally, so a
  Step-16 re-run — the documented crash-recovery path — silently double-recorded. Seen on the WF2
  #340 run and hand-discarded from `git diff`.

Both were folded into #888 by owner-approved disposition (2026-08-05) as one transactional
persistence contract. Part of epic #871 (M4 wave, records-first). Small-standard lane
(standard_feature, 5 impl files).

## Design Decisions

- **Cannot be duplicated.** `persist_record` is idempotent on a run fingerprint: `run_id` when
  present, else a SHA-256 over the record with the writer-stamped and tool-derived fields removed.
  It returns `"appended"` or `"duplicate"`; a duplicate no-ops and the CLI exits **0** with a
  one-line stderr notice naming workflow, issue and store — a recovery re-run is not a failure.
- **Fail-open on an unreadable store.** It warns and appends. Losing a record is the worse of the
  two failures this issue closes (1-in-6 dropped against one hand-discarded duplicate), and it
  matches the repo's convention that data you cannot classify is kept.
- **Cannot be dropped.** Step 14 gains the merge-grant sub-step: assemble → `usage_capture` →
  `summarize` → commit the JSONL line as `chore(telemetry)` → re-verify CI **per-sha on the new
  head** → prove **this run's** line is in that commit (`git show --numstat`) → merge. The
  record's shape there is `outcome.merged: null`, glossed so a later reader cannot mistake it for
  a failed merge, and `usage` is flagged as pre-merge so it is not read as full-run cost.
- **Never summarized twice.** Step 16 gains the `--no-persist` render-only path and says plainly
  that the idempotency guard is the backstop rather than the plan.
- **Dedupes runs, not issues.** A later run over the same issue with different findings has
  different content, so it appends normally.

## The defect this PR's own review caught

The first cut excluded `generated_at`, `schema_version` and `timing` from identity. That was not
enough, and the inline Step-11 pass found why: `summarize` mutates the record *after* validation —
`derive_wall_clock_s` copies `timing.total_s` into `usage.wall_clock_s`, and `worker_token_share`
is computed from project config. The volatile field therefore reached identity **through `usage`**,
and the guard would have missed the duplicate on exactly the recovery re-run it exists for. Both
derived `usage` members are now excluded. Two tests guard it, and both were confirmed to fail
against the unfixed code: a unit test on the fingerprint, and an end-to-end one driving
`summarize` twice through the real auto-embed → derive → persist chain with drifting timing.

## Step 11 review — 6 cross-model findings (gpt-5.6-sol), 4 fixed, 2 declined

| # | Sev | Finding | Disposition |
|---|---|---|---|
| 1 | High | A store line that merely *parsed* was fingerprinted as authoritative, so a `{"run_id": …}` stub could suppress a complete record with that id while the CLI reported success | **Fixed** — only entries that validate as records enter the dedupe set |
| 2 | High | The content fallback identifies content, not a run instance; two genuinely separate runs with identical retained fields would collide | **Declined** (see below) |
| 3 | High | Fail-open on an unreadable store means exactly-once is not guaranteed | **Declined** (see below) |
| 4 | High | Read-check-append is not atomic; two writers can both miss and both append | **Fixed** — one `flock` spans the check and the append |
| 5 | Medium | `usage` captured pre-merge omits the run's tail | **Partly fixed** — Step 14 now says so where the `follow_ups` note is written; the `usage.capture_cutoff` schema field is a follow-up, not this PR |
| 6 | Medium | `find --issue` cannot prove *this* run landed — it is issue-scoped | **Fixed** — Step 14 requires this run's added line in the telemetry commit |

The inline pass contributed the `usage.wall_clock_s` leak described above, and the review
surfaced one more defect indirectly: iterating a non-UTF-8 store raises `UnicodeDecodeError`
during decode — outside the per-line guard and past an `OSError`-only catch — so it reached the
CLI as a traceback rather than either documented behaviour. Fixed and tested.

**Finding 2, declined.** The remedy proposed (require a globally unique `run_id` on every new
record and reject records without one) is a breaking schema change: `run_id` is optional-additive
by #473, and rejecting records lacking it would break WF3 and every legacy caller — far outside
this issue. The residual risk is narrow: a collision needs two distinct runs to agree
simultaneously on PR number, token counts, file/line counts, gate findings and follow-ups. The
plausible corner is two blocked runs on one issue with null usage and zero counts; that is worth
knowing about and is recorded as a follow-up rather than fixed by a breaking change here.

**Finding 3, declined, and it is a deliberate trade-off rather than an oversight.** When the
dedupe read fails we cannot know whether this run is already stored. Appending risks a duplicate;
aborting risks a loss. Those are not symmetric: a duplicate line is detectable and repairable
offline, while a dropped record is unrecoverable — and the measured harm runs the same way (1 of 6
records dropped on saystory #204 against one hand-discarded duplicate on #340). The warning now
states plainly that exactly-once has degraded to at-least-once for that write, so the weaker
guarantee is visible rather than silent.

## Verification

- Full suite **5340 → 5366**, `pytest tests/ -q` exit **0**. Baseline recorded at `ff2ee4a1`
  before any work. An intermediate run failed the prose-budget guard; that was fixed, not waived.
- Both pylint lanes **10.00/10**.
- Step 11.5 security scan **PASS**; `iac` skipped as not applicable to this project — a recorded
  visible skip, never a silent pass.
- `scripts/sync_shared_blocks.py --check`: shared blocks in sync.

## Prose-budget ceiling raise, stated openly

`references/step-14.md`'s ceiling goes 3_614 → 5_231 (actual 4_975 + 256 allowed headroom). The
guard's own message permits this "in the same commit, say why in the PR", and the #903 precedent
requires trimming first: the draft was compressed by 252 bytes before the raise, and the residual
growth is a genuinely new gated sub-step — Step 14 carried no run-record ordering at all — rather
than commentary. `references/step-16.md`'s companion edit was trimmed to fit under its existing
ceiling instead of raised alongside.

No workflow-spine change → **no diagram REV**.

Closes #888
