### PR TITLE
feat(supervision,security): PreToolUse hard enforcement — block a raw gh pr merge while a campaign is active (#976)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.138.1",
+  "version": "3.139.0",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -773,8 +773,11 @@ For major changes, please open an issue first to discuss the approach.
   stops an accidental raw merge, not a deliberate bypass — `PreToolUse` fires per tool
   call, not per OS process, which is also exactly why the broker's own internal merge
   passes untouched with no spoofable signal. `docs/supervision.md` replaces its "still
-  deliberately out of scope" paragraph. No workflow-spine change → no diagram REV.
-  Suite 6210→6274.
+  deliberately out of scope" paragraph. Two cross-model review rounds (`gpt-5.6-sol`)
+  contributed 12 fixes, including three the guard's own first draft got wrong: quoted
+  argument values were being destroyed before parsing, only the first merge in a Bash call
+  was checked, and a wrongly-typed `pr` field read as active-but-unmatchable. No
+  workflow-spine change → no diagram REV. Suite 6210→6317.
 
 ### v3.138.1 (2026-08-07)
 - **A command that MENTIONS a step's needle no longer stamps that step, and the review

--- a/README.md
+++ b/README.md
@@ -749,6 +749,33 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.139.0 (2026-08-07)
+- **A raw `gh pr merge` is now BLOCKED while the target PR belongs to an active campaign,
+  and the broker it routes to actually works again (#976).** #963 shipped the supervised
+  merge broker, but what routed a campaign merge into it was prose pinned by guard tests,
+  so a prose-violating session still reached the raw command and skipped authority
+  evaluation, target binding, the execute-once claim and the decision telemetry in one
+  step. New `PreToolUse` hook on the `Bash` matcher —
+  `hooks/campaign-merge-guard.py` plus the pure `hooks/campaign_merge_guard_lib.py` —
+  reads durable state under `claude_docs/.driver-state/`, binds on `{repo, pr}`, and
+  refuses with a message naming the campaign, the issue, the PR and the exact
+  `broker-merge` command. **Its fail mode is split at the classification boundary
+  (D186):** fail-OPEN with a stderr diagnostic before a command is classified, because
+  this hook runs on every Bash call and a blanket fail-closed bug would deny `ls`
+  everywhere; fail-CLOSED once the command IS a raw `gh pr merge`, where the whole blast
+  radius is that one command. A missing state directory is absence, not failure, so every
+  project that never ran a campaign is untouched. **Scope was widened by one fix (D185,
+  owner decision):** `broker_campaign_names_issue` read `state["children"][].issue`, a
+  shape `driver_lib` never writes — real state is `issues[].number` — so target binding
+  refused EVERY real campaign with rc 12, invisible because the test fixture invented the
+  same wrong shape. Switching that fixture to the real shape turned 16 green broker tests
+  red, which is the measurement. **Stated plainly, and not overclaimed (D187):** the guard
+  stops an accidental raw merge, not a deliberate bypass — `PreToolUse` fires per tool
+  call, not per OS process, which is also exactly why the broker's own internal merge
+  passes untouched with no spoofable signal. `docs/supervision.md` replaces its "still
+  deliberately out of scope" paragraph. No workflow-spine change → no diagram REV.
+  Suite 6210→6274.
+
 ### v3.138.1 (2026-08-07)
 - **A command that MENTIONS a step's needle no longer stamps that step, and the review
   input cap doubles (#963 follow-up).** Measured on the #963 run: 18 of 38 recorded

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -203,8 +203,44 @@ executor (D174) and that #871 could not answer for its own core.
 marker. Run `python3 hooks/supervision_admin.py bootstrap-marker --workspace <root>` once
 after upgrading; `broker-merge` and every `declare`/`mark_attended` also self-heal it.
 
-Still deliberately out of scope: executable PreToolUse enforcement that BLOCKS a raw
-`gh pr merge` during an active campaign. What routes campaign merges into the broker is
-prose pinned by guard tests — the same enforcement layer every gate in this plugin uses —
-so a prose-violating session can still reach the raw command. That hardening is the named
-follow-up.
+## The merge guard (#976)
+
+`hooks/campaign-merge-guard.py` is the executable half of the sentence above. It is a
+`PreToolUse` hook on the `Bash` matcher: when a command is a raw `gh pr merge` whose PR is
+a child of an **active** campaign, the hook refuses it and names the `broker-merge` command
+to run instead. Before #976, what routed a campaign merge into the broker was prose pinned
+by guard tests, so a prose-violating session reached the raw command and skipped authority
+evaluation, target binding, the execute-once claim and the decision telemetry in one step.
+
+**"Active" is read from durable state, never session context.** A campaign file under
+`claude_docs/.driver-state/` is active when at least one entry in its top-level `issues[]`
+has a status outside `{merged, deferred, abandoned}`. Binding is on `{repo, pr}`: an
+explicit `--repo` that is not this project's own repo is allowed through, because PR
+numbers are repository-scoped.
+
+**The fail mode is split at the classification boundary**, and the split is the whole
+design (decision D186):
+
+| Path | Mode | Why |
+|---|---|---|
+| stdin unparseable, no command field, startup exception | **ALLOW**, with a stderr diagnostic | this hook runs on every Bash call; a bug here would otherwise deny `ls` and `pytest` in every project |
+| no `.rawgentic.json` above cwd, or no `.driver-state/` | **ALLOW** | absence, not failure — the same rule this document states for supervision state, that `ENOENT` under a valid root is the only file failure treated as absence |
+| classified as a raw `gh pr merge`, but campaign state is corrupt, oversized or unreadable | **DENY** | the blast radius is exactly one refused raw command, and `broker-merge` is not a `gh pr merge` command line, so the sanctioned path stays open |
+
+The two existing `PreToolUse` siblings are deliberately opposite — `wal-guard` fails closed
+(`wal-guard:14-17`), `security-guard.py` fails open (`security-guard.py:6`). This hook is
+both, because the two are right about different paths.
+
+**What it does not do, stated plainly (decision D187).** It stops an *accidental* raw
+merge — a session that drifted from the prose. It does **not** stop a deliberate bypass:
+`PreToolUse` fires per Claude Code tool call, not per OS process, so
+`python3 -c "subprocess.run(['gh','pr','merge',…])"` is invisible to it. That same property
+is what makes the broker's own internal merge pass untouched with no spoofable signal —
+the distinction is a process boundary, not a token nobody may forge. Closing the deliberate
+bypass would need the merge credential to live somewhere a session cannot reach, or
+GitHub-side merge-queue permissions; both are larger changes than this guard, and neither
+is shipped. The threat model here is caller confusion and prose drift, which is the same
+one the broker states for its own target binding (`launcher_lib.py:5300-5303`).
+
+The guard-tested prose in WF2 Step 14 and the epic-run boundary stays exactly as it was:
+the hook hardens that route, it does not replace it.

--- a/hooks/campaign-merge-guard.py
+++ b/hooks/campaign-merge-guard.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Campaign Merge Guard -- PreToolUse hook that routes campaign merges to the broker.
+
+Hook: PreToolUse (matcher: Bash)
+Protocol: JSON stdout with permissionDecision: deny
+Policy: SPLIT at the classification boundary (#976 AC3, decision D186)
+  - before a command is classified  -> fail-OPEN, with a stderr diagnostic
+  - after it is a raw `gh pr merge`  -> fail-CLOSED
+
+Why split, when `wal-guard` fails closed and `security-guard.py` fails open: both are
+right, about different paths. This hook runs on EVERY Bash call, so a blanket fail-closed
+bug would deny `ls` and `pytest` in every project on the host. But once a command IS a raw
+`gh pr merge`, the blast radius of refusing it is exactly that one command -- and the
+sanctioned path, `broker-merge`, is not a `gh pr merge` command line, so it stays open.
+
+What this guard is NOT (D187): unbypassable. PreToolUse fires per Claude Code tool call,
+not per OS process, so an indirect spawn is invisible to it. It stops the accidental raw
+merge, not the deliberate one.
+
+See docs/supervision.md and claude_docs/976-design.md.
+"""
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import campaign_merge_guard_lib as guard  # noqa: E402
+
+
+def _diagnostic(message):
+    """The fail-open path must be visible (review finding F4) -- but never blocking.
+
+    stderr, not stdout: stdout is the permission-decision channel, and anything
+    non-JSON there would corrupt the protocol.
+    """
+    try:
+        print("campaign-merge-guard: allowing (%s)" % message, file=sys.stderr)
+    except (OSError, ValueError):
+        pass
+
+
+def _deny(reason):
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }}))
+    sys.exit(0)
+
+
+def main():
+    deadline = time.monotonic() + guard.INTERNAL_DEADLINE_S
+
+    # ---- before classification: every failure ALLOWS, and says why ----------
+    try:
+        input_data = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, IOError, ValueError):
+        _diagnostic("stdin was not valid JSON")
+        sys.exit(0)
+    if not isinstance(input_data, dict):
+        _diagnostic("stdin JSON was not an object")
+        sys.exit(0)
+
+    tool_input = input_data.get("tool_input")
+    command = tool_input.get("command") if isinstance(tool_input, dict) else None
+    if not command:
+        sys.exit(0)                      # the overwhelmingly common case: not our business
+
+    target = guard.parse_merge_command(command)
+    if target is None:
+        sys.exit(0)                      # the hot path -- not a raw gh pr merge
+
+    # ---- classified as a raw `gh pr merge`: from here, failures REFUSE ------
+    cwd = input_data.get("cwd") or os.getcwd()
+    project_root = guard.find_project_root(cwd)
+    if project_root is None:
+        # No .rawgentic.json above cwd => no campaign can exist. Absence, not failure.
+        sys.exit(0)
+
+    active, unevaluable = guard.read_campaigns(project_root, deadline=deadline)
+    if time.monotonic() > deadline and not unevaluable:
+        unevaluable = ["<internal deadline reached before the state was read>"]
+
+    decision = guard.decide(target, active, unevaluable,
+                            guard.configured_repo(project_root))
+    if decision["action"] == "deny":
+        _deny(guard.format_deny(decision))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:  # pylint: disable=broad-except
+        # Pre-classification fail-open, as a backstop. A crash here must never wedge every
+        # Bash call in every session -- but it is no longer silent.
+        _diagnostic("unexpected error: %r" % (exc,))
+        sys.exit(0)

--- a/hooks/campaign-merge-guard.py
+++ b/hooks/campaign-merge-guard.py
@@ -13,6 +13,10 @@ bug would deny `ls` and `pytest` in every project on the host. But once a comman
 `gh pr merge`, the blast radius of refusing it is exactly that one command -- and the
 sanctioned path, `broker-merge`, is not a `gh pr merge` command line, so it stays open.
 
+The boundary is tracked in `_CLASSIFIED`, not merely documented: the outer handler reads
+it, so an unexpected exception AFTER classification denies rather than silently allowing
+the very command this hook exists to stop (Step 8a finding F2).
+
 What this guard is NOT (D187): unbypassable. PreToolUse fires per Claude Code tool call,
 not per OS process, so an indirect spawn is invisible to it. It stops the accidental raw
 merge, not the deliberate one.
@@ -30,9 +34,13 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 import campaign_merge_guard_lib as guard  # noqa: E402
 
+#: Flipped the instant the command is known to be a raw `gh pr merge`. Everything after
+#: that point fails CLOSED, including an unexpected crash.
+_CLASSIFIED = False
+
 
 def _diagnostic(message):
-    """The fail-open path must be visible (review finding F4) -- but never blocking.
+    """The fail-open path must be visible (Step 4 finding F4) -- but never blocking.
 
     stderr, not stdout: stdout is the permission-decision channel, and anything
     non-JSON there would corrupt the protocol.
@@ -53,6 +61,7 @@ def _deny(reason):
 
 
 def main():
+    global _CLASSIFIED  # pylint: disable=global-statement
     deadline = time.monotonic() + guard.INTERNAL_DEADLINE_S
 
     # ---- before classification: every failure ALLOWS, and says why ----------
@@ -68,18 +77,27 @@ def main():
     tool_input = input_data.get("tool_input")
     command = tool_input.get("command") if isinstance(tool_input, dict) else None
     if not command:
-        sys.exit(0)                      # the overwhelmingly common case: not our business
+        _diagnostic("tool_input.command was missing or empty")
+        sys.exit(0)
 
     target = guard.parse_merge_command(command)
     if target is None:
         sys.exit(0)                      # the hot path -- not a raw gh pr merge
 
     # ---- classified as a raw `gh pr merge`: from here, failures REFUSE ------
-    cwd = input_data.get("cwd") or os.getcwd()
-    project_root = guard.find_project_root(cwd)
+    _CLASSIFIED = True
+
+    hook_cwd = input_data.get("cwd") or os.getcwd()
+    # Where the merge segment would ACTUALLY run: `cd /elsewhere && gh pr merge 887`
+    # executes in /elsewhere, so resolving state from the hook's cwd read the wrong
+    # project (Step 8a finding F3).
+    project_root = guard.find_project_root(guard.effective_cwd(target, hook_cwd))
     if project_root is None:
-        # No .rawgentic.json above cwd => no campaign can exist. Absence, not failure.
-        sys.exit(0)
+        # No .rawgentic.json above the effective directory => no campaign can exist.
+        # Absence, not failure -- but an unresolvable `cd` is failure, and `decide`
+        # refuses on it.
+        if not target.get("cd_unresolvable"):
+            sys.exit(0)
 
     active, unevaluable = guard.read_campaigns(project_root, deadline=deadline)
     if time.monotonic() > deadline and not unevaluable:
@@ -88,7 +106,7 @@ def main():
     decision = guard.decide(target, active, unevaluable,
                             guard.configured_repo(project_root))
     if decision["action"] == "deny":
-        _deny(guard.format_deny(decision))
+        _deny(guard.format_deny(decision, project_root))
     sys.exit(0)
 
 
@@ -98,7 +116,19 @@ if __name__ == "__main__":
     except SystemExit:
         raise
     except Exception as exc:  # pylint: disable=broad-except
-        # Pre-classification fail-open, as a backstop. A crash here must never wedge every
-        # Bash call in every session -- but it is no longer silent.
+        if _CLASSIFIED:
+            # Post-classification: refuse. Allowing here would silently wave through the
+            # exact command this hook exists to stop.
+            _deny(
+                "BLOCKED: this command is a raw `gh pr merge`, and the campaign merge "
+                "guard hit an unexpected error before it could decide whether the "
+                "target belongs to an active campaign.\n\n"
+                "  Error: %r\n\n"
+                "This guard fails closed once a command is identified as a raw merge. "
+                "Merge through the supervised broker instead:\n\n"
+                "  python3 hooks/launcher_lib.py broker-merge --pr <pr> --issue <issue> "
+                "\\\n    --campaign <campaign> --project-root <project root>\n" % (exc,))
+        # Pre-classification fail-open. A crash here must never wedge every Bash call in
+        # every session -- but it is no longer silent.
         _diagnostic("unexpected error: %r" % (exc,))
         sys.exit(0)

--- a/hooks/campaign_merge_guard_lib.py
+++ b/hooks/campaign_merge_guard_lib.py
@@ -19,6 +19,7 @@ constraint `supervision_lib.py` documents for the same reason).
 import json
 import os
 import re
+import shlex
 import time
 
 #: Mirrored from `driver_lib._DISPOSED_STATUSES`. Copied rather than imported because
@@ -41,23 +42,18 @@ DRIVER_STATE_RELPATH = os.path.join("claude_docs", ".driver-state")
 #: nothing else. `gh`, then `pr`, then `merge`, as whole words in order.
 _PREFILTER_RE = re.compile(r"\bgh\b[^\n;|&]*?\bpr\b[^\n;|&]*?\bmerge\b")
 
-#: The classifier, applied to QUOTE-STRIPPED text (see `parse_merge_command`). `gh pr
-#: merge` as three consecutive tokens in COMMAND POSITION: the start of a segment,
-#: allowing leading whitespace and `VAR=value` prefixes.
+#: Shell operators that end a command segment. `shlex(punctuation_chars=True)` emits `&&`
+#: and `||` as single tokens, and a separator inside a quoted string never becomes one —
+#: which is why classification is done over TOKENS rather than raw text (Step 8a F6).
 #:
 #: Deliberately NOT matched: `sh -c "gh pr merge …"` and other wrappers. That is the right
 #: trade for this guard's threat model (D187): a false positive blocks unrelated work in
 #: every project on the host, while a false negative only misses a form nobody reaches by
 #: accident — and the guard never claimed to stop a deliberate bypass.
-_MERGE_RE = re.compile(
-    r"^\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*gh\s+pr\s+merge\b")
+_OPERATORS = frozenset({";", "&&", "||", "|", "&", "\n"})
 
-#: Segment separators. Splitting quote-stripped text means a `;` inside a quoted string
-#: can no longer masquerade as one (Step 8a finding F6).
-_SEGMENT_RE = re.compile(r"(?:\|\||&&|[;|&\n])")
-
-#: `cd <literal>` as a whole segment.
-_CD_RE = re.compile(r"^\s*cd\s+(\S+)\s*$")
+#: `VAR=value` prefixes, which sit before the command word.
+_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 #: Shell text this module refuses to reason about inside a `cd` target.
 _UNSAFE_CHARS = ("$", "`", "*", "?", "~")
@@ -72,23 +68,77 @@ _VALUE_FLAGS = frozenset({
 _REPO_FLAGS = frozenset({"--repo", "-R"})
 
 
-def _executable_text(command):
-    """`command` with quoted strings and heredoc bodies removed.
+def _strip_heredocs(command):
+    """Everything from the first `<<` onward, removed.
 
-    Delegates to `step_state_post.executable_text` — the repo already owns this exact
-    problem ("a command that MENTIONS a needle is not a command that RUNS it", v3.138.1),
-    so this reuses it rather than growing a second copy. On import failure the raw text is
-    returned: this runs before classification, where the policy is fail-open.
+    A heredoc body is data being written, never a command being run — the reasoning
+    `step_state_post.executable_text` already states for this repo. Cutting can only
+    REMOVE text, so it can never manufacture a false denial.
     """
+    cut = command.find("<<")
+    return command if cut == -1 else command[:cut]
+
+
+def _lex(command):
+    """Shell tokens with operators kept, or ``None`` when the text will not lex.
+
+    `shlex` rather than a regex over raw text (Step 11 findings F1 and F6): it keeps a
+    quoted ARGUMENT VALUE intact — `--repo "3D-Stories/rawgentic"` stays one token — while
+    a quoted MENTION collapses into a single token, so `echo 'gh pr merge 887'` can never
+    look like three command tokens. An earlier version stripped quotes wholesale, which
+    turned `--repo "o/r" --squash` into `--repo --squash` and read `--squash` as the
+    repository, allowing the merge it was meant to block.
+    """
+    lexer = shlex.shlex(_strip_heredocs(command), posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
     try:
-        import step_state_post  # pylint: disable=import-outside-toplevel
-        return step_state_post.executable_text(command)
-    except Exception:  # pylint: disable=broad-except
-        return command
+        return list(lexer)
+    except ValueError:
+        return None
 
 
-def _tokenize(segment):
-    return [t for t in segment.split() if t]
+def _segments(tokens):
+    """Split a token list on shell operators."""
+    out, current = [], []
+    for token in tokens:
+        if token in _OPERATORS:
+            out.append(current)
+            current = []
+        else:
+            current.append(token)
+    out.append(current)
+    return out
+
+
+def _parse_merge_args(args):
+    """The `gh pr merge` argument grammar → ``{"pr": int|None, "repo": str|None}``."""
+    pr, repo, index = None, None, 0
+    while index < len(args):
+        token = args[index]
+        if token.startswith("-") and token != "-":
+            name, sep, inline = token.partition("=")
+            if sep:
+                if name in _REPO_FLAGS:
+                    repo = inline
+                index += 1
+                continue
+            if name in _VALUE_FLAGS:
+                value = args[index + 1] if index + 1 < len(args) else None
+                # A value-taking flag whose value is missing or is itself a flag has no
+                # usable value; never adopt the next flag as one (Step 11 finding F1).
+                if value is not None and not value.startswith("-"):
+                    if name in _REPO_FLAGS:
+                        repo = value
+                    index += 2
+                    continue
+                index += 1
+                continue
+            index += 1
+            continue
+        if pr is None and token.isdigit():
+            pr = int(token)
+        index += 1
+    return {"pr": pr, "repo": repo}
 
 
 def parse_merge_command(command):
@@ -97,68 +147,53 @@ def parse_merge_command(command):
     ``None`` means "not a raw `gh pr merge`" and is the answer for essentially every
     command. Otherwise::
 
-        {"pr": int|None, "repo": str|None, "cd": str|None, "cd_unresolvable": bool}
+        {"pr": int|None, "repo": str|None,        # the FIRST target, for convenience
+         "targets": [{"pr": …, "repo": …}, …],    # EVERY target, in execution order
+         "cd": str|None, "cd_unresolvable": bool, "unlexable": bool}
 
-    ``pr is None`` means the invocation IS a raw merge but its target could not be read —
-    `gh pr merge` with no number merges the current branch's PR, which this hook cannot
-    resolve, so the caller must treat it as an unknown target rather than as "no PR".
+    Every merge target is returned, not just the first (Step 11 finding F2): one Bash call
+    may carry several, and `gh pr merge 999; gh pr merge 887` must not be waved through on
+    the strength of its harmless first half.
+
+    ``pr is None`` on a target means the invocation IS a raw merge but its target could not
+    be read — `gh pr merge` with no number merges the current branch's PR, which this hook
+    cannot resolve, so the caller treats it as an unknown target rather than as "no PR".
     """
     if not isinstance(command, str) or not command:
         return None
     if not _PREFILTER_RE.search(command):
         return None
 
-    text = _executable_text(command)
-    segments = _SEGMENT_RE.split(text)
+    tokens = _lex(command)
+    if tokens is None:
+        # It looks like a merge and will not lex. Refusing to guess is the point.
+        return {"pr": None, "repo": None, "targets": [{"pr": None, "repo": None}],
+                "cd": None, "cd_unresolvable": False, "unlexable": True}
 
-    cd_target, cd_unresolvable = None, False
-    merge_tokens = None
-    for segment in segments:
-        cd_match = _CD_RE.match(segment)
-        if cd_match:
-            candidate = cd_match.group(1)
+    cd_target, cd_unresolvable, targets = None, False, []
+    for segment in _segments(tokens):
+        # Drop `VAR=value` prefixes, which precede the command word.
+        index = 0
+        while index < len(segment) and _ASSIGNMENT_RE.match(segment[index]):
+            index += 1
+        words = segment[index:]
+        if not words:
+            continue
+        if words[0] == "cd" and len(words) >= 2:
+            candidate = words[1]
             if any(ch in candidate for ch in _UNSAFE_CHARS):
                 cd_unresolvable = True
             else:
-                cd_target = candidate.strip("\"'")
+                cd_target = candidate
             continue
-        if _MERGE_RE.match(segment):
-            merge_tokens = _tokenize(segment)
-            break
+        if words[:3] == ["gh", "pr", "merge"]:
+            targets.append(_parse_merge_args(words[3:]))
 
-    if merge_tokens is None:
+    if not targets:
         return None
-
-    # Drop everything up to and including the `merge` verb, plus any VAR=value prefixes.
-    try:
-        start = merge_tokens.index("merge") + 1
-    except ValueError:
-        start = len(merge_tokens)
-    args = merge_tokens[start:]
-
-    pr, repo, index = None, None, 0
-    while index < len(args):
-        token = args[index]
-        if token.startswith("-"):
-            name, _, inline = token.partition("=")
-            if inline:
-                if name in _REPO_FLAGS:
-                    repo = inline
-                index += 1
-                continue
-            if name in _VALUE_FLAGS:
-                if name in _REPO_FLAGS and index + 1 < len(args):
-                    repo = args[index + 1]
-                index += 2
-                continue
-            index += 1
-            continue
-        if pr is None and token.isdigit():
-            pr = int(token)
-        index += 1
-
-    return {"pr": pr, "repo": repo, "cd": cd_target,
-            "cd_unresolvable": cd_unresolvable}
+    first = targets[0]
+    return {"pr": first["pr"], "repo": first["repo"], "targets": targets,
+            "cd": cd_target, "cd_unresolvable": cd_unresolvable, "unlexable": False}
 
 
 def find_project_root(start_path):
@@ -218,15 +253,39 @@ def configured_repo(project_root):
         return None
 
 
+def valid_issue_entry(entry):
+    """Does this queue entry carry the fields the decision actually compares?
+
+    Step 11 finding F3: checking only `isinstance(entry, dict)` accepted
+    ``{"pr": "887"}`` as an ACTIVE child, and `_match_pr` then compared that string to the
+    integer 887, found nothing, and allowed the raw merge — a corrupt file producing the
+    exact outcome the fail-closed rule exists to prevent. `bool` is excluded from the
+    integer checks because `True == 1` in Python.
+    """
+    if not isinstance(entry, dict):
+        return False
+    number = entry.get("number")
+    if not isinstance(number, int) or isinstance(number, bool):
+        return False
+    status = entry.get("status")
+    if not isinstance(status, str) or not status:
+        return False
+    pr = entry.get("pr")
+    if pr is not None and (not isinstance(pr, int) or isinstance(pr, bool)):
+        return False
+    return True
+
+
 def campaign_activity(state):
     """``"active"`` | ``"settled"`` | ``"invalid"``.
 
     Three-valued deliberately (Step 8a finding F4). A syntactically valid JSON object whose
-    `issues` field is missing or is not a list is **invalid**, not settled: reading it as
-    "no active children" let a corrupt campaign file allow a raw merge, which is the exact
-    opposite of the fail-closed rule for state that cannot be evaluated. Every real
-    campaign file carries an `issues` list (verified across all five in
-    claude_docs/.driver-state/), so this cannot refuse legitimate state.
+    `issues` field is missing, is not a list, or holds an entry whose compared fields are
+    the wrong type is **invalid**, not settled: reading either as "no active children" let
+    a corrupt campaign file allow a raw merge, the exact opposite of the fail-closed rule
+    for state that cannot be evaluated. Verified against all five real campaign files in
+    claude_docs/.driver-state/ — every entry passes — so this cannot refuse legitimate
+    state.
     """
     if not isinstance(state, dict):
         return "invalid"
@@ -234,8 +293,9 @@ def campaign_activity(state):
     if not isinstance(issues, list):
         return "invalid"
     for entry in issues:
-        if not isinstance(entry, dict):
+        if not valid_issue_entry(entry):
             return "invalid"
+    for entry in issues:
         if entry.get("status") not in DISPOSED_STATUSES:
             return "active"
     return "settled"
@@ -325,10 +385,13 @@ def decide(target, active, unevaluable, project_repo):
 
     # A foreign repository is not this campaign's business (Step 4 finding F3: PR numbers
     # are repository-scoped, so binding on the number alone denies unrelated work).
-    target_repo = target.get("repo")
-    if target_repo and project_repo and target_repo != project_repo:
+    subjects = [t for t in target.get("targets") or [target]
+                if not (t.get("repo") and project_repo
+                        and t.get("repo") != project_repo)]
+    if not subjects:
         return {"action": "allow",
-                "reason": "targets %s, not this project's %s" % (target_repo, project_repo)}
+                "reason": "every merge target names a repository other than %s"
+                          % project_repo}
 
     reasons = list(unevaluable)
     if target.get("cd_unresolvable"):
@@ -344,22 +407,34 @@ def decide(target, active, unevaluable, project_repo):
     if not active:
         return {"action": "allow", "reason": "no active campaign"}
 
-    pr = target.get("pr")
-    if pr is None:
+    if target.get("unlexable"):
         return {
             "action": "deny", "kind": "unknown-target",
             "campaign": active[0]["campaign"],
-            "reason": "the target PR could not be read from the command while a campaign "
-                      "is active",
+            "reason": "the command contains a `gh pr merge` but will not parse as shell, "
+                      "so its target cannot be read while a campaign is active",
         }
 
-    campaign, issue = _match_pr(active, pr)
-    if campaign is None:
-        return {"action": "allow",
-                "reason": "no active campaign names PR #%d" % pr}
-    return {"action": "deny", "kind": "campaign", "campaign": campaign,
-            "issue": issue, "pr": pr,
-            "reason": "PR #%d is a child of active campaign %s" % (pr, campaign)}
+    # EVERY target is checked, not just the first (Step 11 finding F2): one Bash call can
+    # carry several, and a harmless first merge must not clear the whole call.
+    for subject in subjects:
+        pr = subject.get("pr")
+        if pr is None:
+            return {
+                "action": "deny", "kind": "unknown-target",
+                "campaign": active[0]["campaign"],
+                "reason": "a target PR could not be read from the command while a "
+                          "campaign is active",
+            }
+        campaign, issue = _match_pr(active, pr)
+        if campaign is not None:
+            return {"action": "deny", "kind": "campaign", "campaign": campaign,
+                    "issue": issue, "pr": pr,
+                    "reason": "PR #%d is a child of active campaign %s" % (pr, campaign)}
+
+    return {"action": "allow",
+            "reason": "no active campaign names %s"
+                      % ", ".join("PR #%s" % t.get("pr") for t in subjects)}
 
 
 def _root_arg(project_root):

--- a/hooks/campaign_merge_guard_lib.py
+++ b/hooks/campaign_merge_guard_lib.py
@@ -27,7 +27,7 @@ import time
 #: is the drift guard that keeps the copy honest (repo CLAUDE.md §4 mistake 21).
 DISPOSED_STATUSES = frozenset({"merged", "deferred", "abandoned"})
 
-#: Bounded reads (review finding F5). The host's behavior when a PreToolUse hook exceeds
+#: Bounded reads (Step 4 finding F5). The host's behavior when a PreToolUse hook exceeds
 #: its registered timeout is UNPROVEN, so the design removes the dependency instead of
 #: resting on it: the work is capped so the hook always answers first.
 MAX_STATE_BYTES = 1024 * 1024
@@ -41,52 +41,124 @@ DRIVER_STATE_RELPATH = os.path.join("claude_docs", ".driver-state")
 #: nothing else. `gh`, then `pr`, then `merge`, as whole words in order.
 _PREFILTER_RE = re.compile(r"\bgh\b[^\n;|&]*?\bpr\b[^\n;|&]*?\bmerge\b")
 
-#: The classifier. `gh pr merge` as three consecutive tokens, in COMMAND POSITION: the
-#: start of the string or just after a separator (`;` `|` `&` newline, which covers `&&`
-#: and `||`), allowing leading whitespace and `VAR=value` prefixes. So
-#: `cd x && gh pr merge 887` matches, while `echo 'run gh pr merge 887 by hand'` and
-#: `grep -rn 'gh pr merge' docs/` do not — a mention is not an invocation.
+#: The classifier, applied to QUOTE-STRIPPED text (see `parse_merge_command`). `gh pr
+#: merge` as three consecutive tokens in COMMAND POSITION: the start of a segment,
+#: allowing leading whitespace and `VAR=value` prefixes.
 #:
-#: Deliberately NOT matched: `sh -c "gh pr merge …"` and other wrappers. That is the
-#: right trade for this guard's threat model (D187): a false positive blocks unrelated
-#: work in every project on the host, while a false negative only misses a form nobody
-#: reaches by accident — and the guard never claimed to stop a deliberate bypass.
+#: Deliberately NOT matched: `sh -c "gh pr merge …"` and other wrappers. That is the right
+#: trade for this guard's threat model (D187): a false positive blocks unrelated work in
+#: every project on the host, while a false negative only misses a form nobody reaches by
+#: accident — and the guard never claimed to stop a deliberate bypass.
 _MERGE_RE = re.compile(
-    r"(?:^|[;|&\n])\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*gh\s+pr\s+merge\b")
+    r"^\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*gh\s+pr\s+merge\b")
 
-_PR_RE = re.compile(r"\b(\d{1,7})\b")
-_REPO_RE = re.compile(r"--repo(?:=|\s+)([^\s;|&]+)")
+#: Segment separators. Splitting quote-stripped text means a `;` inside a quoted string
+#: can no longer masquerade as one (Step 8a finding F6).
+_SEGMENT_RE = re.compile(r"(?:\|\||&&|[;|&\n])")
+
+#: `cd <literal>` as a whole segment.
+_CD_RE = re.compile(r"^\s*cd\s+(\S+)\s*$")
+
+#: Shell text this module refuses to reason about inside a `cd` target.
+_UNSAFE_CHARS = ("$", "`", "*", "?", "~")
+
+#: `gh pr merge` flags that consume the NEXT token as a value. Without this the first
+#: number anywhere after `merge` was taken as the PR, so `--subject 2026 887` resolved to
+#: PR 2026 (Step 8a finding F5).
+_VALUE_FLAGS = frozenset({
+    "--subject", "-t", "--body", "-b", "--body-file", "-F",
+    "--match-head-commit", "--author-email", "-A", "--repo", "-R",
+})
+_REPO_FLAGS = frozenset({"--repo", "-R"})
+
+
+def _executable_text(command):
+    """`command` with quoted strings and heredoc bodies removed.
+
+    Delegates to `step_state_post.executable_text` — the repo already owns this exact
+    problem ("a command that MENTIONS a needle is not a command that RUNS it", v3.138.1),
+    so this reuses it rather than growing a second copy. On import failure the raw text is
+    returned: this runs before classification, where the policy is fail-open.
+    """
+    try:
+        import step_state_post  # pylint: disable=import-outside-toplevel
+        return step_state_post.executable_text(command)
+    except Exception:  # pylint: disable=broad-except
+        return command
+
+
+def _tokenize(segment):
+    return [t for t in segment.split() if t]
 
 
 def parse_merge_command(command):
-    """Classify *command*. Returns ``{"pr": int|None, "repo": str|None}`` or ``None``.
+    """Classify *command*. Returns a dict or ``None``.
 
     ``None`` means "not a raw `gh pr merge`" and is the answer for essentially every
-    command. A returned dict with ``pr is None`` means the invocation IS a raw merge but
-    its target could not be read — `gh pr merge` with no number merges the current
-    branch's PR, which this hook has no way to resolve.
+    command. Otherwise::
+
+        {"pr": int|None, "repo": str|None, "cd": str|None, "cd_unresolvable": bool}
+
+    ``pr is None`` means the invocation IS a raw merge but its target could not be read —
+    `gh pr merge` with no number merges the current branch's PR, which this hook cannot
+    resolve, so the caller must treat it as an unknown target rather than as "no PR".
     """
     if not isinstance(command, str) or not command:
         return None
     if not _PREFILTER_RE.search(command):
         return None
-    match = _MERGE_RE.search(command)
-    if not match:
+
+    text = _executable_text(command)
+    segments = _SEGMENT_RE.split(text)
+
+    cd_target, cd_unresolvable = None, False
+    merge_tokens = None
+    for segment in segments:
+        cd_match = _CD_RE.match(segment)
+        if cd_match:
+            candidate = cd_match.group(1)
+            if any(ch in candidate for ch in _UNSAFE_CHARS):
+                cd_unresolvable = True
+            else:
+                cd_target = candidate.strip("\"'")
+            continue
+        if _MERGE_RE.match(segment):
+            merge_tokens = _tokenize(segment)
+            break
+
+    if merge_tokens is None:
         return None
 
-    tail = command[match.end():]
-    # Stop at a command separator so `gh pr merge && gh pr view 42` cannot borrow 42.
-    tail = re.split(r"[;|&\n]", tail, maxsplit=1)[0]
+    # Drop everything up to and including the `merge` verb, plus any VAR=value prefixes.
+    try:
+        start = merge_tokens.index("merge") + 1
+    except ValueError:
+        start = len(merge_tokens)
+    args = merge_tokens[start:]
 
-    repo_match = _REPO_RE.search(tail)
-    repo = repo_match.group(1) if repo_match else None
-    if repo:
-        # Never let the repo's own text supply the PR number.
-        tail = tail.replace(repo_match.group(0), " ")
+    pr, repo, index = None, None, 0
+    while index < len(args):
+        token = args[index]
+        if token.startswith("-"):
+            name, _, inline = token.partition("=")
+            if inline:
+                if name in _REPO_FLAGS:
+                    repo = inline
+                index += 1
+                continue
+            if name in _VALUE_FLAGS:
+                if name in _REPO_FLAGS and index + 1 < len(args):
+                    repo = args[index + 1]
+                index += 2
+                continue
+            index += 1
+            continue
+        if pr is None and token.isdigit():
+            pr = int(token)
+        index += 1
 
-    pr_match = _PR_RE.search(tail)
-    pr = int(pr_match.group(1)) if pr_match else None
-    return {"pr": pr, "repo": repo}
+    return {"pr": pr, "repo": repo, "cd": cd_target,
+            "cd_unresolvable": cd_unresolvable}
 
 
 def find_project_root(start_path):
@@ -111,6 +183,24 @@ def find_project_root(start_path):
         current = parent
 
 
+def effective_cwd(target, hook_cwd):
+    """Where the merge segment would actually run (Step 8a finding F3).
+
+    `cd /campaign-project && gh pr merge 887` executes in the campaign project, not in the
+    hook's cwd, so resolving campaign state from `hook_cwd` alone read the wrong project's
+    state — or none at all.
+    """
+    cd_target = (target or {}).get("cd")
+    if not cd_target:
+        return hook_cwd
+    if os.path.isabs(cd_target):
+        return cd_target
+    try:
+        return os.path.normpath(os.path.join(hook_cwd or os.getcwd(), cd_target))
+    except (OSError, ValueError, TypeError):
+        return hook_cwd
+
+
 def configured_repo(project_root):
     """`repo.fullName` from the project's own config, or ``None``.
 
@@ -128,17 +218,27 @@ def configured_repo(project_root):
         return None
 
 
-def _campaign_is_active(state):
-    """Active == at least one child is not yet disposed."""
+def campaign_activity(state):
+    """``"active"`` | ``"settled"`` | ``"invalid"``.
+
+    Three-valued deliberately (Step 8a finding F4). A syntactically valid JSON object whose
+    `issues` field is missing or is not a list is **invalid**, not settled: reading it as
+    "no active children" let a corrupt campaign file allow a raw merge, which is the exact
+    opposite of the fail-closed rule for state that cannot be evaluated. Every real
+    campaign file carries an `issues` list (verified across all five in
+    claude_docs/.driver-state/), so this cannot refuse legitimate state.
+    """
+    if not isinstance(state, dict):
+        return "invalid"
     issues = state.get("issues")
     if not isinstance(issues, list):
-        return False
+        return "invalid"
     for entry in issues:
         if not isinstance(entry, dict):
-            continue
+            return "invalid"
         if entry.get("status") not in DISPOSED_STATUSES:
-            return True
-    return False
+            return "active"
+    return "settled"
 
 
 def read_campaigns(project_root, deadline=None):
@@ -147,7 +247,7 @@ def read_campaigns(project_root, deadline=None):
     Returns ``(active_campaigns, unevaluable)``:
 
     - ``active_campaigns`` — ``[{"campaign": str, "issues": [...]}, …]``
-    - ``unevaluable`` — names of state files that EXIST but could not be read.
+    - ``unevaluable`` — reasons the state set could not be fully evaluated.
 
     A missing directory yields ``([], [])``: absence, not failure. That is deliberately
     the rule `docs/supervision.md` already states — "`ENOENT` under a valid root is the
@@ -165,9 +265,17 @@ def read_campaigns(project_root, deadline=None):
     except (OSError, ValueError):
         return active, ["<driver-state directory unreadable>"]
 
-    for name in names[:MAX_STATE_FILES]:
-        if not name.endswith(".json"):
-            continue
+    # Filter to state files BEFORE applying the cap, and never drop an overflow silently
+    # (Step 8a finding F1): `.lock` siblings live in this directory and used to consume
+    # the budget, and files past the cap vanished with no trace, which allowed the merge.
+    state_files = [n for n in names if n.endswith(".json")]
+    if len(state_files) > MAX_STATE_FILES:
+        unevaluable.append(
+            "<%d campaign files exceed the %d-file read cap>"
+            % (len(state_files), MAX_STATE_FILES))
+        state_files = state_files[:MAX_STATE_FILES]
+
+    for name in state_files:
         if deadline is not None and time.monotonic() > deadline:
             unevaluable.append("<deadline reached before reading %s>" % name)
             break
@@ -183,10 +291,10 @@ def read_campaigns(project_root, deadline=None):
         except (OSError, ValueError, UnicodeDecodeError):
             unevaluable.append(name)
             continue
-        if not isinstance(state, dict):
+        activity = campaign_activity(state)
+        if activity == "invalid":
             unevaluable.append(name)
-            continue
-        if _campaign_is_active(state):
+        elif activity == "active":
             active.append({
                 "campaign": state.get("campaign") or name[:-len(".json")],
                 "issues": [e for e in state.get("issues") or [] if isinstance(e, dict)],
@@ -215,18 +323,22 @@ def decide(target, active, unevaluable, project_repo):
     if target is None:
         return {"action": "allow", "reason": "not a raw gh pr merge"}
 
-    # A foreign repository is not this campaign's business (review finding F3: PR numbers
+    # A foreign repository is not this campaign's business (Step 4 finding F3: PR numbers
     # are repository-scoped, so binding on the number alone denies unrelated work).
     target_repo = target.get("repo")
     if target_repo and project_repo and target_repo != project_repo:
         return {"action": "allow",
                 "reason": "targets %s, not this project's %s" % (target_repo, project_repo)}
 
-    if unevaluable:
+    reasons = list(unevaluable)
+    if target.get("cd_unresolvable"):
+        reasons.append("<the command changes directory to a path this guard cannot "
+                       "resolve, so the campaign state to check is unknown>")
+    if reasons:
         return {
-            "action": "deny", "kind": "unevaluable", "files": list(unevaluable),
-            "reason": "campaign state exists but could not be read: %s"
-                      % ", ".join(str(f) for f in unevaluable),
+            "action": "deny", "kind": "unevaluable", "files": reasons,
+            "reason": "campaign state could not be evaluated: %s"
+                      % ", ".join(str(f) for f in reasons),
         }
 
     if not active:
@@ -250,16 +362,30 @@ def decide(target, active, unevaluable, project_repo):
             "reason": "PR #%d is a child of active campaign %s" % (pr, campaign)}
 
 
-def format_deny(decision):
+def _root_arg(project_root):
+    """`--project-root` value for the replacement command.
+
+    Step 8a finding F8: a literal `.` is wrong whenever the Bash call ran in a
+    subdirectory of the project, which is exactly when the caller most needs the command
+    to work as printed.
+    """
+    if not project_root:
+        return "."
+    return project_root if not re.search(r"[\s'\"$`]", project_root) \
+        else "'%s'" % project_root.replace("'", "'\\''")
+
+
+def format_deny(decision, project_root=None):
     """The AC5 message: never a bare "blocked"."""
     kind = decision.get("kind")
     broker = "python3 hooks/launcher_lib.py broker-merge"
+    root = _root_arg(project_root)
 
     if kind == "campaign":
         pr, issue = decision.get("pr"), decision.get("issue")
         campaign = decision.get("campaign")
-        command = ("  %s --pr %s --issue %s \\\n    --campaign %s --project-root ."
-                   % (broker, pr, issue, campaign))
+        command = ("  %s --pr %s --issue %s \\\n    --campaign %s --project-root %s"
+                   % (broker, pr, issue, campaign, root))
         return (
             "BLOCKED: this PR belongs to an active campaign, so it merges through the "
             "supervised broker.\n\n"
@@ -277,17 +403,18 @@ def format_deny(decision):
             "child.\n\n"
             "Name the PR explicitly if it is unrelated to the campaign, or merge through "
             "the broker:\n\n  %s --pr <pr> --issue <issue> \\\n    --campaign %s "
-            "--project-root .\n"
-            % (decision.get("campaign"), broker, decision.get("campaign")))
+            "--project-root %s\n"
+            % (decision.get("campaign"), broker, decision.get("campaign"), root))
 
     return (
-        "BLOCKED: campaign state exists but could not be read, so this guard cannot "
-        "prove that merging is safe.\n\n"
-        "  Unreadable: %s\n\n"
+        "BLOCKED: campaign state could not be evaluated, so this guard cannot prove that "
+        "merging is safe.\n\n"
+        "  Unevaluable: %s\n\n"
         "This guard fails closed once a command is identified as a raw `gh pr merge` — "
         "the refusal costs you this one command, while an unnoticed bypass costs the "
         "campaign its authority checks, its execute-once claim and its telemetry.\n\n"
         "Fix or remove the unreadable state under claude_docs/.driver-state/, or merge "
         "through the broker:\n\n  %s --pr <pr> --issue <issue> \\\n    --campaign "
-        "<campaign> --project-root .\n"
-        % (", ".join(str(f) for f in decision.get("files") or ["<unknown>"]), broker))
+        "<campaign> --project-root %s\n"
+        % (", ".join(str(f) for f in decision.get("files") or ["<unknown>"]),
+           broker, root))

--- a/hooks/campaign_merge_guard_lib.py
+++ b/hooks/campaign_merge_guard_lib.py
@@ -1,0 +1,293 @@
+"""Pure decision layer for the campaign merge guard (#976).
+
+`hooks/campaign-merge-guard.py` is the thin PreToolUse wrapper; everything decidable
+lives here so it can be unit-tested without a subprocess. Same split as
+`security-guard.py` / `security_guard_lib.py`.
+
+**What this guard is, and is not (D187).** It hard-blocks a raw `gh pr merge` on the Bash
+tool path when the target PR belongs to an active campaign, and points the caller at
+`broker-merge`. It stops an *accidental* raw merge — a session that drifted from the
+prose. It does **not** stop a deliberate bypass: PreToolUse fires per Claude Code tool
+call, not per OS process, so a `python3 -c "subprocess.run(['gh','pr','merge',…])"` is
+invisible to it. The threat model is caller confusion and prose drift — the same one the
+broker states for its own target binding (`launcher_lib.py:5300-5303`).
+
+Standard library only, and no subprocess or network call: this runs on EVERY Bash tool
+call, so it must be cheap and it must never block on I/O it does not control (the
+constraint `supervision_lib.py` documents for the same reason).
+"""
+import json
+import os
+import re
+import time
+
+#: Mirrored from `driver_lib._DISPOSED_STATUSES`. Copied rather than imported because
+#: `driver_lib` is ~3900 lines and this module is loaded on every Bash tool call.
+#: `tests/hooks/test_campaign_merge_guard.py::test_disposed_statuses_mirror_driver_lib`
+#: is the drift guard that keeps the copy honest (repo CLAUDE.md §4 mistake 21).
+DISPOSED_STATUSES = frozenset({"merged", "deferred", "abandoned"})
+
+#: Bounded reads (review finding F5). The host's behavior when a PreToolUse hook exceeds
+#: its registered timeout is UNPROVEN, so the design removes the dependency instead of
+#: resting on it: the work is capped so the hook always answers first.
+MAX_STATE_BYTES = 1024 * 1024
+MAX_STATE_FILES = 64
+#: Well under the 5 s registered in hooks/hooks.json.
+INTERNAL_DEADLINE_S = 2.0
+
+DRIVER_STATE_RELPATH = os.path.join("claude_docs", ".driver-state")
+
+#: Cheap pre-filter for the hot path — every Bash call in every session hits this and
+#: nothing else. `gh`, then `pr`, then `merge`, as whole words in order.
+_PREFILTER_RE = re.compile(r"\bgh\b[^\n;|&]*?\bpr\b[^\n;|&]*?\bmerge\b")
+
+#: The classifier. `gh pr merge` as three consecutive tokens, in COMMAND POSITION: the
+#: start of the string or just after a separator (`;` `|` `&` newline, which covers `&&`
+#: and `||`), allowing leading whitespace and `VAR=value` prefixes. So
+#: `cd x && gh pr merge 887` matches, while `echo 'run gh pr merge 887 by hand'` and
+#: `grep -rn 'gh pr merge' docs/` do not — a mention is not an invocation.
+#:
+#: Deliberately NOT matched: `sh -c "gh pr merge …"` and other wrappers. That is the
+#: right trade for this guard's threat model (D187): a false positive blocks unrelated
+#: work in every project on the host, while a false negative only misses a form nobody
+#: reaches by accident — and the guard never claimed to stop a deliberate bypass.
+_MERGE_RE = re.compile(
+    r"(?:^|[;|&\n])\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*gh\s+pr\s+merge\b")
+
+_PR_RE = re.compile(r"\b(\d{1,7})\b")
+_REPO_RE = re.compile(r"--repo(?:=|\s+)([^\s;|&]+)")
+
+
+def parse_merge_command(command):
+    """Classify *command*. Returns ``{"pr": int|None, "repo": str|None}`` or ``None``.
+
+    ``None`` means "not a raw `gh pr merge`" and is the answer for essentially every
+    command. A returned dict with ``pr is None`` means the invocation IS a raw merge but
+    its target could not be read — `gh pr merge` with no number merges the current
+    branch's PR, which this hook has no way to resolve.
+    """
+    if not isinstance(command, str) or not command:
+        return None
+    if not _PREFILTER_RE.search(command):
+        return None
+    match = _MERGE_RE.search(command)
+    if not match:
+        return None
+
+    tail = command[match.end():]
+    # Stop at a command separator so `gh pr merge && gh pr view 42` cannot borrow 42.
+    tail = re.split(r"[;|&\n]", tail, maxsplit=1)[0]
+
+    repo_match = _REPO_RE.search(tail)
+    repo = repo_match.group(1) if repo_match else None
+    if repo:
+        # Never let the repo's own text supply the PR number.
+        tail = tail.replace(repo_match.group(0), " ")
+
+    pr_match = _PR_RE.search(tail)
+    pr = int(pr_match.group(1)) if pr_match else None
+    return {"pr": pr, "repo": repo}
+
+
+def find_project_root(start_path):
+    """Walk up for the directory holding `.rawgentic.json`, or ``None``.
+
+    Same shape as `security-guard.py:49-63` — the established hook pattern here.
+    """
+    if not start_path:
+        return None
+    try:
+        current = os.path.abspath(start_path)
+    except (OSError, ValueError, TypeError):
+        return None
+    if os.path.isfile(current):
+        current = os.path.dirname(current)
+    while True:
+        if os.path.exists(os.path.join(current, ".rawgentic.json")):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None
+        current = parent
+
+
+def configured_repo(project_root):
+    """`repo.fullName` from the project's own config, or ``None``.
+
+    A hook reading its own single config block directly, fail-open — the sanctioned
+    exception in the repo manual (§1), not a deviation.
+    """
+    if not project_root:
+        return None
+    try:
+        with open(os.path.join(project_root, ".rawgentic.json"), encoding="utf-8") as fh:
+            config = json.load(fh)
+        name = (config.get("repo") or {}).get("fullName")
+        return name if isinstance(name, str) and name else None
+    except (OSError, ValueError, TypeError, AttributeError):
+        return None
+
+
+def _campaign_is_active(state):
+    """Active == at least one child is not yet disposed."""
+    issues = state.get("issues")
+    if not isinstance(issues, list):
+        return False
+    for entry in issues:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("status") not in DISPOSED_STATUSES:
+            return True
+    return False
+
+
+def read_campaigns(project_root, deadline=None):
+    """Read durable campaign state.
+
+    Returns ``(active_campaigns, unevaluable)``:
+
+    - ``active_campaigns`` — ``[{"campaign": str, "issues": [...]}, …]``
+    - ``unevaluable`` — names of state files that EXIST but could not be read.
+
+    A missing directory yields ``([], [])``: absence, not failure. That is deliberately
+    the rule `docs/supervision.md` already states — "`ENOENT` under a valid root is the
+    only file failure treated as absence" — and it is what keeps every project that has
+    never run a campaign completely unaffected (AC4).
+    """
+    active, unevaluable = [], []
+    if not project_root:
+        return active, unevaluable
+    state_dir = os.path.join(project_root, DRIVER_STATE_RELPATH)
+    try:
+        names = sorted(os.listdir(state_dir))
+    except FileNotFoundError:
+        return active, unevaluable          # absence
+    except (OSError, ValueError):
+        return active, ["<driver-state directory unreadable>"]
+
+    for name in names[:MAX_STATE_FILES]:
+        if not name.endswith(".json"):
+            continue
+        if deadline is not None and time.monotonic() > deadline:
+            unevaluable.append("<deadline reached before reading %s>" % name)
+            break
+        path = os.path.join(state_dir, name)
+        try:
+            if not os.path.isfile(path):
+                continue
+            if os.path.getsize(path) > MAX_STATE_BYTES:
+                unevaluable.append(name)
+                continue
+            with open(path, encoding="utf-8") as fh:
+                state = json.load(fh)
+        except (OSError, ValueError, UnicodeDecodeError):
+            unevaluable.append(name)
+            continue
+        if not isinstance(state, dict):
+            unevaluable.append(name)
+            continue
+        if _campaign_is_active(state):
+            active.append({
+                "campaign": state.get("campaign") or name[:-len(".json")],
+                "issues": [e for e in state.get("issues") or [] if isinstance(e, dict)],
+            })
+    return active, unevaluable
+
+
+def _match_pr(active, pr):
+    """The first active campaign naming *pr*, as ``(campaign, issue_number)``."""
+    for campaign in active:
+        for entry in campaign["issues"]:
+            if entry.get("status") in DISPOSED_STATUSES:
+                continue
+            if entry.get("pr") == pr:
+                return campaign["campaign"], entry.get("number")
+    return None, None
+
+
+def decide(target, active, unevaluable, project_repo):
+    """The decision table. Returns ``{"action": "allow"|"deny", …}``.
+
+    Fail-CLOSED lives here and ONLY here — it is reachable only once *target* proves the
+    command is a raw `gh pr merge`, so its whole blast radius is one refused raw command
+    (D186). The sanctioned `broker-merge` path never reaches this function.
+    """
+    if target is None:
+        return {"action": "allow", "reason": "not a raw gh pr merge"}
+
+    # A foreign repository is not this campaign's business (review finding F3: PR numbers
+    # are repository-scoped, so binding on the number alone denies unrelated work).
+    target_repo = target.get("repo")
+    if target_repo and project_repo and target_repo != project_repo:
+        return {"action": "allow",
+                "reason": "targets %s, not this project's %s" % (target_repo, project_repo)}
+
+    if unevaluable:
+        return {
+            "action": "deny", "kind": "unevaluable", "files": list(unevaluable),
+            "reason": "campaign state exists but could not be read: %s"
+                      % ", ".join(str(f) for f in unevaluable),
+        }
+
+    if not active:
+        return {"action": "allow", "reason": "no active campaign"}
+
+    pr = target.get("pr")
+    if pr is None:
+        return {
+            "action": "deny", "kind": "unknown-target",
+            "campaign": active[0]["campaign"],
+            "reason": "the target PR could not be read from the command while a campaign "
+                      "is active",
+        }
+
+    campaign, issue = _match_pr(active, pr)
+    if campaign is None:
+        return {"action": "allow",
+                "reason": "no active campaign names PR #%d" % pr}
+    return {"action": "deny", "kind": "campaign", "campaign": campaign,
+            "issue": issue, "pr": pr,
+            "reason": "PR #%d is a child of active campaign %s" % (pr, campaign)}
+
+
+def format_deny(decision):
+    """The AC5 message: never a bare "blocked"."""
+    kind = decision.get("kind")
+    broker = "python3 hooks/launcher_lib.py broker-merge"
+
+    if kind == "campaign":
+        pr, issue = decision.get("pr"), decision.get("issue")
+        campaign = decision.get("campaign")
+        command = ("  %s --pr %s --issue %s \\\n    --campaign %s --project-root ."
+                   % (broker, pr, issue, campaign))
+        return (
+            "BLOCKED: this PR belongs to an active campaign, so it merges through the "
+            "supervised broker.\n\n"
+            "  Campaign: %s   Issue: #%s   PR: #%s\n\n"
+            "A raw `gh pr merge` skips authority evaluation, target binding, the "
+            "execute-once claim and the decision telemetry. Run this instead:\n\n%s\n"
+            % (campaign, issue, pr, command))
+
+    if kind == "unknown-target":
+        return (
+            "BLOCKED: campaign %s is active and this command's target PR could not be "
+            "read.\n\n"
+            "`gh pr merge` with no PR number merges the current branch's PR, which this "
+            "guard cannot resolve — so it cannot prove the merge is not a campaign "
+            "child.\n\n"
+            "Name the PR explicitly if it is unrelated to the campaign, or merge through "
+            "the broker:\n\n  %s --pr <pr> --issue <issue> \\\n    --campaign %s "
+            "--project-root .\n"
+            % (decision.get("campaign"), broker, decision.get("campaign")))
+
+    return (
+        "BLOCKED: campaign state exists but could not be read, so this guard cannot "
+        "prove that merging is safe.\n\n"
+        "  Unreadable: %s\n\n"
+        "This guard fails closed once a command is identified as a raw `gh pr merge` — "
+        "the refusal costs you this one command, while an unnoticed bypass costs the "
+        "campaign its authority checks, its execute-once claim and its telemetry.\n\n"
+        "Fix or remove the unreadable state under claude_docs/.driver-state/, or merge "
+        "through the broker:\n\n  %s --pr <pr> --issue <issue> \\\n    --campaign "
+        "<campaign> --project-root .\n"
+        % (", ".join(str(f) for f in decision.get("files") or ["<unknown>"]), broker))

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -37,6 +37,17 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/campaign-merge-guard.py",
+            "args": [],
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write|MultiEdit|NotebookEdit|Read",
         "hooks": [
           {

--- a/hooks/launcher_lib.py
+++ b/hooks/launcher_lib.py
@@ -5323,14 +5323,30 @@ def broker_binding_ok(pr_data, issue: int, repo: "str | None" = None) -> bool:
 
 
 def broker_campaign_names_issue(state: dict, issue: int) -> bool:
-    """Is `issue` a child of this campaign? PURE. Reads the queue the driver owns."""
+    """Is `issue` a child of this campaign? PURE. Reads the queue the driver owns.
+
+    #976 T0: this read ONLY `state["children"][].issue`, a shape `driver_lib` neither
+    writes nor reads. Real driver state carries top-level
+    `issues: [{"number": N, "status": …, "pr": M}]` (`driver_lib.py:844,1077,1348,1409,
+    1680`); the only `children` key in that module is the unrelated
+    `queue_revalidation.children` dict, keyed by issue-number string. So target binding
+    refused EVERY real campaign with rc 12 — invisible in CI because the test fixture
+    invented the same wrong shape. Both keys are accepted now, real one first, and the
+    fixture writes the real shape so the suite exercises production.
+    """
     if not isinstance(state, dict):
         return False
-    for child in (state.get("children") or []):
-        if isinstance(child, dict) and child.get("issue") == issue:
-            return True
-        if child == issue:
-            return True
+    for key, id_field in (("issues", "number"), ("children", "issue")):
+        entries = state.get(key)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict) and entry.get(id_field) == issue:
+                return True
+            # A bare int entry. `bool` is excluded deliberately: `True == 1` in Python,
+            # so a stray boolean would otherwise bind issue #1.
+            if isinstance(entry, int) and not isinstance(entry, bool) and entry == issue:
+                return True
     return False
 
 

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.138.1",
+  "version": "3.139.0",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.138.1"
+EXPECTED_PLUGIN_VERSION = "3.139.0"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_campaign_merge_guard.py
+++ b/tests/hooks/test_campaign_merge_guard.py
@@ -528,6 +528,92 @@ def test_f8_the_replacement_command_names_the_real_project_root(tmp_path):
     assert "--project-root .\n" not in reason
 
 
+# ── Step 11 review findings ───────────────────────────────────────────────
+
+@pytest.mark.parametrize("command", [
+    'gh pr merge 887 --repo "3D-Stories/rawgentic" --squash',
+    "gh pr merge 887 --repo '3D-Stories/rawgentic'",
+    'gh pr merge --subject "fix 2026 bug" 887',
+    'gh pr merge 887 --body "merging 2026 changes"',
+])
+def test_s11_f1_a_quoted_argument_value_survives(tmp_path, command):
+    """Stripping quotes wholesale turned `--repo "o/r" --squash` into `--repo --squash`,
+    read `--squash` as the repository, called it foreign, and allowed the merge."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision(command, root) == "deny"
+
+
+def test_s11_f1_a_value_flag_never_adopts_the_next_flag_as_its_value():
+    got = lib.parse_merge_command("gh pr merge 887 --repo --squash")
+    assert got["repo"] is None
+    assert got["pr"] == 887
+
+
+def test_s11_f2_every_merge_target_is_checked(tmp_path):
+    """A harmless first merge must not clear the whole Bash call."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision("gh pr merge 999; gh pr merge 887", root) == "deny"
+    assert _decision("gh pr merge 999 && gh pr merge 887", root) == "deny"
+
+
+def test_s11_f2_parse_returns_targets_in_execution_order():
+    got = lib.parse_merge_command("gh pr merge 999; gh pr merge 887")
+    assert [t["pr"] for t in got["targets"]] == [999, 887]
+
+
+def test_s11_f2_several_unrelated_merges_still_allow(tmp_path):
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision("gh pr merge 111; gh pr merge 222", root) == "allow"
+
+
+@pytest.mark.parametrize("entry", [
+    {"number": 880, "status": "pr_open", "pr": "887"},   # pr as a string
+    {"number": "880", "status": "pr_open", "pr": 887},   # number as a string
+    {"number": 880, "status": "pr_open", "pr": True},    # bool is not a PR
+    {"number": 880, "pr": 887},                          # no status
+    {"number": 880, "status": "", "pr": 887},            # empty status
+])
+def test_s11_f3_a_wrongly_typed_entry_is_unevaluable(tmp_path, entry):
+    """`{"pr": "887"}` was read as ACTIVE, never matched integer 887, and allowed."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [entry])
+    assert _decision("gh pr merge 887", root) == "deny"
+
+
+def test_s11_f3_a_queued_child_with_no_pr_yet_is_still_valid():
+    """A child that has not opened its PR carries no `pr` — that is normal, not corrupt."""
+    assert lib.valid_issue_entry({"number": 880, "status": "queued"}) is True
+    assert lib.campaign_activity({"issues": [{"number": 880, "status": "queued"}]}) \
+        == "active"
+
+
+def test_s11_f3_real_campaign_files_are_never_invalid():
+    """The guard must not refuse legitimate state that exists on this host right now."""
+    import glob  # noqa: PLC0415
+    files = sorted(glob.glob(str(REPO_ROOT / "claude_docs" / ".driver-state" / "*.json")))
+    if not files:
+        pytest.skip("no live campaign state on this host")
+    for path in files:
+        with open(path, encoding="utf-8") as fh:
+            state = json.load(fh)
+        assert lib.campaign_activity(state) != "invalid", path
+
+
+def test_an_unlexable_command_denies_while_a_campaign_is_active(tmp_path):
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision('gh pr merge 887 --subject "unbalanced', root) == "deny"
+
+
+def test_an_unlexable_command_allows_when_no_campaign_is_active(tmp_path):
+    """Unparseable is only a problem when there is something to protect."""
+    root = _project(tmp_path)
+    assert _decision('gh pr merge 887 --subject "unbalanced', root) == "allow"
+
+
 # ── registration ──────────────────────────────────────────────────────────
 
 def test_the_hook_is_registered_as_a_pretooluse_bash_hook():

--- a/tests/hooks/test_campaign_merge_guard.py
+++ b/tests/hooks/test_campaign_merge_guard.py
@@ -1,0 +1,391 @@
+"""Tests for hooks/campaign-merge-guard.py — PreToolUse guard for campaign merges (#976).
+
+The guard refuses a raw `gh pr merge` whose PR belongs to an ACTIVE campaign, and points
+the caller at `broker-merge` instead. Covers the issue's five acceptance criteria:
+
+- AC1 refusal decided from durable driver state, never session context
+- AC2 the broker's own merge is not blocked, with no spoofable signal
+- AC3 the fail mode, settled per path (open before classification, closed after)
+- AC4 non-campaign merges byte-for-byte unaffected
+- AC5 a legible denial
+
+Hooks are tested black-box via subprocess with JSON on stdin exactly as Claude Code
+invokes them (docs/testing.md:5-8); the pure decision functions are imported directly.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.hooks.conftest import parse_hook_output, run_hook
+
+HOOK = "campaign-merge-guard.py"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "hooks"))
+
+import campaign_merge_guard_lib as lib  # noqa: E402
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────
+
+CONFIGURED_REPO = "3D-Stories/rawgentic"
+
+
+def _project(tmp_path: Path, *, repo: str = CONFIGURED_REPO) -> Path:
+    """A project root with a .rawgentic.json, like every real project here."""
+    root = tmp_path / "proj"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / ".rawgentic.json").write_text(json.dumps({
+        "version": 1,
+        "project": {"name": "rawgentic", "type": "library"},
+        "repo": {"provider": "github", "fullName": repo, "defaultBranch": "main"},
+    }), encoding="utf-8")
+    return root
+
+
+def _campaign(root: Path, name: str, issues: list[dict]) -> Path:
+    """Write a driver-state file in the REAL shape.
+
+    Real driver state carries top-level `issues: [{"number": N, "status": …, "pr": M}]`
+    — verified against claude_docs/.driver-state/epic-875-stay-small.json and every
+    reader in hooks/driver_lib.py. A fixture that invents a different shape is the
+    exact bug this file exists to prevent recurring (see the T0 regression in
+    tests/hooks/test_launcher_lib.py).
+    """
+    state_dir = root / "claude_docs" / ".driver-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / f"{name}.json"
+    path.write_text(json.dumps({
+        "schema_version": 2,
+        "campaign": name,
+        "project": "rawgentic",
+        "epic": 875,
+        "epic_status": "open",
+        "issues": issues,
+    }), encoding="utf-8")
+    return path
+
+
+def _guard(command: str, cwd: Path) -> tuple[str, str, int]:
+    return run_hook(HOOK, {"tool_name": "Bash", "tool_input": {"command": command}},
+                    cwd=cwd)
+
+
+def _decision(command: str, cwd: Path) -> str:
+    stdout, _stderr, _rc = _guard(command, cwd)
+    parsed = parse_hook_output(stdout)
+    if parsed is None:
+        return "allow"
+    got = parsed.get("hookSpecificOutput", {}).get("permissionDecision", "")
+    return "deny" if got == "deny" else "allow"
+
+
+# ── AC1: refuse a raw merge whose PR belongs to an active campaign ────────
+
+def test_ac1_denies_raw_merge_of_an_active_campaign_pr(tmp_path):
+    root = _project(tmp_path)
+    _campaign(root, "epic-875-stay-small",
+              [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision("gh pr merge 887 --squash --delete-branch", root) == "deny"
+
+
+def test_ac1_decided_from_durable_state_not_session_context(tmp_path):
+    """No environment variable and no session field can turn the refusal on or off."""
+    root = _project(tmp_path)
+    _campaign(root, "epic-875-stay-small",
+              [{"number": 880, "status": "in_progress", "pr": 887}])
+    stdout, _stderr, _rc = run_hook(
+        HOOK,
+        {"tool_name": "Bash", "tool_input": {"command": "gh pr merge 887"},
+         "session_id": "whatever", "campaign": "none", "cwd": str(root)},
+        cwd=root,
+        env_override={"RAWGENTIC_CAMPAIGN": "", "CLAUDE_CODE_SESSION_ID": "x"},
+    )
+    parsed = parse_hook_output(stdout)
+    assert parsed is not None
+    assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+@pytest.mark.parametrize("status", ["queued", "in_progress", "pr_open"])
+def test_ac1_active_statuses_deny(tmp_path, status):
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": status, "pr": 887}])
+    assert _decision("gh pr merge 887", root) == "deny"
+
+
+@pytest.mark.parametrize("status", ["merged", "deferred", "abandoned"])
+def test_ac1_disposed_statuses_allow(tmp_path, status):
+    """A campaign whose every child is disposed is finished — it gates nothing."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": status, "pr": 887}])
+    assert _decision("gh pr merge 887", root) == "allow"
+
+
+def test_ac1_unparseable_pr_number_with_an_active_campaign_denies(tmp_path):
+    """`gh pr merge` with no number targets the current branch's PR — unknowable here."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision("gh pr merge --squash", root) == "deny"
+
+
+# ── AC2: the broker's own merge is never blocked, with no spoofable signal ─
+
+def test_ac2_the_broker_command_is_not_classified_as_a_raw_merge():
+    """`broker-merge` carries no `gh pr merge` token sequence, so the pre-filter misses it."""
+    assert lib.parse_merge_command(
+        "python3 hooks/launcher_lib.py broker-merge --pr 887 --issue 880 "
+        "--campaign epic-875-stay-small --project-root ."
+    ) is None
+
+
+def test_ac2_the_broker_command_is_allowed_with_a_campaign_active(tmp_path):
+    root = _project(tmp_path)
+    _campaign(root, "epic-875-stay-small",
+              [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision(
+        "python3 hooks/launcher_lib.py broker-merge --pr 887 --issue 880 "
+        "--campaign epic-875-stay-small --project-root .", root) == "allow"
+
+
+def test_ac2_the_broker_spawns_gh_with_a_list_argv_not_a_shell_string():
+    """The signal is a PROCESS BOUNDARY, not a token — so pin the shape it rests on.
+
+    PreToolUse fires per Claude Code tool call, not per OS process. The broker's merge is
+    `subprocess.run([...], shell=False)` from Python, so it is not a Bash tool call and
+    this hook never sees it. If that ever became a shell string routed through the Bash
+    tool, the guard would start blocking the broker itself.
+    """
+    source = (REPO_ROOT / "hooks" / "launcher_lib.py").read_text(encoding="utf-8")
+    assert ('argv = ["gh", "pr", "merge", str(pr), "--repo", repo, "--squash", '
+            '"--delete-branch"]') in source
+    assert "shell=False" in source
+
+
+# ── AC3: the fail mode, settled per path ──────────────────────────────────
+
+def test_ac3_unparseable_stdin_fails_open_and_says_so():
+    """Before classification: ALLOW. A bug here would otherwise block every Bash call."""
+    hook = REPO_ROOT / "hooks" / HOOK
+    proc = subprocess.run([sys.executable, str(hook)], input="not json at all",
+                          capture_output=True, text=True, timeout=10)
+    assert proc.returncode == 0
+    assert parse_hook_output(proc.stdout) is None
+    assert proc.stderr.strip(), "the fail-open path must not be silent (finding F4)"
+
+
+def test_ac3_missing_command_field_fails_open(tmp_path):
+    root = _project(tmp_path)
+    stdout, _stderr, rc = run_hook(HOOK, {"tool_name": "Bash", "tool_input": {}},
+                                   cwd=root)
+    assert rc == 0
+    assert parse_hook_output(stdout) is None
+
+
+def test_ac3_corrupt_campaign_state_fails_closed(tmp_path):
+    """After classification: DENY. The blast radius is one refused raw command."""
+    root = _project(tmp_path)
+    state_dir = root / "claude_docs" / ".driver-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "broken.json").write_text("{ this is not json", encoding="utf-8")
+    assert _decision("gh pr merge 887", root) == "deny"
+
+
+def test_ac3_corrupt_state_does_not_block_a_non_merge_command(tmp_path):
+    """The fail-CLOSED path is reachable ONLY after the command is classified."""
+    root = _project(tmp_path)
+    state_dir = root / "claude_docs" / ".driver-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "broken.json").write_text("{ this is not json", encoding="utf-8")
+    assert _decision("pytest tests/ -q", root) == "allow"
+    assert _decision("ls -la", root) == "allow"
+    assert _decision("git commit -m 'wip'", root) == "allow"
+
+
+def test_ac3_missing_state_directory_is_absence_not_failure(tmp_path):
+    """ENOENT under a valid root is absence — the rule docs/supervision.md already states."""
+    root = _project(tmp_path)
+    assert not (root / "claude_docs" / ".driver-state").exists()
+    assert _decision("gh pr merge 887", root) == "allow"
+
+
+def test_ac3_no_project_root_allows(tmp_path):
+    """No .rawgentic.json above cwd: there is no campaign to gate on."""
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    assert _decision("gh pr merge 887", bare) == "allow"
+
+
+def test_ac3_oversized_state_file_fails_closed(tmp_path):
+    root = _project(tmp_path)
+    state_dir = root / "claude_docs" / ".driver-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "huge.json").write_text(
+        "[" + ("0," * (lib.MAX_STATE_BYTES // 2)) + "0]", encoding="utf-8")
+    assert _decision("gh pr merge 887", root) == "deny"
+
+
+# ── AC4: non-campaign merges are byte-for-byte unaffected ─────────────────
+
+def test_ac4_no_campaign_file_at_all_allows(tmp_path):
+    root = _project(tmp_path)
+    assert _decision("gh pr merge 887 --squash --delete-branch", root) == "allow"
+
+
+def test_ac4_a_campaign_that_does_not_name_this_pr_allows(tmp_path):
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision("gh pr merge 999", root) == "allow"
+
+
+def test_ac4_a_foreign_repo_target_allows(tmp_path):
+    """Finding F3: PR numbers are repo-scoped, so a foreign --repo must not collide."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision("gh pr merge 887 --repo other-org/other-repo", root) == "allow"
+
+
+def test_ac4_this_repo_named_explicitly_still_denies(tmp_path):
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision(f"gh pr merge 887 --repo {CONFIGURED_REPO}", root) == "deny"
+
+
+@pytest.mark.parametrize("command", [
+    "gh pr create --title x --body y",
+    "gh pr view 887 --json state",
+    "gh pr list --state open",
+    "gh issue view 976",
+    "git merge main",
+    "echo 'run gh pr merge 887 by hand'",
+    'echo "gh pr merge 887"',
+    "grep -rn 'gh pr merge' docs/",
+    "git commit -m 'document gh pr merge 887'",
+])
+def test_ac4_non_merge_commands_allow(tmp_path, command):
+    """A MENTION of the command is not an INVOCATION of it."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision(command, root) == "allow"
+
+
+@pytest.mark.parametrize("command", [
+    "gh pr merge 887",
+    "  gh pr merge 887",
+    "cd /repo && gh pr merge 887 --squash",
+    "git fetch origin; gh pr merge 887",
+    "GH_TOKEN=x gh pr merge 887",
+])
+def test_ac1_command_position_invocations_deny(tmp_path, command):
+    """Real invocations, including after a separator or an env-var prefix."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision(command, root) == "deny"
+
+
+# ── AC5: a legible denial ─────────────────────────────────────────────────
+
+def test_ac5_denial_names_campaign_issue_pr_reason_and_the_broker_command(tmp_path):
+    root = _project(tmp_path)
+    _campaign(root, "epic-875-stay-small",
+              [{"number": 880, "status": "pr_open", "pr": 887}])
+    stdout, _stderr, _rc = _guard("gh pr merge 887", root)
+    parsed = parse_hook_output(stdout)
+    assert parsed is not None
+    reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert "epic-875-stay-small" in reason, "names the campaign"
+    assert "880" in reason, "names the issue"
+    assert "887" in reason, "names the PR"
+    assert "broker-merge" in reason, "names the command to run instead"
+    assert "--campaign epic-875-stay-small" in reason
+    assert "--issue 880" in reason
+    assert "--pr 887" in reason
+    assert len(reason.splitlines()) > 2, "never a bare one-line 'blocked'"
+
+
+def test_ac5_the_unevaluable_denial_says_why(tmp_path):
+    root = _project(tmp_path)
+    state_dir = root / "claude_docs" / ".driver-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "broken.json").write_text("{ nope", encoding="utf-8")
+    stdout, _stderr, _rc = _guard("gh pr merge 887", root)
+    reason = parse_hook_output(stdout)["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "broken.json" in reason, "names the file it could not read"
+    assert "broker-merge" in reason
+
+
+# ── the pure decision layer ───────────────────────────────────────────────
+
+@pytest.mark.parametrize("command,pr,repo", [
+    ("gh pr merge 887", 887, None),
+    ("gh pr merge 887 --squash --delete-branch", 887, None),
+    ("gh pr merge --squash 887", 887, None),
+    ("gh pr merge 887 --repo a/b", 887, "a/b"),
+    ("gh pr merge --repo a/b 887", 887, "a/b"),
+    ("gh  pr   merge  887", 887, None),
+    ("gh pr merge", None, None),
+    ("gh pr merge --auto", None, None),
+])
+def test_parse_merge_command_extracts_the_target(command, pr, repo):
+    got = lib.parse_merge_command(command)
+    assert got is not None, command
+    assert got["pr"] == pr
+    assert got["repo"] == repo
+
+
+@pytest.mark.parametrize("command", [
+    "gh pr create",
+    "gh pr view 1",
+    "git merge",
+    "gh repo merge",
+    "python3 hooks/launcher_lib.py broker-merge --pr 1 --issue 2 --campaign c",
+    "",
+])
+def test_parse_merge_command_rejects_non_merges(command):
+    assert lib.parse_merge_command(command) is None
+
+
+def test_disposed_statuses_mirror_driver_lib():
+    """Mirrored constant, drift-guarded — the established pattern (CLAUDE.md §4 #21).
+
+    driver_lib is 3945 lines and this hook runs on every Bash call, so the set is copied
+    rather than imported. This test is what keeps the copy honest.
+    """
+    sys.path.insert(0, str(REPO_ROOT / "hooks"))
+    import driver_lib  # noqa: PLC0415
+    assert lib.DISPOSED_STATUSES == frozenset(driver_lib._DISPOSED_STATUSES)
+
+
+def test_reads_are_bounded():
+    """Finding F5: the platform's timeout behavior is unknown, so never approach it."""
+    assert lib.MAX_STATE_BYTES <= 2 * 1024 * 1024
+    assert lib.MAX_STATE_FILES <= 256
+    assert lib.INTERNAL_DEADLINE_S < 5, "must answer before the registered 5 s cutoff"
+
+
+def test_internal_deadline_denies_a_classified_merge(tmp_path):
+    """Hitting the deadline post-classification refuses, per the AC3 split."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    target = lib.parse_merge_command("gh pr merge 887")
+    decision = lib.decide(target, [], ["<deadline>"], CONFIGURED_REPO)
+    assert decision["action"] == "deny"
+
+
+# ── registration ──────────────────────────────────────────────────────────
+
+def test_the_hook_is_registered_as_a_pretooluse_bash_hook():
+    entries = json.loads((REPO_ROOT / "hooks" / "hooks.json").read_text())["hooks"]
+    commands = [
+        h.get("command", "")
+        for group in entries["PreToolUse"] if "Bash" in group.get("matcher", "")
+        for h in group.get("hooks", [])
+    ]
+    assert any(c.endswith(f"/hooks/{HOOK}") for c in commands), commands
+
+
+def test_the_hook_file_is_executable():
+    assert os.access(REPO_ROOT / "hooks" / HOOK, os.X_OK)

--- a/tests/hooks/test_campaign_merge_guard.py
+++ b/tests/hooks/test_campaign_merge_guard.py
@@ -274,12 +274,17 @@ def test_ac4_non_merge_commands_allow(tmp_path, command):
 @pytest.mark.parametrize("command", [
     "gh pr merge 887",
     "  gh pr merge 887",
-    "cd /repo && gh pr merge 887 --squash",
+    "cd . && gh pr merge 887 --squash",
     "git fetch origin; gh pr merge 887",
     "GH_TOKEN=x gh pr merge 887",
 ])
 def test_ac1_command_position_invocations_deny(tmp_path, command):
-    """Real invocations, including after a separator or an env-var prefix."""
+    """Real invocations, including after a separator or an env-var prefix.
+
+    A `cd` to somewhere OUTSIDE the project is deliberately NOT here: after the Step 8a
+    F3 fix that merge really would run elsewhere, so allowing it is correct. The
+    cd-into-a-campaign case has its own test below.
+    """
     root = _project(tmp_path)
     _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
     assert _decision(command, root) == "deny"
@@ -373,6 +378,154 @@ def test_internal_deadline_denies_a_classified_merge(tmp_path):
     target = lib.parse_merge_command("gh pr merge 887")
     decision = lib.decide(target, [], ["<deadline>"], CONFIGURED_REPO)
     assert decision["action"] == "deny"
+
+
+# ── Step 8a review findings, each pinned by the case that exposed it ──────
+
+def test_f1_a_json_file_past_the_read_cap_is_not_silently_dropped(tmp_path):
+    """Files beyond MAX_STATE_FILES used to vanish, allowing the merge they governed.
+
+    `.lock` siblings live in this directory too, and used to consume the budget before
+    the cap was applied to state files only.
+    """
+    root = _project(tmp_path)
+    state_dir = root / "claude_docs" / ".driver-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(lib.MAX_STATE_FILES + 5):
+        _campaign(root, "campaign-%03d" % i,
+                  [{"number": 1, "status": "merged", "pr": 1}])
+    # The active campaign sorts last, past the cap.
+    _campaign(root, "zzz-active", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision("gh pr merge 887", root) == "deny"
+
+
+def test_f1_lock_files_do_not_consume_the_read_budget(tmp_path):
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    state_dir = root / "claude_docs" / ".driver-state"
+    for i in range(lib.MAX_STATE_FILES + 10):
+        (state_dir / ("c1-%03d.json.lock" % i)).write_text("", encoding="utf-8")
+    active, unevaluable = lib.read_campaigns(str(root))
+    assert unevaluable == []
+    assert [c["campaign"] for c in active] == ["c1"]
+
+
+def test_f2_an_error_after_classification_denies(tmp_path, monkeypatch):
+    """The outer handler must refuse once the command is a known raw merge."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    hook = REPO_ROOT / "hooks" / HOOK
+    # Break a function the hook calls only AFTER classification.
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(
+        "import sys\n"
+        f"sys.path.insert(0, {str(REPO_ROOT / 'hooks')!r})\n"
+        "import campaign_merge_guard_lib as g\n"
+        "def boom(*a, **k):\n"
+        "    raise RuntimeError('injected')\n"
+        "g.read_campaigns = boom\n", encoding="utf-8")
+    env = dict(os.environ, PYTHONPATH=str(tmp_path))
+    payload = json.dumps({"tool_name": "Bash",
+                          "tool_input": {"command": "gh pr merge 887"},
+                          "cwd": str(root)})
+    proc = subprocess.run([sys.executable, str(hook)], input=payload, env=env,
+                          capture_output=True, text=True, timeout=15, cwd=str(root))
+    parsed = parse_hook_output(proc.stdout)
+    assert parsed is not None, f"expected a deny, got stdout={proc.stdout!r}"
+    assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "broker-merge" in parsed["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_f3_a_cd_into_a_campaign_project_is_evaluated_there(tmp_path):
+    """`cd /campaign && gh pr merge 887` runs in /campaign, not in the hook's cwd."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    assert _decision(f"cd {root} && gh pr merge 887", outside) == "deny"
+
+
+def test_f3_a_bare_merge_from_outside_any_project_still_allows(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    assert _decision("gh pr merge 887", outside) == "allow"
+
+
+def test_f3_an_unresolvable_cd_target_denies(tmp_path):
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision('cd "$TARGET" && gh pr merge 887', root) == "deny"
+
+
+def test_f4_a_campaign_object_without_an_issues_list_is_unevaluable(tmp_path):
+    """Valid JSON is not valid state; reading it as 'settled' allowed the merge."""
+    root = _project(tmp_path)
+    state_dir = root / "claude_docs" / ".driver-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "c1.json").write_text(json.dumps({"campaign": "c1"}), encoding="utf-8")
+    assert _decision("gh pr merge 887", root) == "deny"
+
+
+@pytest.mark.parametrize("state,expected", [
+    ({"issues": [{"number": 1, "status": "pr_open"}]}, "active"),
+    ({"issues": [{"number": 1, "status": "merged"}]}, "settled"),
+    ({"issues": []}, "settled"),
+    ({"campaign": "c"}, "invalid"),
+    ({"issues": "nope"}, "invalid"),
+    ({"issues": [None]}, "invalid"),
+    ("not a dict", "invalid"),
+])
+def test_f4_campaign_activity_is_three_valued(state, expected):
+    assert lib.campaign_activity(state) == expected
+
+
+@pytest.mark.parametrize("command,pr", [
+    ("gh pr merge --subject 2026 887", 887),
+    ("gh pr merge -t 2026 887", 887),
+    ("gh pr merge --body 12345 887 --squash", 887),
+    ("gh pr merge --match-head-commit 999 887", 887),
+    ("gh pr merge --subject=2026 887", 887),
+])
+def test_f5_a_flag_value_is_never_mistaken_for_the_pr(command, pr):
+    """The first number after `merge` used to win, so `--subject 2026 887` read PR 2026."""
+    assert lib.parse_merge_command(command)["pr"] == pr
+
+
+def test_f5_a_non_numeric_positional_yields_an_unknown_target():
+    """`gh pr merge my-branch` is a real form; it is unknown, not absent."""
+    got = lib.parse_merge_command("gh pr merge my-feature-branch")
+    assert got is not None and got["pr"] is None
+
+
+@pytest.mark.parametrize("command", [
+    "echo 'note; gh pr merge 887'",
+    'echo "wrap; gh pr merge 887"',
+    "cat <<'EOF'\ngh pr merge 887\nEOF",
+])
+def test_f6_a_separator_inside_quoted_text_is_not_a_separator(tmp_path, command):
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    assert _decision(command, root) == "allow"
+
+
+def test_f7_a_missing_command_field_emits_a_diagnostic(tmp_path):
+    root = _project(tmp_path)
+    _stdout, stderr, rc = run_hook(HOOK, {"tool_name": "Bash", "tool_input": {}},
+                                   cwd=root)
+    assert rc == 0
+    assert "campaign-merge-guard" in stderr
+
+
+def test_f8_the_replacement_command_names_the_real_project_root(tmp_path):
+    """A literal `.` is wrong exactly when the call ran in a subdirectory."""
+    root = _project(tmp_path)
+    _campaign(root, "c1", [{"number": 880, "status": "pr_open", "pr": 887}])
+    sub = root / "deep" / "nested"
+    sub.mkdir(parents=True)
+    stdout, _stderr, _rc = _guard("gh pr merge 887", sub)
+    reason = parse_hook_output(stdout)["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "--project-root %s" % root in reason
+    assert "--project-root .\n" not in reason
 
 
 # ── registration ──────────────────────────────────────────────────────────

--- a/tests/hooks/test_launcher_lib.py
+++ b/tests/hooks/test_launcher_lib.py
@@ -3763,11 +3763,36 @@ class TestBrokerCampaignBindingReadsRealDriverState:
         assert ll.broker_campaign_names_issue({"issues": "nope"}, 1) is False
         assert ll.broker_campaign_names_issue({"issues": [None, "x", 3.5]}, 1) is False
 
-    def test_the_shape_this_fixture_writes_matches_what_driver_lib_reads(self, tmp_path):
-        """The bug was a fixture that lied. Pin the fixture against the real reader."""
-        source = (HOOKS / "driver_lib.py").read_text(encoding="utf-8")
-        assert 'state.get("issues", [])' in source, \
-            "driver_lib reads issues[]; the broker fixture must write that shape"
+    def test_the_production_writer_and_the_broker_agree_on_the_schema(self):
+        """The bug was a fixture that lied, so assert BEHAVIOR, not a source substring.
+
+        Step 11 finding: an earlier version of this test only checked that the string
+        `state.get("issues", [])` appeared somewhere in driver_lib.py, which proves
+        nothing about what the writer emits. This drives a real production writer and
+        feeds its output straight to the broker's reader, so a future schema change
+        breaks it for the right reason.
+        """
+        sys.path.insert(0, str(HOOKS))
+        import driver_lib  # noqa: PLC0415
+
+        state = {"schema_version": 2, "campaign": "epic-test", "project": "p",
+                 "issues": [{"number": 880, "status": "queued", "pr": 887},
+                            {"number": 881, "status": "queued", "pr": 888}]}
+
+        # The writer the epic driver actually uses when a child ships.
+        updated = driver_lib.record_child_outcome(state, 880, "merged")
+        assert updated is not None
+        assert updated["issues"][0]["status"] == "merged"
+
+        # The broker's reader must find both children in the writer's own output.
+        assert ll.broker_campaign_names_issue(updated, 880) is True
+        assert ll.broker_campaign_names_issue(updated, 881) is True
+        assert ll.broker_campaign_names_issue(updated, 999) is False
+
+    def test_the_fixture_writes_state_the_validator_accepts(self, tmp_path):
+        """And the fixture's own shape must survive driver_lib's validator."""
+        sys.path.insert(0, str(HOOKS))
+        import driver_lib  # noqa: PLC0415
 
         root = _broker_workspace(tmp_path, campaign="c", issue=880, pr_number=887)
         written = json.loads(
@@ -3776,3 +3801,7 @@ class TestBrokerCampaignBindingReadsRealDriverState:
         assert written["issues"][0]["number"] == 880
         assert written["issues"][0]["pr"] == 887
         assert ll.broker_campaign_names_issue(written, 880) is True
+
+        # record_child_outcome runs `_numbers()`, which fails closed on a missing or
+        # non-int number -- so accepting this fixture proves its entries are well formed.
+        assert driver_lib.record_child_outcome(written, 880, "merged") is not None

--- a/tests/hooks/test_launcher_lib.py
+++ b/tests/hooks/test_launcher_lib.py
@@ -3260,7 +3260,7 @@ class BrokerRunner(Runner):
 
 
 def _broker_workspace(tmp_path, *, campaign="epic-963", issue=963,
-                      merge_policy=None, declared=None):
+                      merge_policy=None, declared=None, pr_number=970):
     """A workspace + project root with a campaign whose queue names `issue`."""
     Path(tmp_path, ".rawgentic_workspace.json").write_text("{}", encoding="utf-8")
     Path(tmp_path, ".rawgentic.json").write_text(json.dumps({
@@ -3269,7 +3269,14 @@ def _broker_workspace(tmp_path, *, campaign="epic-963", issue=963,
     }), encoding="utf-8")
     state_dir = Path(tmp_path, "claude_docs", ".driver-state")
     state_dir.mkdir(parents=True, exist_ok=True)
-    state = {"campaign": campaign, "children": [{"issue": issue, "status": "in_progress"}]}
+    # The REAL driver-state shape (#976 T0). This fixture used to write
+    # {"children": [{"issue": N}]}, a shape `driver_lib` never produces and never reads —
+    # so every broker test below passed against a schema that does not exist, while
+    # `broker_campaign_names_issue` refused every real campaign in production. Real state
+    # is top-level `issues: [{"number": N, "status": …, "pr": M}]` (verified against
+    # claude_docs/.driver-state/epic-875-stay-small.json and driver_lib.py:844,1077,1348).
+    state = {"campaign": campaign, "project": "p",
+             "issues": [{"number": issue, "status": "in_progress", "pr": pr_number}]}
     if merge_policy:
         state["policy"] = {"merge_policy": merge_policy}
     (state_dir / f"{campaign}.json").write_text(json.dumps(state), encoding="utf-8")
@@ -3605,7 +3612,7 @@ class TestBrokerMergeStep11Findings:
 
         path = Path(root, "claude_docs", ".driver-state", "epic-963.json")
         state = json.loads(path.read_text())
-        state["children"][0]["status"] = "pr_open"          # an ordinary driver write
+        state["issues"][0]["status"] = "pr_open"            # an ordinary driver write
         path.write_text(json.dumps(state))
 
         resumed = BrokerRunner()
@@ -3707,3 +3714,65 @@ class TestBrokerMergeCLI:
                             "broker-merge", "--pr", "1"],
                            capture_output=True, text=True, check=False)
         assert r.returncode == 2
+
+
+class TestBrokerCampaignBindingReadsRealDriverState:
+    """#976 T0 — the broker refused every real campaign, and its fixture hid it.
+
+    `broker_campaign_names_issue` read `state["children"][].issue`. `driver_lib` writes
+    and reads top-level `issues[].number`; its only `children` key is the unrelated
+    `queue_revalidation.children` dict. So target binding failed for every real campaign
+    with rc 12 while the suite stayed green against an invented fixture.
+    """
+
+    #: One real record, copied field-for-field from
+    #: claude_docs/.driver-state/epic-875-stay-small.json.
+    REAL = {
+        "schema_version": 2,
+        "campaign": "epic-875-stay-small",
+        "project": "rawgentic",
+        "epic": 875,
+        "epic_status": "open",
+        "issues": [
+            {"number": 856, "status": "merged", "pr": 877, "depends_on": [],
+             "merge_sha": "33f31b5d65032121e750953e6b46f38421d6d921"},
+            {"number": 880, "status": "pr_open", "pr": 887, "depends_on": []},
+        ],
+    }
+
+    def test_a_real_campaign_names_its_children(self):
+        assert ll.broker_campaign_names_issue(self.REAL, 880) is True
+        assert ll.broker_campaign_names_issue(self.REAL, 856) is True
+
+    def test_a_real_campaign_does_not_name_a_foreign_issue(self):
+        assert ll.broker_campaign_names_issue(self.REAL, 999) is False
+
+    def test_the_legacy_children_shape_is_still_accepted(self):
+        """Kept working so no hand-written fixture elsewhere silently flips meaning."""
+        legacy = {"campaign": "c", "children": [{"issue": 963, "status": "in_progress"}]}
+        assert ll.broker_campaign_names_issue(legacy, 963) is True
+        assert ll.broker_campaign_names_issue(legacy, 964) is False
+
+    def test_a_bare_int_entry_is_still_accepted(self):
+        assert ll.broker_campaign_names_issue({"issues": [880]}, 880) is True
+        assert ll.broker_campaign_names_issue({"children": [880]}, 880) is True
+
+    def test_junk_is_refused_rather_than_raising(self):
+        assert ll.broker_campaign_names_issue(None, 1) is False
+        assert ll.broker_campaign_names_issue({}, 1) is False
+        assert ll.broker_campaign_names_issue({"issues": "nope"}, 1) is False
+        assert ll.broker_campaign_names_issue({"issues": [None, "x", 3.5]}, 1) is False
+
+    def test_the_shape_this_fixture_writes_matches_what_driver_lib_reads(self, tmp_path):
+        """The bug was a fixture that lied. Pin the fixture against the real reader."""
+        source = (HOOKS / "driver_lib.py").read_text(encoding="utf-8")
+        assert 'state.get("issues", [])' in source, \
+            "driver_lib reads issues[]; the broker fixture must write that shape"
+
+        root = _broker_workspace(tmp_path, campaign="c", issue=880, pr_number=887)
+        written = json.loads(
+            Path(root, "claude_docs", ".driver-state", "c.json").read_text())
+        assert "issues" in written and "children" not in written
+        assert written["issues"][0]["number"] == 880
+        assert written["issues"][0]["pr"] == 887
+        assert ll.broker_campaign_names_issue(written, 880) is True


### PR DESCRIPTION
Closes #976.

## What this does

Adds `hooks/campaign-merge-guard.py`, a `PreToolUse` hook on the `Bash` matcher that
refuses a raw `gh pr merge` when the target PR is a child of an **active** campaign, and
names the supervised broker command to run instead.

Before this, what routed a campaign merge into the broker was prose pinned by guard tests.
A prose-violating session reached the raw command and skipped authority evaluation, target
binding, the execute-once claim and the decision telemetry in one step.

## Acceptance criteria

| AC | How it is met |
|---|---|
| **1** refuse while a campaign is active, from durable state | Reads `claude_docs/.driver-state/*.json` only. A campaign is active while any `issues[]` entry is outside `{merged, deferred, abandoned}`. No environment variable or session field can turn it on or off — pinned by `test_ac1_decided_from_durable_state_not_session_context`. |
| **2** the broker's own merge is not blocked, no spoofable signal | The broker runs `subprocess.run(["gh","pr","merge",…], shell=False)` (`launcher_lib.py:5491`). `PreToolUse` fires per Claude Code **tool call**, not per OS process, so that merge never reaches the hook. The distinction is a **process boundary, not a token** — there is nothing to set, forge or leak. Probed live before the design was fixed: the exact shipped invocation ran with no interception. |
| **3** fail mode settled per path, reasoning recorded | Split at the classification boundary — see below. Recorded as decision **D186**. |
| **4** non-campaign merges unaffected | No `.rawgentic.json`, no `.driver-state/`, no active campaign, or no campaign naming this PR → allow. A `--repo` naming another repository → allow. WF3, hotfix and single-issue WF2 runs take these rows unchanged. |
| **5** legible denial | Every refusal names the campaign, the issue, the PR, the reason, and a runnable `broker-merge` command with the **discovered** project root. |

## AC3: the fail mode, and why it is split

The repo convention is that a security boundary which cannot evaluate fails CLOSED. The
counter-argument in the issue is that this hook runs on every Bash call, so a fail-closed
bug blocks every merge everywhere. Both are right, about different paths:

| Path | Mode | Why |
|---|---|---|
| stdin unparseable, no command field, startup exception | **ALLOW** + stderr diagnostic | a bug here would otherwise deny `ls` and `pytest` in every project on this host |
| no project root, or no `.driver-state/` | **ALLOW** | absence, not failure — the rule `docs/supervision.md` already states for supervision state |
| classified as a raw `gh pr merge`, state corrupt / oversized / unlexable / past the read cap | **DENY** | blast radius is exactly one refused command, and `broker-merge` is not a `gh pr merge` command line, so the sanctioned path stays open |

The boundary is **tracked in code**, not merely documented: `_CLASSIFIED` is read by the
outer exception handler, so a crash after classification denies.

## Scope was widened by one fix — owner decision D185

`broker_campaign_names_issue` read `state["children"][].issue`. `driver_lib` never writes
that key; real state is `issues[].number`. **Target binding therefore refused every real
campaign with rc 12**, and CI never caught it because the test fixture invented the same
wrong shape (`tests/hooks/test_launcher_lib.py:3272`).

Blocking the raw path while the broker refuses every real campaign would have shipped a
dead end, so the owner authorized widening by exactly this one fix. Switching the fixture
to the real shape turned **16 previously-green broker tests red** before the fix landed —
that is the measurement of how much the suite was not covering.

## What this is NOT — decision D187

It stops an **accidental** raw merge. It does **not** stop a deliberate bypass:
`PreToolUse` fires per tool call, not per OS process, so
`python3 -c "subprocess.run(['gh','pr','merge',…])"` is invisible to it. AC2 as literally
written is unsatisfiable by any `PreToolUse` design.

The cross-model reviewer raised exactly this (Critical, 0.99) and recommended moving the
merge credential into a broker service or enforcing merge-queue permissions GitHub-side.
**Declined for scope, not merit** — both are far larger than #976, and #963 declined the
same class. What was taken instead: every "hard enforcement" and "non-spoofable" claim is
gone from the design, `docs/supervision.md` and this PR, replaced with the honest threat
model — caller confusion and prose drift, the same one the broker states for its own
target binding (`launcher_lib.py:5300-5303`).

## Review

Two cross-model rounds with `gpt-5.6-sol`, **12 findings, all confirmed, all fixed**:

- **Step 4 (design):** 2 Critical, 2 High, 1 Medium. The ambiguity circuit breaker fired
  and the scope question went to the owner.
- **Step 8a:** 8 findings — file-cap applied before the `.json` filter (an active campaign
  past the cap vanished silently); the outer handler failing open past classification;
  campaign state resolved from the wrong directory on `cd X && gh pr merge`; a corrupt
  `issues` field read as settled; a flag value mistaken for the PR number; a separator
  inside a quoted string treated as a real one; a silent allow path; `--project-root .`
  wrong from a subdirectory.
- **Step 11:** 4 findings — including **a bypass introduced by the Step 8a fix**:
  stripping quotes wholesale turned `--repo "3D-Stories/rawgentic" --squash` into
  `--repo --squash`, read `--squash` as the repository, called it foreign, and allowed the
  merge. Classification now runs over `shlex` tokens, which keeps a quoted argument value
  intact while a quoted *mention* collapses to one token. Also: only the first merge in a
  Bash call was checked; a `"pr": "887"` string read as active-but-unmatchable; and the T0
  regression test asserted a source substring rather than behavior (it now drives
  `driver_lib.record_child_outcome` and feeds its output to the broker's reader).

Every fix carries the test case that exposed it.

## Verification

- **Suite 6210 → 6317, exit 0.** Baseline recorded on this branch's base (`ca529959`)
  before any work.
- Both pylint lanes 10.00/10, verbatim from `.github/workflows/lint.yml`.
- **Security scan: PASS.** One visible skip — `iac: not applicable to this project`. Not a
  silent pass.
- The new entry-type validation was checked against all five live campaign files on this
  host; none becomes `invalid`, so legitimate state is never refused.
- No workflow-spine change → **no diagram REV**.

## Deferred verification

None. Every acceptance criterion is verified locally by the suite.

## Noted, not filed (issue throttle, D179)

- **Per-child `{repo, issue, pr}` registration in driver state** — the other #963
  follow-up. This PR binds on the `pr` field that already exists plus the project's
  configured repo; a per-child repo would make the binding exact. Out of scope here.
- **`sh -c "gh pr merge …"` and other wrappers are not classified**, deliberately: a false
  positive blocks unrelated work in every project on this host, while this false negative
  only misses a form nobody reaches by accident. Consistent with D187.
- **Heredoc handling cuts at the first `<<`**, which can also cut a real command that
  follows one on the same line. Cutting only ever removes text, so it cannot manufacture a
  false denial; it is the same trade `step_state_post.executable_text` already makes.

Decisions recorded: **D185** (scope widening), **D186** (fail mode), **D187** (threat
model). The decision log's real tail was **D184**, not D189 — the handoff's own
phantom-id warning applied to its own number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
