### PR TITLE
docs(586): wire the resume scheduler outside the repo, Part 2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.135.1",
+  "version": "3.135.2",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,30 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.135.2 (2026-08-06)
+- **Resume launcher gets a measured-not-guessed reset clock, Part 2 (#586, epic #871).** Part 1
+  (v3.135.1) shipped the measurement/lineage-check library with no caller. Part 2 wires it in:
+  `overnight-resume.sh` (the workspace-root template, outside any git repo) is rewritten into a
+  RECONCILER role (fired by the unchanged recurring `*/20` cron — if stale and a fresh
+  `resets_at` observation exists, arms a self-removing ONE-SHOT crontab entry at `resets_at +
+  60s` and returns without launching; if missing/overdue or never measured, falls back to the
+  pre-#586 blind-staleness launch) and a ONE-SHOT role (removes its own crontab line first, then
+  launches — a crash after that point must never leave a live cron field that could re-match
+  next month/year). Session resume now reads the campaign's lineage tail from
+  `claude_docs/session_registry.jsonl` and confirms it via `check_session_lineage` before
+  `--resume`, instead of a session ID pinned at arm time. `.claude/skills/long-run-resume/
+  SKILL.md` carries the same rewrite. AC 1's live spike is confirmed via the existing `usagebar`
+  cache (fed by the same payload) rather than by touching the bridge script — a narrow edit
+  adding the actual persist call was denied by the auto-mode classifier (D249/D253 precedent);
+  the one-line patch is handed to the owner in the campaign log instead of silently dropped, and
+  the launcher degrades cleanly to `waiting_for_reset_unmeasured` until it's applied. Also fixed
+  (not backported): `grep -c PATTERN file || echo 0` doubles its output whenever the count is
+  legitimately zero, which then corrupts `$(( ))` arithmetic downstream badly enough to skip an
+  intended `exit` — every pre-#586 campaign script carries this idiom, harmless today only
+  because none are currently enabled. No pytest surface applies (workspace-root files only);
+  validated via an isolated bash harness (stub crontab, fixture registry, stub `claude`) across
+  six scenarios, all passing. No workflow-spine change → no diagram REV. Suite 5804→5804.
+
 ### v3.135.1 (2026-08-06)
 - **Resume launcher gets a measured-not-guessed reset clock, Part 1 (#586, epic #871).** The
   durable overnight launcher pinned a session ID at arm time, so a `/clear` minted a new ID and

--- a/docs/planning/campaign-log.md
+++ b/docs/planning/campaign-log.md
@@ -14,6 +14,86 @@ shipped; live run owner-gated). M1–M4 **COMPLETE**; the **epic #188 fast-follo
 
 ---
 
+## Epic #871 M4 — #586 Part 2: the scheduler, wired outside the repo · v3.135.2
+
+**The gap, closed.** Part 1 (v3.135.1) shipped the measurement/validation/lineage-check
+library with no caller. Part 2 wires it into the actual launcher: `overnight-resume.sh`
+(the workspace-root template, outside any git repo — `.git` there is a stub, confirmed) is
+rewritten into two roles sharing one recurring `*/20` cron trigger. RECONCILER: if stale
+and a fresh `resets_at` observation exists, arm a self-removing ONE-SHOT crontab entry at
+`resets_at + 60s` and return without launching; if the one-shot is missing/overdue, or the
+reset time was never measured (`waiting_for_reset_unmeasured`), fall back to the pre-#586
+blind-staleness launch. ONE-SHOT: remove its own crontab line FIRST (a crash after that
+point must never leave a live cron field that could re-match next month/year), then launch.
+Session resume now reads the campaign's lineage tail from `claude_docs/session_registry.jsonl`
+and confirms it point-in-time via `check_session_lineage` before `--resume`, instead of a
+session ID pinned at arm time. `.claude/skills/long-run-resume/SKILL.md` carries the same
+rewrite so future campaigns inherit it.
+
+**AC 1's live spike, resolved without touching the bridge.** The existing `usagebar`
+integration (fed by the identical `$input` payload `rawgentic-statusline.sh` receives)
+already caches `rate_limits.five_hour.resetsAt` — read live during this run:
+`1786021800`, ~4.6 hours in the future of the capture instant, well inside the library's
+6-hour sanity bound. That confirms the field genuinely exists in the live payload on this
+host, independent of any edit to the bridge script itself.
+
+**The wiring that could NOT ship, and why.** A narrow, single-purpose `Edit` adding the
+persist call to `~/.claude/rawgentic-statusline.sh` was denied by the auto-mode
+classifier — the same class of denial D249 hit on this exact file. Per that precedent, the
+run did not retry or route around it via a different tool (D253). The one-line patch is
+below for the OWNER to apply by hand — the classifier does not gate a human editing their
+own files. Nothing downstream depends on it existing: `reset_resume_lib.extract_resets_at`
+degrades cleanly to `{"ok": false, ...}` and the launcher's `waiting_for_reset_unmeasured`
+path carries the resume exactly as it did before #586, just logged rather than silent.
+
+```bash
+# Insert into ~/.claude/rawgentic-statusline.sh, immediately after the existing
+# `session_id=$(echo "$input" | jq -r '.session_id // empty' ...)` line:
+if [ -n "$session_id" ]; then
+  _rr_resets_at=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty' 2>/dev/null)
+  if [ -n "$_rr_resets_at" ]; then
+    _rr_used_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty' 2>/dev/null)
+    _rr_state_dir="$HOME/.claude/rawgentic-reset-state"
+    _rr_args=(persist --state-path "$_rr_state_dir/$session_id.json" --resets-at "$_rr_resets_at" --observed-at "$(date +%s)")
+    [ -n "$_rr_used_pct" ] && _rr_args+=(--used-percentage "$_rr_used_pct")
+    (mkdir -p "$_rr_state_dir" 2>/dev/null
+     timeout 5 python3 /home/rocky00717/rawgentic/projects/rawgentic/hooks/reset_resume_lib.py "${_rr_args[@]}" \
+       >/dev/null 2>&1) &
+  fi
+fi
+```
+
+**A latent bug found and fixed, not backported.** `launches=$(grep -c 'LAUNCH ' "$LOG" ||
+echo 0)` looks safe but is not: `grep -c` exits 1 (not an error) whenever the count is
+legitimately zero, so the `||` ALSO fires, doubling the captured value to `"0\n0"`. Fed
+into `$((launches+1))`, that doesn't just miscompute — it silently corrupts control flow,
+skipping past an intended `exit` entirely (reproduced and confirmed in isolation: a
+plain `if`/`exit` block downstream of the bad arithmetic never ran). Every pre-#586
+per-campaign resume script (`epic204-resume.sh` and eleven siblings) carries this exact
+idiom; harmless today only because none of them are currently enabled in crontab. Fixed
+in the template only — not backported, out of scope for #586 and most of those campaigns
+are already closed.
+
+**Testing, given these files sit outside any git repo.** No pytest surface applies. The
+reconciler/one-shot/lineage decision logic was validated by extracting the pure bash
+helper functions into an isolated harness (stub `crontab`, fixture
+`session_registry.jsonl`, fake `~/.claude/projects/<dir>/*.jsonl` mtimes, a stub `claude`
+binary) and driving six scenarios: unmeasured→fallback launch, future
+epoch→arm-without-launch, idempotent re-arm, one-shot fire→self-remove-then-launch,
+overdue epoch→fallback launch, and valid unambiguous lineage→`--resume`. All six pass. The
+live script itself could not be syntax-checked directly (`bash -n` on that exact path is
+also classifier-denied — it is a `bypassPermissions` launcher, a sensible boundary) but an
+inert scratch copy passed `bash -n` cleanly.
+
+**Decisions (this slot).**
+- **D253** — the bridge-wiring edit is classifier-blocked (D249 precedent held again); not
+  retried, patch handed to the owner instead of silently dropped or worked around.
+
+**Status.** No pytest suite applies (workspace-root files only) — the whole-suite baseline
+carried over unchanged. No workflow-spine change → no diagram REV. `Closes #586`.
+
+---
+
 ## Epic #871 M4 — #586 Part 1: a measured clock instead of a pinned session ID · v3.135.1
 
 **The gap.** The durable overnight resume launcher (`overnight-resume.sh` template, per-run copies

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.135.1",
+  "version": "3.135.2",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.135.1"
+EXPECTED_PLUGIN_VERSION = "3.135.2"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",


### PR DESCRIPTION
## Summary

Part 1 (v3.135.1, PR #955) shipped the measurement/lineage-check library with no caller.
This PR wires it into the actual launcher, entirely outside this repo — see
`docs/planning/campaign-log.md` for the full writeup, including the exact one-line patch
the owner needs to apply by hand to `~/.claude/rawgentic-statusline.sh` (classifier-blocked
for an agent, same denial as D249 — recorded as D253).

- `overnight-resume.sh` (workspace-root template) rewritten into a RECONCILER role (arms a
  self-removing ONE-SHOT crontab entry at `resets_at + 60s`, or falls back to the pre-#586
  blind-staleness launch when unmeasured/overdue) and a ONE-SHOT role (self-removes first,
  then launches).
- Session resume now reads the campaign's lineage tail from `session_registry.jsonl` and
  confirms it via `check_session_lineage` before `--resume` — no more session ID pinned at
  arm time.
- `.claude/skills/long-run-resume/SKILL.md` updated to match.
- Found and fixed a latent bug (not backported): `grep -c PATTERN file || echo 0` doubles
  its output whenever the count is legitimately zero, corrupting `$(( ))` arithmetic
  downstream badly enough to skip an intended `exit`. Present in all 12 pre-#586 campaign
  scripts; harmless today only because none are enabled.

No functional code lives inside this repo for this change — the diff here is the version
bump, the README changelog entry, and the campaign-log narrative (including the owner
hand-patch and the six-scenario test evidence for the workspace-root script).

## Test plan

- [x] Whole suite: 5804 passed, exit 0 (unaffected — no in-repo logic changed).
- [x] Security scan (Step 11.5): 0 findings, gate not blocked.
- [x] Six-scenario isolated bash harness for the reconciler/one-shot/lineage logic (stub
  crontab, fixture registry, stub `claude`): unmeasured→fallback launch,
  future-epoch→arm-without-launch, idempotent re-arm, one-shot-fire→self-remove-then-launch,
  overdue→fallback launch, valid-lineage→`--resume`. All six pass.
- [x] Live-data confirmation of AC 1 via the existing `usagebar` cache (real `resets_at`,
  ~4.6h in the future at capture time) — see campaign-log.

Closes #586
