### PR TITLE
fix(telemetry,review): a mentioned needle no longer stamps a step; review cap 200KB→400KB

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.138.0",
+  "version": "3.138.1",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,27 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.138.1 (2026-08-07)
+- **A command that MENTIONS a step's needle no longer stamps that step, and the review
+  input cap doubles (#963 follow-up).** Measured on the #963 run: 18 of 38 recorded
+  step-transitions were stamped `Step 14 Merge` with no merge in sight, putting 2,661s —
+  **30% of that run's wall clock** — under a step it never entered. The cause was raw
+  substring matching in `hooks/step_state_post.py`: `grep -rn 'gh pr merge' skills/`
+  stamped a merge, and so did writing a brief whose heredoc quoted the broker command.
+  Every phase number in `run_records.jsonl` inherits that error, which makes the
+  telemetry unusable for the optimization work it exists to serve. New pure
+  `executable_text()` strips quoted strings and any heredoc body before matching, in both
+  `detect_signature` and the `_may_have_signature` prefilter, so a grep no longer even
+  pays for the state read. It errs toward removing text: a missed stamp leaves the prior
+  position standing, while a wrong one corrupts the record. Separately,
+  `adversarial_review_lib._MAX_BYTES_DEFAULT` goes 200 KB → 400 KB (owner decision
+  2026-08-07): 200 KB refused a routine feature diff (#963's was 256,989 bytes, ~70% of
+  it tests) and cost a full review round trip to discover, and a reviewer who cannot see
+  the tests cannot judge coverage. The oversize REFUSAL is untouched (#834) — input is
+  never truncated-and-continued. Tests added in `test_step_state_hook.py`
+  (`TestSignaturesIgnoreQuotedAndHeredocText`) and `test_adversarial_review_config.py`
+  (`TestReviewInputCap`). No workflow-spine change → no diagram REV. Suite 6192→6210.
+
 ### v3.138.0 (2026-08-06)
 - **Supervised-merge broker — the #947 authority core gets its live caller, with decision
   telemetry (#963, epic #871).** New `launcher_lib.py broker-merge` runs a campaign-scoped

--- a/hooks/adversarial_review_lib.py
+++ b/hooks/adversarial_review_lib.py
@@ -37,7 +37,14 @@ from typing import Final
 # Env-frozen constants (clamped, loaded once at import — mirrors plan_lib.py)
 # ============================================================================
 
-_MAX_BYTES_DEFAULT = 200_000
+# 400_000 since 2026-08-07 (owner decision, #963 follow-up). At 200_000 a routine
+# rawgentic feature diff was refused — #963's own was 256,989 bytes, roughly 70% of it
+# tests — and the caller only learned that by spending a whole review round trip. A
+# reviewer who cannot see the tests cannot judge coverage, so the cap moved rather than
+# the diff shrinking. The REFUSAL is untouched (#834): oversize input is never
+# truncated-and-continued, because a silently shortened diff yields a review that looks
+# complete and is not.
+_MAX_BYTES_DEFAULT = 400_000
 _MAX_BYTES_MIN, _MAX_BYTES_MAX = 1_000, 5_000_000
 # 600s (not 300s): the review now pins high reasoning effort (below), which runs
 # ~1.4x slower than the medium default a fresh ~/.codex/config.toml would use.

--- a/hooks/step_state_post.py
+++ b/hooks/step_state_post.py
@@ -232,6 +232,31 @@ def _step_num(step) -> "float | None":
     return float(m.group(1)) if m else None
 
 
+#: Quoted runs, single or double. Non-greedy so adjacent quoted spans stay separate.
+_QUOTED_RE = re.compile(r"'[^']*'|\"[^\"]*\"")
+
+
+def executable_text(command: str) -> str:
+    """`command` with quoted strings and any heredoc body removed. PURE.
+
+    A command that MENTIONS a needle is not a command that RUNS it, and matching raw
+    text could not tell the difference: measured on the #963 run, `grep -rn 'gh pr
+    merge' skills/` and a brief whose heredoc quoted the broker command each stamped a
+    merge, putting 30% of that run's wall clock under a step it never entered.
+
+    Quotes are stripped first so a quoted heredoc tag (`<< 'EOF'`) still reads as an
+    opener, then everything from the opener onward goes — a heredoc body is data being
+    written, never a command being run. Both directions err toward removing text: a
+    missed stamp leaves the previous position standing, while a wrong one corrupts the
+    record that phase telemetry is derived from.
+    """
+    if not isinstance(command, str):
+        return ""
+    text = _QUOTED_RE.sub(" ", command)
+    cut = text.find("<<")
+    return text if cut == -1 else text[:cut]
+
+
 def detect_signature(command: str, workflow, current_step=None) -> "tuple[str, str] | None":
     """Match a per-step command AGAINST THE WORKFLOW'S OWN table; None when the
     workflow is unknown or carries no table (marker-only workflows). entry_only
@@ -239,8 +264,9 @@ def detect_signature(command: str, workflow, current_step=None) -> "tuple[str, s
     the row's target — no recorded position, no entry stamp (conservative)."""
     if not isinstance(command, str) or not isinstance(workflow, str):
         return None
+    text = executable_text(command)
     for needle, hit, entry_only in _SIGNATURES.get(workflow, ()):
-        if needle not in command:
+        if needle not in text:
             continue
         if entry_only:
             cur, target = _step_num(current_step), _step_num(hit[0])
@@ -259,7 +285,10 @@ def _may_have_signature(command) -> bool:
     only knowable after the state read, which this gate avoids on misses)."""
     if not isinstance(command, str):
         return False
-    return any(needle in command
+    # The SAME stripped text `detect_signature` will match against: a prefilter that
+    # passed a grep would pay for the state read this gate exists to avoid.
+    text = executable_text(command)
+    return any(needle in text
                for table in _SIGNATURES.values() for needle, _, _ in table)
 
 

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.138.0",
+  "version": "3.138.1",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_config.py
+++ b/tests/hooks/test_adversarial_review_config.py
@@ -219,3 +219,29 @@ def test_effort_unknown_falls_back_with_warning(monkeypatch, capsys):
 def test_effort_empty_returns_default(monkeypatch):
     monkeypatch.setenv("RAWGENTIC_ADV_REVIEW_EFFORT", "   ")
     assert arl._coerce_effort_env("RAWGENTIC_ADV_REVIEW_EFFORT", "high") == "high"
+
+
+class TestReviewInputCap:
+    """The byte ceiling on one review's input (#963 follow-up, owner decision
+    2026-08-07).
+
+    200 KB refused a routine rawgentic feature diff: #963's was 256,989 bytes, about
+    70% of it tests, and the refusal cost a whole review round trip before anyone
+    learned the size. A reviewer who cannot see the tests cannot judge coverage, so the
+    fix is a bigger cap rather than a diff that excludes them.
+
+    The REFUSAL is deliberately untouched (#834): oversize input is never truncated and
+    continued, because a silently shortened diff yields a review that looks complete
+    and is not.
+    """
+
+    def test_the_default_cap_is_400kb(self):
+        assert arl._MAX_BYTES_DEFAULT == 400_000
+
+    def test_the_effective_cap_stays_inside_its_clamp(self):
+        assert arl._MAX_BYTES_MIN <= arl.MAX_BYTES <= arl._MAX_BYTES_MAX
+
+    def test_the_knob_and_its_clamp_are_unchanged(self):
+        """The default moved. The env override and its bounds did not."""
+        assert arl._MAX_BYTES_MIN == 1_000
+        assert arl._MAX_BYTES_MAX == 5_000_000

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.138.0"
+EXPECTED_PLUGIN_VERSION = "3.138.1"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_step_state_hook.py
+++ b/tests/hooks/test_step_state_hook.py
@@ -475,3 +475,59 @@ class TestBrokerMergeSignature:
         the prefilter would mean the hook never even reads state."""
         assert ssp._may_have_signature(
             "python3 hooks/launcher_lib.py broker-merge --pr 970") is True
+
+
+class TestSignaturesIgnoreQuotedAndHeredocText:
+    """A command that MENTIONS a needle is not a command that RUNS it (#963 follow-up).
+
+    Measured on the #963 run: 18 of 38 recorded step-transitions were stamped
+    "Step 14 Merge", accounting for 2,661s — 30% of the run's wall clock — with no
+    merge anywhere near them. `grep -rn 'gh pr merge' skills/` stamped a merge. So did
+    writing a brief whose heredoc body quoted the broker command. Every phase-timing
+    number in run_records.jsonl inherits that error, which makes the telemetry unusable
+    for exactly the optimization work it exists to serve.
+
+    A missed stamp leaves the prior position standing; a WRONG stamp corrupts the
+    record. So the stripper errs toward removing text, never toward matching more.
+    """
+
+    def test_a_grep_for_a_needle_is_not_that_command(self):
+        for cmd in ("grep -rn 'gh pr merge' skills/",
+                    'grep -rn "gh pr create" docs/',
+                    "rg \"security_scan.py scan\" hooks/"):
+            assert ssp.detect_signature(cmd, "wf2") is None, cmd
+
+    def test_a_heredoc_body_quoting_a_command_is_not_that_command(self):
+        cmd = ("cat > brief.md << 'EOF'\n"
+               "Run: python3 hooks/launcher_lib.py broker-merge --pr 973\n"
+               "EOF")
+        assert ssp.detect_signature(cmd, "wf2") is None
+
+    def test_a_python_c_string_mentioning_a_needle_does_not_stamp(self):
+        assert ssp.detect_signature(
+            'python3 -c "print(\'gh pr merge\')"', "wf2") is None
+
+    def test_real_invocations_still_stamp(self):
+        assert ssp.detect_signature("gh pr merge 973 --repo o/r --squash",
+                                    "wf2") == ("14", "Merge")
+        assert ssp.detect_signature("cd /repo && gh pr merge 973 --squash",
+                                    "wf2") == ("14", "Merge")
+        assert ssp.detect_signature(
+            "python3 hooks/launcher_lib.py broker-merge --pr 973 --issue 963",
+            "wf2") == ("14", "Merge")
+        assert ssp.detect_signature("gh pr create --fill", "wf2") == ("12", "Create PR")
+        assert ssp.detect_signature(
+            "python3 hooks/security_scan.py scan --base origin/main",
+            "wf2") == ("11.5", "Security Scan")
+
+    def test_a_commit_whose_message_mentions_a_needle_is_still_a_commit(self):
+        """The row ordering already handled this; now it holds because the message
+        text is gone before matching, not because `git commit ` happens to sort first."""
+        cmd = 'git commit -m "feat(driver): broker-merge and gh pr create (#963)"'
+        assert ssp.detect_signature(cmd, "wf2", current_step="7") == ("8", "Implementation")
+
+    def test_the_prefilter_agrees_with_the_matcher(self):
+        """A prefilter that passes text the matcher then rejects still pays for a
+        state read on every grep — the cost the prefilter exists to avoid."""
+        assert ssp._may_have_signature("grep -rn 'gh pr merge' skills/") is False
+        assert ssp._may_have_signature("gh pr merge 973 --squash") is True


### PR DESCRIPTION
Two fixes the #963 efficiency review surfaced.

## 1. The step labelling was corrupting its own telemetry

Measured on the #963 run: **18 of 38** recorded step-transitions were stamped `Step 14 Merge` with no merge anywhere near them. That is **2,661 seconds — 30% of the run's wall clock** — filed under a step it never entered.

The cause was raw substring matching in `hooks/step_state_post.py`. Verified live:

| Command | Was stamped |
|---|---|
| `grep -rn 'gh pr merge' skills/` | Step 14 |
| a heredoc body quoting `broker-merge --pr 973` | Step 14 |
| `python3 -c "print('gh pr merge')"` | Step 14 |

Every phase number in `docs/measurements/run_records.jsonl` inherits this, which makes the telemetry unusable for the phase-timing optimization it exists to serve — including for runs already analyzed.

New pure `executable_text()` strips quoted strings and any heredoc body before matching. Quotes are stripped first, so a quoted heredoc tag (`<< 'EOF'`) still reads as an opener. It is applied in **both** `detect_signature` and the `_may_have_signature` prefilter, so a grep no longer pays for the state read that gate exists to avoid.

It errs toward removing text on purpose: a missed stamp leaves the prior position standing, while a wrong stamp corrupts the record.

Real invocations still stamp — `gh pr merge …`, `cd x && gh pr merge …`, `launcher_lib.py broker-merge …`, `gh pr create`, `security_scan.py scan`. A commit whose message mentions another needle is still classified as a commit, now because the message text is gone before matching rather than because `git commit ` happens to sort first.

## 2. Review input cap 200 KB → 400 KB

Owner decision 2026-08-07. At 200 KB a routine rawgentic feature diff was refused: #963's own was 256,989 bytes, roughly 70% of it tests, and the caller only learned that by spending a full review round trip. A reviewer who cannot see the tests cannot judge coverage, so the cap moved rather than the diff shrinking.

The oversize **refusal** is deliberately untouched (#834) — input is never truncated-and-continued, because a silently shortened diff yields a review that looks complete and is not. The env override `RAWGENTIC_ADV_REVIEW_MAX_BYTES` and its 1 KB–5 MB clamp are unchanged.

## Gates

- Tests 6192 → 6210, exit 0.
- Lint 10.00/10.
- Security scan PASS, one visible skip (`iac`, not applicable).
- No workflow-spine change → no diagram REV.

## Note on already-collected telemetry

This fixes collection going forward. It does **not** repair the 227 existing records. Phase numbers in runs before this should be treated as suspect, not as a baseline.