### PR TITLE
fix(resume): measured resets_at extraction, freshness and session-lineage checks (#586)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.135.0",
+  "version": "3.135.1",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -762,7 +762,13 @@ For major changes, please open an issue first to discuss the approach.
   tie, or empty transcript listing refuses the shortcut in favor of the generated fresh `-p`
   prompt). The scheduler wiring, the `overnight-resume.sh` template rewrite, and the watchdog-to-
   reconciler demotion are workspace-root changes outside any git repo and ship in a follow-up PR
-  (D250). No workflow-spine change → no diagram REV. Suite 5762→5788.
+  (D250). Step-11 cross-model review (gpt-5.6-sol) found 2 High + 3 Medium — all fixed in this
+  PR: the freshness check now also bounds observation age against a live clock, the
+  session-lineage docstring makes explicit that Part 2 must resume via `--resume
+  <verified-tail>` immediately rather than a separately-resolved `--continue`, malformed
+  payload/state shapes return clean failures instead of raising, and the `read` CLI's failure
+  JSON moved to stdout to match its own documented contract.
+  No workflow-spine change → no diagram REV. Suite 5762→5804.
 
 ### v3.135.0 (2026-08-06)
 - **A handoff now has to say what the predecessor left running (#726, epic #871).** Every gate in

--- a/README.md
+++ b/README.md
@@ -749,6 +749,21 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.135.1 (2026-08-06)
+- **Resume launcher gets a measured-not-guessed reset clock, Part 1 (#586, epic #871).** The
+  durable overnight launcher pinned a session ID at arm time, so a `/clear` minted a new ID and
+  broke `--resume`. Part 1 ships the testable core only: `hooks/reset_resume_lib.py` extracts and
+  validates `rate_limits.five_hour.resets_at` from a statusline-shaped payload (rejects a
+  non-numeric, past, or implausibly-far-future epoch), asserts freshness on the OBSERVATION
+  timestamp advancing rather than on `resets_at` changing (the wave log's measured herdr-tokens
+  defect showed a value can legitimately stay constant for hours — a frozen capture, not a
+  changed value, is the real failure), computes the one-shot resume epoch (`resets_at + 60s`),
+  and runs the conservative session-lineage identity check before any `--continue` (any mismatch,
+  tie, or empty transcript listing refuses the shortcut in favor of the generated fresh `-p`
+  prompt). The scheduler wiring, the `overnight-resume.sh` template rewrite, and the watchdog-to-
+  reconciler demotion are workspace-root changes outside any git repo and ship in a follow-up PR
+  (D250). No workflow-spine change → no diagram REV. Suite 5762→5788.
+
 ### v3.135.0 (2026-08-06)
 - **A handoff now has to say what the predecessor left running (#726, epic #871).** Every gate in
   `perform_handoff` looked FORWARD at the successor; nothing looked backward. Measured 2026-07-30: a

--- a/docs/planning/campaign-log.md
+++ b/docs/planning/campaign-log.md
@@ -14,6 +14,57 @@ shipped; live run owner-gated). M1–M4 **COMPLETE**; the **epic #188 fast-follo
 
 ---
 
+## Epic #871 M4 — #586 Part 1: a measured clock instead of a pinned session ID · v3.135.1
+
+**The gap.** The durable overnight resume launcher (`overnight-resume.sh` template, per-run copies
+like `epic204-resume.sh`) relaunched via `claude --resume "$SESSION_ID"` with the ID **pinned at arm
+time**. A `/clear` mints a new session ID, so `--resume <old-id>` errors, and the fresh-`-p` fallback
+was fragile enough to intermittently miss overnight (owner report, 2026-07-22).
+
+**What shipped, and what deliberately did not.** Part 1 (this PR, `Part of #586`) ships only the
+testable core: `hooks/reset_resume_lib.py` extracts and validates
+`rate_limits.five_hour.resets_at` from a statusline-shaped payload, asserts freshness on the
+OBSERVATION timestamp advancing (never on `resets_at` itself changing — see below), computes the
+one-shot resume epoch (`resets_at + 60s`), and runs a conservative session-lineage identity check
+before any `--continue`. The scheduler wiring, the `overnight-resume.sh` rewrite, and the
+watchdog-to-reconciler demotion are workspace-root changes outside any git repo (`.git` there is a
+stub with no HEAD/objects/refs — confirmed, not assumed) and ship in a follow-up PR (D250).
+
+**The live spike that AC 1 called for, and what it actually produced.** Instrumenting the live
+global bridge script (`~/.claude/rawgentic-statusline.sh`) to observe its real stdin payload was
+denied by the auto-mode permission classifier on every attempt. A nested `claude --debug hooks -p`
+one-shot DID confirm, first-hand, that headless print-mode never invokes the statusLine command at
+all across a full session lifecycle — empirically backing, rather than merely assuming, the design
+doc's own claim that the bridge write must happen during a live interactive session. The harder
+fact — whether THIS host's interactive payload carries the field — stays unconfirmed and is why
+`extract_resets_at` returns a clean `{"ok": false, ...}` rather than trusting the value blind;
+Part 2 is where this gets a live caller for the first time. Recorded as D249.
+
+**The freshness design decision.** This same wave's log recorded a measured defect: `herdr`'s
+scraped statusline `tokens` field returned byte-identical output and an unchanged revision counter
+across three probes spread over many minutes — the capture had frozen, not the value. `resets_at`
+legitimately stays constant for up to five hours, so freshness here is asserted on the OBSERVATION
+timestamp advancing between reads, never on `resets_at` changing — checking the latter would
+false-positive on every healthy read.
+
+**Decisions (this slot).**
+- **D249** — the classifier-blocked live spike is shipped as a runtime self-check
+  (`extract_resets_at`'s `ok: false` path) rather than a manual pre-verification gate.
+- **D250** — splits #586 into two PRs (the #927 D233 precedent): this PR ships the pure library;
+  Part 2 (fresh WF2 run) wires it into the actual scheduler and the workspace-root templates.
+
+**Reviews.** One Step-11 cross-model pass (`gpt-5.6-sol`, diagnostic): 2 High + 3 Medium, all
+applied — the freshness check gained a live-clock recency bound (an advancing-but-ancient pair was
+wrongly "fresh"), the lineage check's docstring now states plainly that it is a point-in-time
+snapshot and Part 2 must resume via `--resume <verified-tail>` immediately rather than a
+separately-resolved `--continue`, and three malformed-input paths that raised now return clean
+failures.
+
+**Status.** Suite 5762→5804 (+42), exit 0. No workflow-spine change → no diagram REV. PR, CI and
+merge SHA filled by the next slot's pass, per the established convention here.
+
+---
+
 ## Epic #871 M4 — #726: a handoff finally looks backward · v3.135.0
 
 **The gap.** Every gate in `perform_handoff` — split, agent start, project bind, prompt landed,

--- a/hooks/reset_resume_lib.py
+++ b/hooks/reset_resume_lib.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Measured resets_at capture + freshness + session-lineage identity check (#586, Part 1).
+
+Part of the M4 wave's resume rewrite (docs/planning/2026-08-05-871-m4-session-continuity-away-mode.md
+§3.3): the durable overnight launcher must stop pinning a session ID and instead arm a one-shot
+resume at the MEASURED `rate_limits.five_hour.resets_at` from the statusline bridge, then resume
+via `claude -p --continue` behind a session-lineage identity check.
+
+This module ships the pure, testable core only (extraction/validation/freshness/lineage-check).
+The scheduler wiring, the `overnight-resume.sh` template rewrite, and the watchdog-to-reconciler
+demotion are workspace-root changes outside any git repo and ship in a follow-up PR (D250).
+
+Freshness contract (measured lesson, epic-871-m4-wave-log.md "herdr tokens STALE on this host"):
+a `resets_at` value that stays IDENTICAL across two reads is the EXPECTED steady state for a
+5-hour window — it must never be treated as staleness. What actually failed on this host was the
+underlying capture never refreshing at all. So freshness is asserted on `observed_at` advancing
+between reads, never on `resets_at` changing.
+"""
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from atomic_write_lib import atomic_write_text  # noqa: E402
+
+DEFAULT_ONE_SHOT_LAG_SECONDS = 60
+DEFAULT_MAX_FUTURE_SECONDS = 6 * 3600
+DEFAULT_MIN_ADVANCE_SECONDS = 1
+
+
+def extract_resets_at(payload, now_epoch, *, max_future_seconds=DEFAULT_MAX_FUTURE_SECONDS):
+    """Extract + validate rate_limits.five_hour.{resets_at,used_percentage} from a
+    statusline-shaped payload dict. Never raises on a malformed payload."""
+    five_hour = (payload or {}).get("rate_limits", {}).get("five_hour", {})
+    if not isinstance(five_hour, dict) or "resets_at" not in five_hour:
+        return {"ok": False, "reason": "field_absent"}
+
+    raw = five_hour["resets_at"]
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return {"ok": False, "reason": "not_numeric"}
+    resets_at = int(raw)
+
+    if resets_at <= now_epoch:
+        return {"ok": False, "reason": "not_in_future"}
+    if resets_at - now_epoch > max_future_seconds:
+        return {"ok": False, "reason": "too_far_future"}
+
+    used_percentage = five_hour.get("used_percentage")
+    if used_percentage is not None and not isinstance(used_percentage, bool):
+        try:
+            used_percentage = float(used_percentage)
+        except (TypeError, ValueError):
+            used_percentage = None
+    else:
+        used_percentage = None
+
+    return {"ok": True, "resets_at": resets_at, "used_percentage": used_percentage}
+
+
+def assess_freshness(prior, current, *, min_advance_seconds=DEFAULT_MIN_ADVANCE_SECONDS):
+    """`prior`/`current`: {"resets_at": int, "observed_at": number}. Fresh iff the
+    observation timestamp itself advanced — resets_at staying constant is expected."""
+    advanced = current["observed_at"] - prior["observed_at"] >= min_advance_seconds
+    if advanced:
+        return {"fresh": True, "reason": "observed_at_advanced"}
+    return {"fresh": False, "reason": "observed_at_frozen"}
+
+
+def compute_one_shot_epoch(resets_at, lag_seconds=DEFAULT_ONE_SHOT_LAG_SECONDS):
+    return resets_at + lag_seconds
+
+
+def check_session_lineage(lineage_tail, session_mtimes, *, tie_window_seconds=1):
+    """Conservative --continue safety check. `session_mtimes`: {session_id: mtime_epoch}.
+    Safe only when a unique newest transcript exists and it IS the lineage tail — any
+    mismatch, tie, or empty listing means launch the generated fresh -p prompt instead."""
+    if not session_mtimes:
+        return {"safe": False, "reason": "no_transcripts"}
+
+    ordered = sorted(session_mtimes.items(), key=lambda kv: kv[1], reverse=True)
+    newest_id, newest_mtime = ordered[0]
+
+    if len(ordered) > 1:
+        _, second_mtime = ordered[1]
+        if newest_mtime - second_mtime <= tie_window_seconds:
+            return {"safe": False, "reason": "tie_within_staleness_window"}
+
+    if newest_id != lineage_tail:
+        return {"safe": False, "reason": "newest_transcript_not_lineage_tail"}
+
+    return {"safe": True, "reason": "newest_transcript_matches_lineage_tail"}
+
+
+def persist_observation(state_path, resets_at, observed_at, used_percentage=None):
+    text = json.dumps({
+        "resets_at": resets_at,
+        "observed_at": observed_at,
+        "used_percentage": used_percentage,
+    })
+    atomic_write_text(state_path, text, mkdir=True, prefix=".reset-resume-", suffix=".tmp")
+
+
+def read_observation(state_path):
+    p = Path(state_path)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _cmd_extract(args):
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        print(json.dumps({"ok": False, "reason": "unparseable_stdin"}))
+        return 1
+    now_epoch = args.now if args.now is not None else int(datetime.now(timezone.utc).timestamp())
+    result = extract_resets_at(payload, now_epoch, max_future_seconds=args.max_future_seconds)
+    print(json.dumps(result))
+    return 0 if result["ok"] else 1
+
+
+def _cmd_one_shot_epoch(args):
+    print(json.dumps({"one_shot_epoch": compute_one_shot_epoch(args.resets_at, args.lag_seconds)}))
+    return 0
+
+
+def _cmd_persist(args):
+    persist_observation(args.state_path, args.resets_at, args.observed_at, args.used_percentage)
+    return 0
+
+
+def _cmd_read(args):
+    result = read_observation(args.state_path)
+    if result is None:
+        print(json.dumps({"ok": False, "reason": "no_observation"}), file=sys.stderr)
+        return 2
+    print(json.dumps(result))
+    return 0
+
+
+def _cmd_assess_freshness(args):
+    prior = json.loads(Path(args.prior_file).read_text())
+    current = json.loads(Path(args.current_file).read_text())
+    result = assess_freshness(prior, current, min_advance_seconds=args.min_advance_seconds)
+    print(json.dumps(result))
+    return 0 if result["fresh"] else 1
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_extract = sub.add_parser("extract", help="Extract resets_at from a statusline payload on stdin")
+    p_extract.add_argument("--now", type=int, default=None)
+    p_extract.add_argument("--max-future-seconds", type=int, default=DEFAULT_MAX_FUTURE_SECONDS)
+    p_extract.set_defaults(func=_cmd_extract)
+
+    p_oneshot = sub.add_parser("one-shot-epoch", help="Compute resets_at + lag")
+    p_oneshot.add_argument("--resets-at", type=int, required=True)
+    p_oneshot.add_argument("--lag-seconds", type=int, default=DEFAULT_ONE_SHOT_LAG_SECONDS)
+    p_oneshot.set_defaults(func=_cmd_one_shot_epoch)
+
+    p_persist = sub.add_parser("persist", help="Persist a reset observation to a state file")
+    p_persist.add_argument("--state-path", required=True)
+    p_persist.add_argument("--resets-at", type=int, required=True)
+    p_persist.add_argument("--observed-at", type=float, required=True)
+    p_persist.add_argument("--used-percentage", type=float, default=None)
+    p_persist.set_defaults(func=_cmd_persist)
+
+    p_read = sub.add_parser("read", help="Read a persisted reset observation")
+    p_read.add_argument("--state-path", required=True)
+    p_read.set_defaults(func=_cmd_read)
+
+    p_fresh = sub.add_parser("assess-freshness", help="Compare two observation JSON files")
+    p_fresh.add_argument("--prior-file", required=True)
+    p_fresh.add_argument("--current-file", required=True)
+    p_fresh.add_argument("--min-advance-seconds", type=float, default=DEFAULT_MIN_ADVANCE_SECONDS)
+    p_fresh.set_defaults(func=_cmd_assess_freshness)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/reset_resume_lib.py
+++ b/hooks/reset_resume_lib.py
@@ -28,17 +28,33 @@ from atomic_write_lib import atomic_write_text  # noqa: E402
 DEFAULT_ONE_SHOT_LAG_SECONDS = 60
 DEFAULT_MAX_FUTURE_SECONDS = 6 * 3600
 DEFAULT_MIN_ADVANCE_SECONDS = 1
+# How old the LATEST observation may be and still count as fresh. Review finding (High,
+# confidence 0.91): checking only that observed_at advanced between two reads says nothing
+# about whether that pair is itself hours old — an ancient-but-internally-advancing pair
+# must still be reported stale relative to the live clock.
+DEFAULT_MAX_OBSERVATION_AGE_SECONDS = 5 * 60
+
+
+def _is_numeric(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 def extract_resets_at(payload, now_epoch, *, max_future_seconds=DEFAULT_MAX_FUTURE_SECONDS):
     """Extract + validate rate_limits.five_hour.{resets_at,used_percentage} from a
     statusline-shaped payload dict. Never raises on a malformed payload."""
-    five_hour = (payload or {}).get("rate_limits", {}).get("five_hour", {})
-    if not isinstance(five_hour, dict) or "resets_at" not in five_hour:
+    if not isinstance(payload, dict):
+        return {"ok": False, "reason": "malformed_payload"}
+    rate_limits = payload.get("rate_limits", {})
+    if not isinstance(rate_limits, dict):
+        return {"ok": False, "reason": "malformed_payload"}
+    five_hour = rate_limits.get("five_hour", {})
+    if not isinstance(five_hour, dict):
+        return {"ok": False, "reason": "malformed_payload"}
+    if "resets_at" not in five_hour:
         return {"ok": False, "reason": "field_absent"}
 
     raw = five_hour["resets_at"]
-    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+    if not _is_numeric(raw):
         return {"ok": False, "reason": "not_numeric"}
     resets_at = int(raw)
 
@@ -59,13 +75,25 @@ def extract_resets_at(payload, now_epoch, *, max_future_seconds=DEFAULT_MAX_FUTU
     return {"ok": True, "resets_at": resets_at, "used_percentage": used_percentage}
 
 
-def assess_freshness(prior, current, *, min_advance_seconds=DEFAULT_MIN_ADVANCE_SECONDS):
-    """`prior`/`current`: {"resets_at": int, "observed_at": number}. Fresh iff the
-    observation timestamp itself advanced — resets_at staying constant is expected."""
+def assess_freshness(
+    prior, current, *, now_epoch,
+    min_advance_seconds=DEFAULT_MIN_ADVANCE_SECONDS,
+    max_observation_age_seconds=DEFAULT_MAX_OBSERVATION_AGE_SECONDS,
+):
+    """`prior`/`current`: {"resets_at": int, "observed_at": number}. `now_epoch` is REQUIRED
+    (no default) so a caller cannot silently skip the recency bound by omission.
+
+    Fresh iff BOTH: (1) observed_at advanced between prior and current — proves a NEW capture
+    actually ran (resets_at staying constant for hours is expected, never treated as
+    staleness); and (2) current's observed_at is recent relative to now_epoch — proves the
+    advancing pair is not itself an old, un-refreshed capture (review finding, High)."""
     advanced = current["observed_at"] - prior["observed_at"] >= min_advance_seconds
-    if advanced:
-        return {"fresh": True, "reason": "observed_at_advanced"}
-    return {"fresh": False, "reason": "observed_at_frozen"}
+    if not advanced:
+        return {"fresh": False, "reason": "observed_at_frozen"}
+    age = now_epoch - current["observed_at"]
+    if age < 0 or age > max_observation_age_seconds:
+        return {"fresh": False, "reason": "observed_at_stale_relative_to_now"}
+    return {"fresh": True, "reason": "observed_at_advanced"}
 
 
 def compute_one_shot_epoch(resets_at, lag_seconds=DEFAULT_ONE_SHOT_LAG_SECONDS):
@@ -73,9 +101,18 @@ def compute_one_shot_epoch(resets_at, lag_seconds=DEFAULT_ONE_SHOT_LAG_SECONDS):
 
 
 def check_session_lineage(lineage_tail, session_mtimes, *, tie_window_seconds=1):
-    """Conservative --continue safety check. `session_mtimes`: {session_id: mtime_epoch}.
-    Safe only when a unique newest transcript exists and it IS the lineage tail — any
-    mismatch, tie, or empty listing means launch the generated fresh -p prompt instead."""
+    """POINT-IN-TIME snapshot check, not a standing guarantee. `session_mtimes`:
+    {session_id: mtime_epoch}. Safe only when a unique newest transcript exists and it IS the
+    lineage tail — any mismatch, tie, or empty listing means launch the generated fresh -p
+    prompt instead.
+
+    Review finding (High, confidence 0.96): a `safe: True` result describes the transcript
+    listing AT THE MOMENT IT WAS TAKEN. A new session created between this check and the
+    actual resume subprocess launch is a real race `--continue` cannot see. Part 2 (the
+    scheduler that actually launches the resume) MUST close this gap by resuming via
+    `--resume <verified-lineage-tail-id>` immediately after this check succeeds, never a
+    separately-resolved `--continue` — this function only tells you whether it was safe to
+    do so as of this snapshot, and the caller must act on that snapshot without delay."""
     if not session_mtimes:
         return {"safe": False, "reason": "no_transcripts"}
 
@@ -102,14 +139,24 @@ def persist_observation(state_path, resets_at, observed_at, used_percentage=None
     atomic_write_text(state_path, text, mkdir=True, prefix=".reset-resume-", suffix=".tmp")
 
 
+def _is_valid_observation(obj):
+    """Review finding (Medium, confidence 0.98): a schema-violating-but-valid-JSON file was
+    returned as-is, so a downstream assess_freshness raised KeyError/TypeError instead of a
+    clean failure. Require a dict with numeric resets_at/observed_at (bool excluded)."""
+    if not isinstance(obj, dict):
+        return False
+    return _is_numeric(obj.get("resets_at")) and _is_numeric(obj.get("observed_at"))
+
+
 def read_observation(state_path):
     p = Path(state_path)
     if not p.exists():
         return None
     try:
-        return json.loads(p.read_text())
+        obj = json.loads(p.read_text())
     except (OSError, json.JSONDecodeError):
         return None
+    return obj if _is_valid_observation(obj) else None
 
 
 def _cmd_extract(args):
@@ -138,16 +185,30 @@ def _cmd_persist(args):
 def _cmd_read(args):
     result = read_observation(args.state_path)
     if result is None:
-        print(json.dumps({"ok": False, "reason": "no_observation"}), file=sys.stderr)
+        # Review finding (Medium, confidence 0.99): stderr broke the documented "machine JSON
+        # always on stdout" contract — a caller parsing stdout got nothing on failure.
+        print(json.dumps({"ok": False, "reason": "no_observation"}))
         return 2
     print(json.dumps(result))
     return 0
 
 
 def _cmd_assess_freshness(args):
-    prior = json.loads(Path(args.prior_file).read_text())
-    current = json.loads(Path(args.current_file).read_text())
-    result = assess_freshness(prior, current, min_advance_seconds=args.min_advance_seconds)
+    try:
+        prior = json.loads(Path(args.prior_file).read_text())
+        current = json.loads(Path(args.current_file).read_text())
+    except (OSError, json.JSONDecodeError):
+        print(json.dumps({"fresh": False, "reason": "malformed_observation"}))
+        return 1
+    if not (_is_valid_observation(prior) and _is_valid_observation(current)):
+        print(json.dumps({"fresh": False, "reason": "malformed_observation"}))
+        return 1
+    now_epoch = args.now if args.now is not None else int(datetime.now(timezone.utc).timestamp())
+    result = assess_freshness(
+        prior, current, now_epoch=now_epoch,
+        min_advance_seconds=args.min_advance_seconds,
+        max_observation_age_seconds=args.max_observation_age_seconds,
+    )
     print(json.dumps(result))
     return 0 if result["fresh"] else 1
 
@@ -180,7 +241,11 @@ def main(argv=None):
     p_fresh = sub.add_parser("assess-freshness", help="Compare two observation JSON files")
     p_fresh.add_argument("--prior-file", required=True)
     p_fresh.add_argument("--current-file", required=True)
+    p_fresh.add_argument("--now", type=int, default=None, help="ISO/epoch override (testing)")
     p_fresh.add_argument("--min-advance-seconds", type=float, default=DEFAULT_MIN_ADVANCE_SECONDS)
+    p_fresh.add_argument(
+        "--max-observation-age-seconds", type=float, default=DEFAULT_MAX_OBSERVATION_AGE_SECONDS,
+    )
     p_fresh.set_defaults(func=_cmd_assess_freshness)
 
     args = parser.parse_args(argv)

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.135.0",
+  "version": "3.135.1",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.135.0"
+EXPECTED_PLUGIN_VERSION = "3.135.1"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_reset_resume_lib.py
+++ b/tests/hooks/test_reset_resume_lib.py
@@ -74,15 +74,57 @@ class TestExtractResetsAt:
         result = extract_resets_at(payload, now_epoch=now)
         assert result == {"ok": True, "resets_at": now + 100, "used_percentage": None}
 
+    # --- Review finding (Medium, confidence 0.99): a non-dict payload/rate_limits/five_hour
+    # value raised AttributeError instead of returning a clean ok:false result. ---
+
+    def test_non_dict_top_level_payload_is_malformed_not_a_crash(self):
+        from reset_resume_lib import extract_resets_at
+        result = extract_resets_at(["not", "a", "dict"], now_epoch=1_000_000)
+        assert result == {"ok": False, "reason": "malformed_payload"}
+
+    def test_null_rate_limits_value_is_malformed_not_a_crash(self):
+        from reset_resume_lib import extract_resets_at
+        result = extract_resets_at({"rate_limits": None}, now_epoch=1_000_000)
+        assert result == {"ok": False, "reason": "malformed_payload"}
+
+    def test_non_dict_rate_limits_value_is_malformed_not_a_crash(self):
+        from reset_resume_lib import extract_resets_at
+        result = extract_resets_at({"rate_limits": "nope"}, now_epoch=1_000_000)
+        assert result == {"ok": False, "reason": "malformed_payload"}
+
+    def test_null_five_hour_value_is_malformed_not_a_crash(self):
+        from reset_resume_lib import extract_resets_at
+        result = extract_resets_at({"rate_limits": {"five_hour": None}}, now_epoch=1_000_000)
+        assert result == {"ok": False, "reason": "malformed_payload"}
+
+    def test_non_dict_five_hour_value_is_malformed_not_a_crash(self):
+        from reset_resume_lib import extract_resets_at
+        result = extract_resets_at({"rate_limits": {"five_hour": [1, 2]}}, now_epoch=1_000_000)
+        assert result == {"ok": False, "reason": "malformed_payload"}
+
+    def test_boolean_resets_at_is_rejected_not_treated_as_an_int(self):
+        """bool is an int subclass in Python — True/False must not slip past the numeric check."""
+        from reset_resume_lib import extract_resets_at
+        payload = {"rate_limits": {"five_hour": {"resets_at": True}}}
+        result = extract_resets_at(payload, now_epoch=1_000_000)
+        assert result == {"ok": False, "reason": "not_numeric"}
+
 
 class TestAssessFreshness:
+    """`now_epoch` is REQUIRED (no default) so a caller cannot silently skip the recency
+    bound by omission — a review finding (High, confidence 0.91) on the first cut of this
+    function showed a relatively-advancing pair can still be an old capture replayed with a
+    rewritten `observed_at`; the recency check below closes exactly that gap."""
+
     def test_advancing_observed_at_is_fresh_even_with_identical_resets_at(self):
         """The measured failure mode: resets_at legitimately stays constant for hours.
         That alone must never be treated as staleness."""
         from reset_resume_lib import assess_freshness
         prior = {"resets_at": 5_000_000, "observed_at": 1_000_000}
         current = {"resets_at": 5_000_000, "observed_at": 1_000_100}
-        assert assess_freshness(prior, current) == {"fresh": True, "reason": "observed_at_advanced"}
+        assert assess_freshness(prior, current, now_epoch=1_000_100) == {
+            "fresh": True, "reason": "observed_at_advanced",
+        }
 
     def test_frozen_observed_at_is_stale_the_herdr_defect(self):
         """Reproduces the exact measured defect: three probes spread across many minutes
@@ -90,21 +132,53 @@ class TestAssessFreshness:
         from reset_resume_lib import assess_freshness
         prior = {"resets_at": 5_000_000, "observed_at": 1_000_000}
         current = {"resets_at": 5_000_000, "observed_at": 1_000_000}
-        assert assess_freshness(prior, current) == {"fresh": False, "reason": "observed_at_frozen"}
+        assert assess_freshness(prior, current, now_epoch=1_000_000) == {
+            "fresh": False, "reason": "observed_at_frozen",
+        }
 
     def test_observed_at_moving_backward_is_stale(self):
         from reset_resume_lib import assess_freshness
         prior = {"resets_at": 5_000_000, "observed_at": 1_000_100}
         current = {"resets_at": 5_000_000, "observed_at": 1_000_000}
-        assert assess_freshness(prior, current) == {"fresh": False, "reason": "observed_at_frozen"}
+        assert assess_freshness(prior, current, now_epoch=1_000_100) == {
+            "fresh": False, "reason": "observed_at_frozen",
+        }
 
     def test_min_advance_seconds_is_respected(self):
         from reset_resume_lib import assess_freshness
         prior = {"resets_at": 5_000_000, "observed_at": 1_000_000}
         current = {"resets_at": 5_000_000, "observed_at": 1_000_000 + 0.5}
-        assert assess_freshness(prior, current, min_advance_seconds=1) == {
+        assert assess_freshness(prior, current, now_epoch=1_000_000, min_advance_seconds=1) == {
             "fresh": False, "reason": "observed_at_frozen",
         }
+
+    def test_advancing_pair_that_is_ancient_relative_to_now_is_still_stale(self):
+        """The review finding, reproduced directly: prior->current shows real relative
+        advancement, but BOTH are from hours ago — a caller re-reading an old, un-refreshed
+        state file must not be told it is fresh just because the two saved timestamps differ."""
+        from reset_resume_lib import assess_freshness
+        prior = {"resets_at": 5_000_000, "observed_at": 1_000_000}
+        current = {"resets_at": 5_000_000, "observed_at": 1_000_100}
+        far_future_now = 1_000_100 + 3600  # an hour after the "current" observation
+        result = assess_freshness(prior, current, now_epoch=far_future_now)
+        assert result == {"fresh": False, "reason": "observed_at_stale_relative_to_now"}
+
+    def test_max_observation_age_seconds_is_respected(self):
+        from reset_resume_lib import assess_freshness
+        prior = {"resets_at": 5_000_000, "observed_at": 1_000_000}
+        current = {"resets_at": 5_000_000, "observed_at": 1_000_100}
+        result = assess_freshness(
+            prior, current, now_epoch=1_000_100 + 30, max_observation_age_seconds=10,
+        )
+        assert result == {"fresh": False, "reason": "observed_at_stale_relative_to_now"}
+
+    def test_observed_at_from_the_future_relative_to_now_is_stale(self):
+        """Guards clock skew / a replayed observation stamped ahead of the real clock."""
+        from reset_resume_lib import assess_freshness
+        prior = {"resets_at": 5_000_000, "observed_at": 1_000_000}
+        current = {"resets_at": 5_000_000, "observed_at": 1_000_100}
+        result = assess_freshness(prior, current, now_epoch=1_000_050)
+        assert result == {"fresh": False, "reason": "observed_at_stale_relative_to_now"}
 
 
 class TestComputeOneShotEpoch:
@@ -168,6 +242,34 @@ class TestPersistAndReadObservation:
         state_path.write_text("{not json")
         assert read_observation(state_path) is None
 
+    # --- Review finding (Medium, confidence 0.98): valid JSON with the wrong shape/types was
+    # returned as-is, so a downstream assess_freshness call raised KeyError/TypeError instead
+    # of a clean failure. ---
+
+    def test_read_wrong_shape_object_returns_none(self, tmp_path):
+        from reset_resume_lib import read_observation
+        state_path = tmp_path / "wrong-shape.json"
+        state_path.write_text(json.dumps({"unrelated": "stuff"}))
+        assert read_observation(state_path) is None
+
+    def test_read_json_array_returns_none(self, tmp_path):
+        from reset_resume_lib import read_observation
+        state_path = tmp_path / "array.json"
+        state_path.write_text(json.dumps([1, 2, 3]))
+        assert read_observation(state_path) is None
+
+    def test_read_string_timestamps_returns_none(self, tmp_path):
+        from reset_resume_lib import read_observation
+        state_path = tmp_path / "string-ts.json"
+        state_path.write_text(json.dumps({"resets_at": "soon", "observed_at": "now"}))
+        assert read_observation(state_path) is None
+
+    def test_read_boolean_timestamp_returns_none(self, tmp_path):
+        from reset_resume_lib import read_observation
+        state_path = tmp_path / "bool-ts.json"
+        state_path.write_text(json.dumps({"resets_at": True, "observed_at": 1_000_000}))
+        assert read_observation(state_path) is None
+
 
 class TestCLI:
     def test_extract_reads_stdin_and_prints_json(self):
@@ -198,5 +300,38 @@ class TestCLI:
         assert json.loads(out2) == {"resets_at": 5000000, "observed_at": 1000000, "used_percentage": None}
 
     def test_read_cli_missing_state_exits_2(self, tmp_path):
+        # Review finding (Medium, confidence 0.99): this used to print the failure JSON to
+        # stderr, breaking the documented "machine JSON always on stdout" contract.
         out, err, rc = _run_cli("read", "--state-path", str(tmp_path / "nope.json"))
         assert rc == 2
+        assert json.loads(out) == {"ok": False, "reason": "no_observation"}
+        assert err == ""
+
+    def test_extract_cli_malformed_payload_exits_1_with_clean_json(self):
+        out, err, rc = _run_cli("extract", "--now", "1000000", input_text=json.dumps(["nope"]))
+        assert rc == 1
+        assert json.loads(out) == {"ok": False, "reason": "malformed_payload"}
+
+    def test_assess_freshness_cli_requires_now(self, tmp_path):
+        prior_file = tmp_path / "prior.json"
+        current_file = tmp_path / "current.json"
+        prior_file.write_text(json.dumps({"resets_at": 5_000_000, "observed_at": 1_000_000}))
+        current_file.write_text(json.dumps({"resets_at": 5_000_000, "observed_at": 1_000_100}))
+        out, err, rc = _run_cli(
+            "assess-freshness", "--prior-file", str(prior_file),
+            "--current-file", str(current_file), "--now", "1000100",
+        )
+        assert rc == 0, err
+        assert json.loads(out) == {"fresh": True, "reason": "observed_at_advanced"}
+
+    def test_assess_freshness_cli_on_malformed_file_is_clean_failure_not_a_crash(self, tmp_path):
+        prior_file = tmp_path / "prior.json"
+        current_file = tmp_path / "current.json"
+        prior_file.write_text(json.dumps({"unrelated": "stuff"}))
+        current_file.write_text(json.dumps({"resets_at": 5_000_000, "observed_at": 1_000_100}))
+        out, err, rc = _run_cli(
+            "assess-freshness", "--prior-file", str(prior_file),
+            "--current-file", str(current_file), "--now", "1000100",
+        )
+        assert rc == 1
+        assert json.loads(out) == {"fresh": False, "reason": "malformed_observation"}

--- a/tests/hooks/test_reset_resume_lib.py
+++ b/tests/hooks/test_reset_resume_lib.py
@@ -1,0 +1,202 @@
+"""Tests for hooks/reset_resume_lib.py — Part 1 of #586 (measurement library only;
+PR 2 wires this into the actual scheduler/launcher, per D250).
+
+The wave log's measured lesson (epic-871-m4-wave-log.md, "Finding — herdr's scraped
+`tokens` field is STALE on this host") drives the freshness contract here: a value that
+stays IDENTICAL across two reads is the EXPECTED steady state for a 5-hour reset epoch —
+what actually failed on this host was the underlying capture never refreshing at all
+(a frozen observation timestamp). So freshness is asserted on `observed_at` advancing
+between reads, never on `resets_at` changing.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+RESET_RESUME_CLI = HOOKS_DIR / "reset_resume_lib.py"
+
+
+def _run_cli(*args, input_text=None, timeout=10):
+    import subprocess
+    result = subprocess.run(
+        ["python3", str(RESET_RESUME_CLI), *args],
+        capture_output=True, text=True, timeout=timeout, input=input_text,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+class TestExtractResetsAt:
+    def test_extracts_valid_future_epoch(self):
+        from reset_resume_lib import extract_resets_at
+        now = 1_000_000
+        payload = {"rate_limits": {"five_hour": {"resets_at": now + 3600, "used_percentage": 42.0}}}
+        result = extract_resets_at(payload, now_epoch=now)
+        assert result == {"ok": True, "resets_at": now + 3600, "used_percentage": 42.0}
+
+    def test_missing_field_is_absent_not_a_crash(self):
+        from reset_resume_lib import extract_resets_at
+        result = extract_resets_at({"rate_limits": {}}, now_epoch=1_000_000)
+        assert result == {"ok": False, "reason": "field_absent"}
+
+    def test_missing_rate_limits_key_entirely_is_absent(self):
+        from reset_resume_lib import extract_resets_at
+        result = extract_resets_at({}, now_epoch=1_000_000)
+        assert result == {"ok": False, "reason": "field_absent"}
+
+    def test_non_numeric_epoch_is_rejected(self):
+        from reset_resume_lib import extract_resets_at
+        payload = {"rate_limits": {"five_hour": {"resets_at": "soon"}}}
+        result = extract_resets_at(payload, now_epoch=1_000_000)
+        assert result == {"ok": False, "reason": "not_numeric"}
+
+    def test_epoch_in_the_past_is_implausible(self):
+        from reset_resume_lib import extract_resets_at
+        now = 1_000_000
+        payload = {"rate_limits": {"five_hour": {"resets_at": now - 60}}}
+        result = extract_resets_at(payload, now_epoch=now)
+        assert result == {"ok": False, "reason": "not_in_future"}
+
+    def test_epoch_too_far_in_future_is_implausible(self):
+        from reset_resume_lib import extract_resets_at
+        now = 1_000_000
+        payload = {"rate_limits": {"five_hour": {"resets_at": now + 100_000}}}
+        result = extract_resets_at(payload, now_epoch=now, max_future_seconds=6 * 3600)
+        assert result == {"ok": False, "reason": "too_far_future"}
+
+    def test_used_percentage_optional(self):
+        from reset_resume_lib import extract_resets_at
+        now = 1_000_000
+        payload = {"rate_limits": {"five_hour": {"resets_at": now + 100}}}
+        result = extract_resets_at(payload, now_epoch=now)
+        assert result == {"ok": True, "resets_at": now + 100, "used_percentage": None}
+
+
+class TestAssessFreshness:
+    def test_advancing_observed_at_is_fresh_even_with_identical_resets_at(self):
+        """The measured failure mode: resets_at legitimately stays constant for hours.
+        That alone must never be treated as staleness."""
+        from reset_resume_lib import assess_freshness
+        prior = {"resets_at": 5_000_000, "observed_at": 1_000_000}
+        current = {"resets_at": 5_000_000, "observed_at": 1_000_100}
+        assert assess_freshness(prior, current) == {"fresh": True, "reason": "observed_at_advanced"}
+
+    def test_frozen_observed_at_is_stale_the_herdr_defect(self):
+        """Reproduces the exact measured defect: three probes spread across many minutes
+        returned byte-identical output AND an unchanged revision — the capture never ran."""
+        from reset_resume_lib import assess_freshness
+        prior = {"resets_at": 5_000_000, "observed_at": 1_000_000}
+        current = {"resets_at": 5_000_000, "observed_at": 1_000_000}
+        assert assess_freshness(prior, current) == {"fresh": False, "reason": "observed_at_frozen"}
+
+    def test_observed_at_moving_backward_is_stale(self):
+        from reset_resume_lib import assess_freshness
+        prior = {"resets_at": 5_000_000, "observed_at": 1_000_100}
+        current = {"resets_at": 5_000_000, "observed_at": 1_000_000}
+        assert assess_freshness(prior, current) == {"fresh": False, "reason": "observed_at_frozen"}
+
+    def test_min_advance_seconds_is_respected(self):
+        from reset_resume_lib import assess_freshness
+        prior = {"resets_at": 5_000_000, "observed_at": 1_000_000}
+        current = {"resets_at": 5_000_000, "observed_at": 1_000_000 + 0.5}
+        assert assess_freshness(prior, current, min_advance_seconds=1) == {
+            "fresh": False, "reason": "observed_at_frozen",
+        }
+
+
+class TestComputeOneShotEpoch:
+    def test_adds_fixed_lag(self):
+        from reset_resume_lib import compute_one_shot_epoch
+        assert compute_one_shot_epoch(1_000_000) == 1_000_060
+
+    def test_custom_lag(self):
+        from reset_resume_lib import compute_one_shot_epoch
+        assert compute_one_shot_epoch(1_000_000, lag_seconds=90) == 1_000_090
+
+
+class TestCheckSessionLineage:
+    def test_newest_matches_lineage_tail_is_safe(self):
+        from reset_resume_lib import check_session_lineage
+        mtimes = {"session-old": 100, "session-new": 200}
+        result = check_session_lineage("session-new", mtimes)
+        assert result == {"safe": True, "reason": "newest_transcript_matches_lineage_tail"}
+
+    def test_newest_mismatched_lineage_tail_is_unsafe(self):
+        """This is the concurrent-session risk the design doc's consult finding raised:
+        an unrelated session in the same workspace root can be the newest transcript."""
+        from reset_resume_lib import check_session_lineage
+        mtimes = {"session-ours": 100, "session-unrelated": 200}
+        result = check_session_lineage("session-ours", mtimes)
+        assert result == {"safe": False, "reason": "newest_transcript_not_lineage_tail"}
+
+    def test_no_transcripts_is_unsafe(self):
+        from reset_resume_lib import check_session_lineage
+        assert check_session_lineage("session-ours", {}) == {"safe": False, "reason": "no_transcripts"}
+
+    def test_tie_within_staleness_window_is_unsafe(self):
+        from reset_resume_lib import check_session_lineage
+        mtimes = {"session-ours": 200, "session-other": 200.4}
+        result = check_session_lineage("session-ours", mtimes, tie_window_seconds=1)
+        assert result == {"safe": False, "reason": "tie_within_staleness_window"}
+
+    def test_tie_outside_staleness_window_resolves_by_mtime(self):
+        from reset_resume_lib import check_session_lineage
+        mtimes = {"session-ours": 100, "session-other": 200}
+        result = check_session_lineage("session-other", mtimes, tie_window_seconds=1)
+        assert result == {"safe": True, "reason": "newest_transcript_matches_lineage_tail"}
+
+
+class TestPersistAndReadObservation:
+    def test_round_trips_through_atomic_write(self, tmp_path):
+        from reset_resume_lib import persist_observation, read_observation
+        state_path = tmp_path / "reset-state.json"
+        persist_observation(state_path, resets_at=5_000_000, observed_at=1_000_000, used_percentage=42.0)
+        assert read_observation(state_path) == {
+            "resets_at": 5_000_000, "observed_at": 1_000_000, "used_percentage": 42.0,
+        }
+
+    def test_read_missing_file_returns_none(self, tmp_path):
+        from reset_resume_lib import read_observation
+        assert read_observation(tmp_path / "does-not-exist.json") is None
+
+    def test_read_corrupt_file_returns_none_not_a_crash(self, tmp_path):
+        from reset_resume_lib import read_observation
+        state_path = tmp_path / "corrupt.json"
+        state_path.write_text("{not json")
+        assert read_observation(state_path) is None
+
+
+class TestCLI:
+    def test_extract_reads_stdin_and_prints_json(self):
+        payload = json.dumps({"rate_limits": {"five_hour": {"resets_at": 2_000_100, "used_percentage": 5.0}}})
+        out, err, rc = _run_cli("extract", "--now", "2000000", input_text=payload)
+        assert rc == 0, err
+        assert json.loads(out) == {"ok": True, "resets_at": 2_000_100, "used_percentage": 5.0}
+
+    def test_extract_exits_nonzero_on_absent_field(self):
+        out, err, rc = _run_cli("extract", "--now", "2000000", input_text="{}")
+        assert rc == 1
+        assert json.loads(out) == {"ok": False, "reason": "field_absent"}
+
+    def test_one_shot_epoch_cli(self):
+        out, err, rc = _run_cli("one-shot-epoch", "--resets-at", "1000000")
+        assert rc == 0, err
+        assert json.loads(out) == {"one_shot_epoch": 1_000_060}
+
+    def test_persist_and_read_cli_round_trip(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        out, err, rc = _run_cli(
+            "persist", "--state-path", str(state_path),
+            "--resets-at", "5000000", "--observed-at", "1000000",
+        )
+        assert rc == 0, err
+        out2, err2, rc2 = _run_cli("read", "--state-path", str(state_path))
+        assert rc2 == 0, err2
+        assert json.loads(out2) == {"resets_at": 5000000, "observed_at": 1000000, "used_percentage": None}
+
+    def test_read_cli_missing_state_exits_2(self, tmp_path):
+        out, err, rc = _run_cli("read", "--state-path", str(tmp_path / "nope.json"))
+        assert rc == 2


### PR DESCRIPTION
## Summary

Part 1 of the #586 resume-launcher rewrite (epic #871 M4 wave, design doc §3.3). Ships the
testable core only: `hooks/reset_resume_lib.py` extracts and validates
`rate_limits.five_hour.resets_at` from a statusline-shaped payload, asserts freshness on the
**observation timestamp advancing** (never on `resets_at` itself changing — see rationale
below), computes the one-shot resume epoch (`resets_at + 60s`), and runs a conservative
session-lineage identity check before any `--continue`.

**Deliberately out of scope for this PR** (D250 — follows the #927 D233 precedent of splitting
an oversized child): the actual system-crontab one-shot scheduler, the `overnight-resume.sh`
template rewrite, and the `*/20` watchdog-to-reconciler demotion. Those are workspace-root
changes outside any git repository (`/home/rocky00717/rawgentic/.git` is a stub with no
HEAD/objects/refs — confirmed, not assumed) and ship in a follow-up PR that carries `Closes #586`.

## Why freshness checks the observation timestamp, not the value

This wave's own log (`claude_docs/session_notes/epic-871-m4-wave-log.md`) recorded a measured
defect: `herdr`'s scraped statusline `tokens` field returned byte-identical output and an
unchanged revision counter across three probes spread over many minutes — the capture had
frozen, not the value. `rate_limits.five_hour.resets_at` legitimately stays constant for up to
five hours, so checking whether it *changed* would false-positive on every healthy read.
Freshness here is asserted on `observed_at` advancing between two reads, with an added
live-clock recency bound (below) so an old-but-internally-advancing pair still reads as stale.

## AC 1's live spike — disclosed, not hidden

AC 1 calls for a live spike proving `rate_limits.five_hour.resets_at` actually reaches
`~/.claude/rawgentic-statusline.sh` on this host. Instrumenting that live global script was
denied by the Claude Code auto-mode permission classifier on every attempt (append-only stdin
capture, reverted after). A nested `claude --debug hooks -p` one-shot did confirm, first-hand,
that headless print-mode never invokes the statusLine command at all — which empirically backs
the design doc's own assumption that the bridge write must happen during a live interactive
session. The harder fact (does this host's *interactive* payload carry the field) stays
unconfirmed, which is why `extract_resets_at` returns a structured `{"ok": false, ...}` rather
than trusting the value blind — Part 2 is where this function gets a live caller for the first
time. Recorded as D249 (`hooks/decision_log.py`).

## Review

Step 11 cross-model pass (`gpt-5.6-sol`, author `claude-sonnet-5`): 2 High + 3 Medium, all
applied in a follow-up commit on this branch:
- `assess_freshness` now also bounds observation age against a live clock (an
  advancing-but-ancient pair was wrongly reported fresh).
- `check_session_lineage`'s docstring states plainly this is a point-in-time snapshot and Part 2
  must resume via `--resume <verified-tail>` immediately after this check, never a
  separately-resolved `--continue`.
- `extract_resets_at` rejects a non-dict payload/rate_limits/five_hour value instead of raising
  `AttributeError`.
- `read_observation` validates shape (numeric `resets_at`/`observed_at`, booleans excluded)
  instead of returning a malformed object as a valid observation.
- The `read` CLI's failure JSON moved to stdout to match its own documented
  machine-JSON-on-stdout contract.

Security scan (`hooks/security_scan.py scan --base-ref origin/main`): clean, gate not blocked.

## Test plan

- [x] 42 new tests in `tests/hooks/test_reset_resume_lib.py` (pure-function + CLI-subprocess,
  matching `tests/hooks/test_resume_lib.py`'s established pattern — that is an unrelated
  module, WF2's own step-resumption cascade, not this issue).
- [x] Whole suite: 5762 → 5804 passed, exit 0 (baseline recorded first-hand at `1cc353f4`
  before this PR's first commit).
- [x] Lint (`pylint hooks/*.py`/`tests/*.py`, the repo's exact CI invocation): 10.00/10 both.
- [x] Version bumped on all three surfaces + the test-file mirror
  (`tests/hooks/test_adversarial_review_registration.py::EXPECTED_PLUGIN_VERSION`).
- [x] README changelog entry carries both tail tokens (`no diagram REV` / `Suite 5762→5804`).
- [x] `docs/planning/campaign-log.md` slot entry added in this PR (the #888 trap this wave
  measured: writing it after the fact requires reconstruction).

Part of #586
