### PR TITLE
fix(tests): supervision CLI tests must not hand a frozen clock to a subprocess

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.131.0",
+  "version": "3.131.1",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,29 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.131.1 (2026-08-05)
+- **Three supervision CLI tests carried a dated time bomb and broke `main` an hour after
+  merging green (follow-up to #948, epic #871).** `tests/hooks/test_supervision_lib.py` and
+  `test_supervision_admin.py` freeze `NOW = 2026-08-05T21:00:00Z` and derive `LATER = NOW + 2h`.
+  That is correct for the in-process tests, because every one of them injects that clock. Three
+  tests handed `LATER` to a CLI **subprocess** instead, and a subprocess cannot take an injected
+  clock — `supervision_admin` deliberately has no `--now` override, since it gates outward
+  installs — so it read the real clock. At 2026-08-05T23:00:00Z `LATER` became the past and all
+  three failed permanently, not intermittently: `declare` refused with "`until` is in the past",
+  `effective` reported `attended-overdue` where the test expected `away`, and `nobody-to-ask`
+  inverted its exit code. CI was green at merge only because it ran before that instant. Fixed at
+  the boundary rather than at the constant: `_real_future()` / `_real_past()` build every
+  timestamp that crosses into `_cli` from the real clock, while the frozen `NOW` stays for the
+  injected in-process calls that want determinism. A sensitivity check confirms the assertions
+  still bite — inverting the helper reproduces exactly the three original failures, so the tests
+  were repaired rather than hollowed out. One guard added
+  (`test_no_cli_test_hands_a_frozen_future_timestamp_to_a_subprocess`), narrow by design per
+  CLAUDE.md §4 mistake #6: one exact pattern, in the CLI section of the two named files. A
+  repo-wide sweep for the same frozen-date-plus-subprocess shape found only
+  `tests/hooks/test_registry_prune.py` and `test_step_state.py`, and both are safe — the former
+  passes `--now` INTO its CLI, the latter injects into a pure function. No workflow-spine change
+  → no diagram REV. Suite 5487→5488.
+
 ### v3.131.0 (2026-08-05)
 - **Supervision is declared, not guessed — `RAWGENTIC_HEADLESS` is retired (#943 Part A, epic #871).**
   Three code paths asked "is anybody watching?" by reading one environment variable that could

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.131.0",
+  "version": "3.131.1",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.131.0"
+EXPECTED_PLUGIN_VERSION = "3.131.1"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_supervision_admin.py
+++ b/tests/hooks/test_supervision_admin.py
@@ -32,6 +32,19 @@ def _iso(dt):
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _real_future(hours=2):
+    """An `until` the REAL clock has not reached yet.
+
+    `_declare` injects the frozen `NOW`, so the in-process tests stay deterministic.
+    The CLI subprocess cannot take that clock — `supervision_admin` has no `--now`
+    override by design, because it gates outward installs — so it reads the real one.
+    A frozen future constant crossing into `_cli` therefore expires for good once
+    wall-clock time passes it: `LATER` is 2026-08-05T23:00:00Z, and the CLI declare
+    test began failing permanently at that instant (#948).
+    """
+    return _iso(datetime.now(timezone.utc) + timedelta(hours=hours))
+
+
 def _read(root):
     return json.loads(Path(sl.supervision_path(str(root))).read_text())
 
@@ -255,7 +268,7 @@ def _cli(*args):
 
 def test_cli_declare_prints_json_on_stdout_and_a_human_line_on_stderr(tmp_path):
     r = _cli("declare", "--workspace", str(tmp_path), "--state", "sleeping",
-             "--until", _iso(LATER), "--session-id", "sess-cli",
+             "--until", _real_future(), "--session-id", "sess-cli",
              "--campaign", "epic-871-m4-wave", "--provider", "gpt", "--granted")
     assert r.returncode == 0
     payload = json.loads(r.stdout)

--- a/tests/hooks/test_supervision_lib.py
+++ b/tests/hooks/test_supervision_lib.py
@@ -38,6 +38,24 @@ def _iso(dt):
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _real_future(hours=2):
+    """An `until` the REAL clock has not reached yet.
+
+    `NOW` above is frozen, and every in-process call takes it as an injected clock, so
+    those tests stay deterministic. A CLI subprocess cannot be handed that clock — it
+    reads the real one — so a frozen future constant crossing into `_cli` expires for
+    good the moment wall-clock time passes it. `LATER` is 2026-08-05T23:00:00Z, and
+    three CLI tests here began failing permanently at that instant (#948). Anything
+    time-sensitive that crosses into `_cli` is therefore built from the real clock.
+    """
+    return _iso(datetime.now(timezone.utc) + timedelta(hours=hours))
+
+
+def _real_past(hours=2):
+    """A deadline the REAL clock has already passed — the `_real_future` mirror."""
+    return _iso(datetime.now(timezone.utc) - timedelta(hours=hours))
+
+
 def _record(state="away", until=None, **kw):
     rec = {
         "schema_version": 1,
@@ -428,14 +446,14 @@ def test_cli_installs_forbidden_exit_codes(tmp_path):
     _write(tmp_path, _record(state="away", until=None))
     assert _cli("installs-forbidden", "--workspace", str(tmp_path)).returncode == 0
 
-    _write(tmp_path, _record(state="away", until=_iso(EARLIER)))
+    _write(tmp_path, _record(state="away", until=_real_past()))
     assert _cli("installs-forbidden", "--workspace", str(tmp_path)).returncode == 0, (
         "an expired declaration must still forbid installs")
 
 
 def test_cli_nobody_to_ask_exit_codes(tmp_path):
     assert _cli("nobody-to-ask", "--workspace", str(tmp_path)).returncode == 1
-    _write(tmp_path, _record(state="sleeping", until=_iso(LATER)))
+    _write(tmp_path, _record(state="sleeping", until=_real_future()))
     assert _cli("nobody-to-ask", "--workspace", str(tmp_path)).returncode == 0
 
 
@@ -444,7 +462,7 @@ def test_cli_missing_required_workspace_is_a_usage_error():
 
 
 def test_cli_effective_prints_parseable_json(tmp_path):
-    _write(tmp_path, _record(state="away", until=_iso(LATER)))
+    _write(tmp_path, _record(state="away", until=_real_future()))
     r = _cli("effective", "--workspace", str(tmp_path))
     assert r.returncode == 0
     payload = json.loads(r.stdout)
@@ -461,3 +479,27 @@ def test_cli_diagnoses_an_invalid_file_on_stderr(tmp_path):
     r = _cli("installs-forbidden", "--workspace", str(tmp_path))
     assert r.returncode == 0            # forbidden
     assert r.stderr.strip(), "an invalid state file must be visible, never silent"
+
+
+# ------------------------------------------------- the #948 time bomb, pinned
+
+def test_no_cli_test_hands_a_frozen_future_timestamp_to_a_subprocess():
+    """A frozen future constant must never cross into a real-clock subprocess.
+
+    `LATER` is `NOW + 2h` off a FROZEN `NOW`, which is right for the in-process tests
+    because each one injects that clock. A CLI subprocess cannot take it and reads the
+    real clock instead, so formatting `LATER` below the `_cli` definition is a dated
+    bomb: it passes until wall-clock reaches the constant, then fails forever. That is
+    exactly what happened at 2026-08-05T23:00:00Z, when three tests across these two
+    files broke on `main` an hour after merging green (#948). Use `_real_future()`.
+
+    Deliberately narrow (CLAUDE.md §4 mistake #6): ONE exact pattern, in the CLI
+    section of two named files — not a corpus-wide regex.
+    """
+    needle = "_iso(" + "LATER)"          # split, so this guard is not its own match
+    for name in ("test_supervision_lib.py", "test_supervision_admin.py"):
+        src = (Path(__file__).parent / name).read_text()
+        cli_section = src[src.index("def _cli("):]
+        assert needle not in cli_section, (
+            f"{name}: a CLI test builds a timestamp from the frozen `LATER`, which "
+            f"expires against the real clock — use `_real_future()` instead")


### PR DESCRIPTION
## What broke

Three supervision tests began failing on `main` at **2026-08-05T23:00:00Z** — one hour after
PR #948 merged green — and would have failed forever after that instant.

`tests/hooks/test_supervision_lib.py` and `tests/hooks/test_supervision_admin.py` freeze
`NOW = 2026-08-05T21:00:00Z` and derive `LATER = NOW + 2h`. That is the right design for the
in-process tests, because every one of them **injects** that clock. Three tests instead handed
`LATER` to a CLI **subprocess**, and a subprocess cannot take an injected clock — it reads the
real one. Once wall-clock time passed `LATER`, the constant was in the past:

| Test | Symptom |
|---|---|
| `test_supervision_admin.py::test_cli_declare_prints_json_on_stdout_and_a_human_line_on_stderr` | `declare` refused: ``` `until` is in the past ``` |
| `test_supervision_lib.py::test_cli_effective_prints_parseable_json` | got `attended-overdue`, expected `away` |
| `test_supervision_lib.py::test_cli_nobody_to_ask_exit_codes` | exit code inverted |

The CLI was behaving **correctly** in all three cases. The tests were wrong.

CI was green at merge only because it ran before 23:00:00Z. Since the `test` lane is a hard
gate, every subsequent PR would have failed it.

## The fix

At the boundary rather than at the constant. `_real_future()` / `_real_past()` build every
timestamp that crosses into `_cli` from the real clock; the frozen `NOW` stays for the
in-process calls that inject it and want determinism.

**Considered and rejected:** giving `supervision_admin` a `--now` override, which is what
`registry_prune` does (`tests/hooks/test_registry_prune.py` passes `--now` into its CLI and is
safe for exactly that reason). Rejected here because this module gates **outward package
installs** while the owner is away — a clock override on that surface is a way to unlock the
guard, not a test convenience. The test-side fix adds nothing to production.

## Verification

- **Reproduced first.** Baseline at `4b190391`: **5484 passed, 3 failed, exit 1**.
- **After the fix:** `pytest tests/ -q` → **5488 passed, exit 0**. Delta = 3 repaired + 1 guard.
- **Sensitivity check** — proof the tests were repaired, not hollowed out: inverting the helper
  to return a past time reproduces **exactly** the three original failures, then restoring it
  returns the suite to green.
- Both lint lanes, run with the exact CI invocations (`pylint hooks/*.py …` and `pylint tests/ …`):
  **10.00/10, exit 0**.
- `hooks/security_scan.py scan` → **PASS**. One visible skip: `iac: not applicable to this
  project` — recorded, not a silent pass.

## Regression guard

`test_no_cli_test_hands_a_frozen_future_timestamp_to_a_subprocess` pins the pattern: below the
`_cli` definition in the two named files, a timestamp must not be built from the frozen `LATER`.
Deliberately narrow per CLAUDE.md §4 mistake #6 — one exact pattern in two named files, not a
corpus-wide regex. Its detection mechanism is demonstrated, not assumed: the first version of
the guard fired on its own docstring, which is why the needle is now assembled at runtime.

## Blast-radius sweep

Every test file that both freezes a date and shells out to a subprocess was checked. Only two
others exist, and both are safe:

- `tests/hooks/test_registry_prune.py` — passes `--now` **into** its CLI, so the clock is
  injected across the boundary.
- `tests/hooks/test_step_state.py` — injects into a pure function; its CLI tests pass no frozen
  future time.

## Scope

Test-only, plus the version bump and changelog. No production code changed. No workflow-spine
change → no diagram REV.

Version 3.131.0 → **3.131.1** on all three surfaces (`.claude-plugin/plugin.json`,
`plugins/rawgentic/.codex-plugin/plugin.json`, and the `EXPECTED_PLUGIN_VERSION` test pin).

Follow-up to #948. Part of epic #871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
