### PR TITLE
fix(wf2,wf3): make the step-state bootstrap mandatory so a run records timing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.139.0",
+  "version": "3.139.1",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,26 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.139.1 (2026-08-07)
+- **A WF2 or WF3 run can no longer finish having recorded no timing at all (#976
+  follow-up).** The #976 run produced `{"status": "absent", "steps": [],
+  "skipped_lines": 0}` — zero per-step timing, from a run whose whole purpose was a clean
+  efficiency measurement. Cause: `step_state_post.main` stamps a signature command
+  (`git commit`, `gh pr create`, `broker-merge`, `work_summary.py summarize`) **only when
+  the step-state pointer already names the current session**, and the pointer is created
+  by exactly two things — a session-note `— DONE` marker, or an explicit
+  `step_state.py write`. Every skill called that write "OPTIONAL belt-and-suspenders" and
+  claimed the hook needed "no per-step action", so a run that wrote no markers could stamp
+  nothing, forever. On #976 the live pointer additionally still belonged to the previous
+  run's session, so the deliberate foreign-session guard dropped every stamp. The write is
+  now **MANDATORY once per run at the branch cut** — WF2 Step 7 and WF3 Step 6 — where the
+  workflow and issue are both known unambiguously, and the false "no per-step action
+  required" sentence is gone from all four skills that carried it. The foreign-session
+  guard is unchanged: it is correct, and panes share one pointer per project. Three
+  behavioral tests pin the mechanism (a signature alone never bootstraps; one bootstrap
+  unblocks every later signature; timing goes from `absent` to real steps) plus three prose
+  guards. No workflow-spine change → no diagram REV. Suite 6317→6323.
+
 ### v3.139.0 (2026-08-07)
 - **A raw `gh pr merge` is now BLOCKED while the target PR belongs to an active campaign,
   and the broker it routes to actually works again (#976).** #963 shipped the supervised

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.139.0",
+  "version": "3.139.1",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -114,7 +114,7 @@ This skill transmits the artifact's TEXT to the selected backend's provider for 
 At the end of each step, log a marker in `claude_docs/session_notes.md`:
 `### WF5 Step X: <Name> — DONE (<key detail>)`
 This enables workflow resumption if context is lost.
-Step-entry state (#480, hook-emitted since #499): the PostToolUse hook (`hooks/step_state_post.py`) derives the now-pointer automatically from step DONE markers and signature commands — no per-step action required. The manual `python3 hooks/step_state.py write --project <project> --workflow wf5 --step <N> --step-title "<step name>" --session-id "$CLAUDE_CODE_SESSION_ID"` call is OPTIONAL belt-and-suspenders for entry-time precision on prose-only steps. Fail-open either way (never gates; any failure is ignored and the step proceeds).
+Step-entry state (#480, hook-emitted since #499): the PostToolUse hook (`hooks/step_state_post.py`) stamps later steps from step DONE markers and signature commands — but ONLY once the step-state pointer already names this session, which a DONE marker or an explicit write creates. It does NOT stamp unaided: a run that creates no pointer contributes no timing at all (#976 measured exactly that). The manual `python3 hooks/step_state.py write --project <project> --workflow wf5 --step <N> --step-title "<step name>" --session-id "$CLAUDE_CODE_SESSION_ID"` call is OPTIONAL here: this workflow cuts no branch and carries no issue number, so it produces no per-run timing to protect. Fail-open either way (never gates; any failure is ignored and the step proceeds).
 </step-tracking>
 
 ---

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -74,7 +74,7 @@ rather than guessing:
   out-of-scope list naming what's deferred.
 </quality-bar>
 
-Step-entry state (#480, hook-emitted since #499): the PostToolUse hook (`hooks/step_state_post.py`) derives the now-pointer automatically from step DONE markers and signature commands — no per-step action required. The manual `python3 hooks/step_state.py write --project <project> --workflow wf1 --step <N> --step-title "<step name>" --session-id "$CLAUDE_CODE_SESSION_ID"` call is OPTIONAL belt-and-suspenders for entry-time precision on prose-only steps. Fail-open either way (never gates; any failure is ignored and the step proceeds).
+Step-entry state (#480, hook-emitted since #499): the PostToolUse hook (`hooks/step_state_post.py`) stamps later steps from step DONE markers and signature commands — but ONLY once the step-state pointer already names this session, which a DONE marker or an explicit write creates. It does NOT stamp unaided: a run that creates no pointer contributes no timing at all (#976 measured exactly that). The manual `python3 hooks/step_state.py write --project <project> --workflow wf1 --step <N> --step-title "<step name>" --session-id "$CLAUDE_CODE_SESSION_ID"` call is OPTIONAL here: this workflow cuts no branch and carries no issue number, so it produces no per-run timing to protect. Fail-open either way (never gates; any failure is ignored and the step proceeds).
 
 ## Step 1: Understand the request
 

--- a/skills/fix-bug/SKILL.md
+++ b/skills/fix-bug/SKILL.md
@@ -284,7 +284,7 @@ conform to its type's slot, and when a literal and this table diverge the table 
 Emitters: the key MUST land in the type's slot — a key anywhere else on the line is
 ignored by consumers. Deliberately un-keyed informational markers (trivial-work
 suggestion, unattended advisories) are declared deferrals, not misses.
-Step-entry state (#480, hook-emitted since #499): the PostToolUse hook (`hooks/step_state_post.py`) derives the now-pointer automatically from step DONE markers and signature commands — no per-step action required. The manual `python3 hooks/step_state.py write --project <project> --workflow wf3 --step <N> --step-title "<step name>" --issue <issue number> --session-id "$CLAUDE_CODE_SESSION_ID"` call is OPTIONAL belt-and-suspenders for entry-time precision on prose-only steps. Fail-open either way (never gates; any failure is ignored and the step proceeds).
+Step-entry state (#480, hook-emitted since #499): the PostToolUse hook (`hooks/step_state_post.py`) stamps later steps from step DONE markers and signature commands — but ONLY once the step-state pointer already names this session, which a DONE marker or an explicit write creates. It does NOT stamp unaided: a run that creates no pointer contributes no timing at all (#976 measured exactly that). The manual `python3 hooks/step_state.py write --project <project> --workflow wf3 --step <N> --step-title "<step name>" --issue <issue number> --session-id "$CLAUDE_CODE_SESSION_ID"` call is MANDATORY once per run at the branch cut (see that step) and useful belt-and-suspenders for entry-time precision on prose-only steps. Fail-open either way (never gates; any failure is ignored and the step proceeds).
 </step-tracking>
 
 <references>

--- a/skills/fix-bug/references/steps.md
+++ b/skills/fix-bug/references/steps.md
@@ -298,7 +298,26 @@ Fix plan with ordered tasks, file paths, and test expectations.
    git checkout -b fix/<issue-number>-<short-desc> origin/capabilities.default_branch
    ```
 3. Verify branch created successfully.
-4. **Pre-flight dependency check:** If the project's `config.techStack` includes npm/yarn/pnpm-based technologies (node, react, vue, angular, etc.) or a `package.json` exists in the project root, verify `node_modules` exists. If missing, run the appropriate install command (`npm install`, `yarn install`, or `pnpm install`) before proceeding to Step 7. Similarly, for Python projects with a `requirements.txt` or `pyproject.toml`, verify the virtual environment is active or dependencies are installed. This prevents test failures due to missing dependencies rather than actual bugs.
+4. **MANDATORY step-state bootstrap — run this before anything else on the branch.**
+   ```bash
+   python3 hooks/step_state.py write --project <project> --workflow wf3 --step 6 \
+     --step-title "Create Fix Branch" --issue <issue number> \
+     --session-id "$CLAUDE_CODE_SESSION_ID"
+   ```
+   **Why it is mandatory, and what breaks without it.** The PostToolUse hook stamps later
+   steps from signature commands (`git commit`, `gh pr create`, `broker-merge`,
+   `work_summary.py summarize`), but it stamps **only when the step-state pointer already
+   names this session** — `step_state_post.main` returns early otherwise, and that
+   foreign-session guard is deliberate, because panes share one pointer per project. The
+   pointer is created by exactly two things: a session-note `— DONE` marker, or this call.
+
+   So a run that skips this **can never stamp anything**. Every later signature command is
+   dropped silently and the run contributes **no timing at all**. That is not theoretical:
+   the #976 run produced `{"status": "absent", "steps": [], "skipped_lines": 0}`, because
+   it wrote no markers and the live pointer still belonged to the previous run's session.
+
+   Fail-open as always — a failure here is ignored and the step proceeds. Run it anyway.
+5. **Pre-flight dependency check:** If the project's `config.techStack` includes npm/yarn/pnpm-based technologies (node, react, vue, angular, etc.) or a `package.json` exists in the project root, verify `node_modules` exists. If missing, run the appropriate install command (`npm install`, `yarn install`, or `pnpm install`) before proceeding to Step 7. Similarly, for Python projects with a `requirements.txt` or `pyproject.toml`, verify the virtual environment is active or dependencies are installed. This prevents test failures due to missing dependencies rather than actual bugs.
 
 ### Output
 

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -480,7 +480,7 @@ Emitters: the key MUST land in the type's slot — a key anywhere else on the li
 ignored by consumers. Deliberately un-keyed informational markers (path-estimate,
 path-estimate refresh, trivial-work suggestion, unattended Step 14/15 skip) are declared
 deferrals, not misses — they are print-and-continue advisories no consumer attributes.
-Step-entry state (#480, hook-emitted since #499): the PostToolUse hook (`hooks/step_state_post.py`) derives the now-pointer automatically from step DONE markers and signature commands — no per-step action required. The manual `python3 hooks/step_state.py write --project <project> --workflow wf2 --step <N> --step-title "<step name>" --issue <issue number> --session-id "$CLAUDE_CODE_SESSION_ID"` call is OPTIONAL belt-and-suspenders for entry-time precision on prose-only steps. Fail-open either way (never gates; any failure is ignored and the step proceeds).
+Step-entry state (#480, hook-emitted since #499): the PostToolUse hook (`hooks/step_state_post.py`) stamps later steps from step DONE markers and signature commands — but ONLY once the step-state pointer already names this session, which a DONE marker or an explicit write creates. It does NOT stamp unaided: a run that creates no pointer contributes no timing at all (#976 measured exactly that). The manual `python3 hooks/step_state.py write --project <project> --workflow wf2 --step <N> --step-title "<step name>" --issue <issue number> --session-id "$CLAUDE_CODE_SESSION_ID"` call is MANDATORY once per run at the branch cut (see that step) and useful belt-and-suspenders for entry-time precision on prose-only steps. Fail-open either way (never gates; any failure is ignored and the step proceeds).
 </step-tracking>
 
 <references>

--- a/skills/implement-feature/references/step-07.md
+++ b/skills/implement-feature/references/step-07.md
@@ -19,12 +19,23 @@
    ```
    `BASE_MISMATCH` → STOP and reconcile before writing any code (do not build on a wrong base). Because nothing is pulled into the current checkout, no pre-existing branch is mutated as a side effect.
 
-3. Push empty branch to origin:
+3. **MANDATORY step-state bootstrap — before anything else on the branch.**
+   ```bash
+   python3 hooks/step_state.py write --project <project> --workflow wf2 --step 7 \
+     --step-title "Create Branch" --issue <issue number> \
+     --session-id "$CLAUDE_CODE_SESSION_ID"
+   ```
+   The hook stamps later steps ONLY once the pointer names this session, and only a
+   `— DONE` marker or this call creates it. Skip it and the run records **no timing at
+   all** (#976 did). Fail-open — run it anyway. Why:
+   `TestSignatureStampingNeedsABootstrap`.
+
+4. Push empty branch to origin:
    ```bash
    git push -u origin <branch_name>
    ```
 
-4. Link branch to issue:
+5. Link branch to issue:
    ```bash
    gh issue comment <issue_number> --repo ${capabilities.repo} --body "Implementation started on branch \`<branch_name>\`"
    ```

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.139.0"
+EXPECTED_PLUGIN_VERSION = "3.139.1"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_step_state.py
+++ b/tests/hooks/test_step_state.py
@@ -267,9 +267,15 @@ def test_step_entry_prose_pin_all_five_skills():
         assert "step_state.py write --project" in text, f"{skill}: entry-call line missing"
         assert token in text, f"{skill}: wrong workflow token"
         assert "fail-open" in text.lower(), f"{skill}: fail-open clause missing"
-        # #499: emission is hook-owned; the manual call is optional belt-and-suspenders.
+        # #499: emission is hook-owned. #976 follow-up: "hook-owned" never meant
+        # "unaided" — the pointer must be bootstrapped before any signature can stamp,
+        # so the two branch-cut workflows mark the call MANDATORY and the rest OPTIONAL.
         assert "hook-emitted since #499" in text, f"{skill}: hook-emission clause missing"
-        assert "OPTIONAL" in text, f"{skill}: the manual call must be marked optional"
+        expected_mode = "MANDATORY" if skill in ("implement-feature", "fix-bug") \
+            else "OPTIONAL"
+        assert expected_mode in text, (
+            f"{skill}: the manual call must be marked {expected_mode} — see "
+            "TestBranchCutBootstrapIsMandatory for why the branch-cut ones differ")
 
 
 # --- Step-11 join fixes (#480): reader honesty + import fail-open ------------------
@@ -520,3 +526,62 @@ def test_status_complete_reachable_at_live_assembly():
     wf3 = [_ev("1", "2026-07-19T10:00:00Z", workflow="wf3"),
            _ev("10", "2026-07-19T10:30:00Z", workflow="wf3")]
     assert ss.compute_timing(wf3, idle_threshold_s=1800)["status"] == "complete"
+
+
+# --- #976 follow-up: the branch-cut bootstrap is MANDATORY, not optional ----------
+
+class TestBranchCutBootstrapIsMandatory:
+    """The #976 run produced ZERO timing, and the prose is why.
+
+    The signature path only stamps when the pointer already names this session, and
+    only a session-note DONE marker or an explicit `step_state.py write` creates that
+    pointer. While every skill called that write "OPTIONAL belt-and-suspenders", a run
+    that wrote no markers could — and did — contribute no timing at all.
+
+    The behavioral proof lives in
+    `tests/hooks/test_step_state_hook.py::TestSignatureStampingNeedsABootstrap`.
+    These pin the prose that makes it happen.
+    """
+
+    #: The two workflows that cut a branch and carry an issue number, so the two whose
+    #: runs can produce timing at all.
+    BRANCH_CUT_SKILLS = {
+        "implement-feature": ("wf2", "7"),
+        "fix-bug": ("wf3", "6"),
+    }
+
+    ALL_SKILLS = ("create-issue", "implement-feature", "fix-bug",
+                  "adversarial-review", "epic-run")
+
+    def _corpus(self, skill):
+        base = HOOKS_DIR.parent / "skills" / skill
+        text = (base / "SKILL.md").read_text(encoding="utf-8")
+        refs = base / "references"
+        if refs.is_dir():
+            for path in sorted(refs.glob("*.md")):
+                text += "\n" + path.read_text(encoding="utf-8")
+        return text
+
+    def test_no_skill_still_claims_the_hook_needs_no_action(self):
+        """The false sentence that caused the gap. It must be gone everywhere."""
+        for skill in self.ALL_SKILLS:
+            assert "no per-step action required" not in self._corpus(skill), (
+                f"{skill}: the hook does NOT stamp unaided — the pointer must be "
+                "bootstrapped before any signature command can stamp")
+
+    def test_the_branch_cut_skills_mark_the_bootstrap_mandatory(self):
+        for skill, (workflow, step) in self.BRANCH_CUT_SKILLS.items():
+            corpus = self._corpus(skill)
+            assert "MANDATORY step-state bootstrap" in corpus, \
+                f"{skill}: the bootstrap must be named as mandatory"
+            assert f"--workflow {workflow} --step {step}" in corpus, \
+                f"{skill}: the bootstrap must name the branch-cut step"
+
+    def test_the_bootstrap_sits_at_the_branch_cut(self):
+        """Next to `git checkout -b`, so it runs once, early, and cannot be forgotten."""
+        for skill in self.BRANCH_CUT_SKILLS:
+            corpus = self._corpus(skill)
+            cut = corpus.index("git checkout -b")
+            call = corpus.index("MANDATORY step-state bootstrap")
+            assert abs(call - cut) < 2500, \
+                f"{skill}: the bootstrap drifted away from the branch cut"

--- a/tests/hooks/test_step_state_hook.py
+++ b/tests/hooks/test_step_state_hook.py
@@ -531,3 +531,79 @@ class TestSignaturesIgnoreQuotedAndHeredocText:
         state read on every grep — the cost the prefilter exists to avoid."""
         assert ssp._may_have_signature("grep -rn 'gh pr merge' skills/") is False
         assert ssp._may_have_signature("gh pr merge 973 --squash") is True
+
+
+class TestSignatureStampingNeedsABootstrap:
+    """Why the branch-cut `step_state.py write` is MANDATORY, not optional.
+
+    Measured on the #976 run, which produced ZERO timing: `step_state.py timing
+    --issue 976` returned `{"status": "absent", "steps": [], "skipped_lines": 0}`.
+
+    The signature path reads the pointer and returns early unless it already names
+    THIS session (`step_state_post.main`). Only a session-note DONE marker or an
+    explicit `step_state.py write` creates that pointer. So a run that writes neither
+    can never stamp anything: every later `git commit`, `gh pr create` and
+    `broker-merge` is silently dropped, and the whole run contributes no timing.
+
+    On #976 the live pointer additionally belonged to a DIFFERENT session (the #963
+    run), so the foreign-session guard — which is deliberate and pinned by
+    `test_branch_cut_never_stamps_foreign_session` — dropped every stamp for the
+    entire run.
+    """
+
+    SIGNATURE_CMD = "gh pr create --title x --body y"
+
+    def test_a_signature_alone_never_bootstraps_the_pointer(self, tmp_path):
+        """The deadlock, stated as a test: no pointer, so no stamp, forever."""
+        ws = _mk_workspace(tmp_path, session_id="sess-boot")
+        r = _run_hook(ws, {"session_id": "sess-boot", "tool_name": "Bash",
+                           "tool_input": {"command": self.SIGNATURE_CMD}})
+        assert r.returncode == 0
+        assert not (ws / "claude_docs" / "wal" / "rawgentic.state.json").exists(), \
+            "a signature command must not invent a run it cannot identify"
+
+    def test_an_explicit_bootstrap_unblocks_every_later_signature(self, tmp_path):
+        """And the fix, stated as a test: one write at the branch cut is enough."""
+        ws = _mk_workspace(tmp_path, session_id="sess-boot")
+        state_dir = ws / "claude_docs" / "wal"
+        subprocess.run(
+            [sys.executable, str(HOOKS / "step_state.py"), "write",
+             "--project", "rawgentic", "--workflow", "wf2", "--step", "7",
+             "--step-title", "Create Branch", "--issue", "976",
+             "--session-id", "sess-boot", "--state-dir", str(state_dir)],
+            capture_output=True, text=True, timeout=30, check=True)
+
+        r = _run_hook(ws, {"session_id": "sess-boot", "tool_name": "Bash",
+                           "tool_input": {"command": self.SIGNATURE_CMD}})
+        assert r.returncode == 0
+        rec = json.loads((state_dir / "rawgentic.state.json").read_text())
+        assert rec["step"] == "12", "the same command that wrote nothing now stamps"
+        assert rec["issue"] == 976
+
+    def test_the_bootstrap_turns_absent_timing_into_real_timing(self, tmp_path):
+        """The property the run actually needs — timing that is not `absent`."""
+        ws = _mk_workspace(tmp_path, session_id="sess-boot")
+        state_dir = ws / "claude_docs" / "wal"
+
+        def timing():
+            out = subprocess.run(
+                [sys.executable, str(HOOKS / "step_state.py"), "timing",
+                 "--project", "rawgentic", "--issue", "976",
+                 "--state-dir", str(state_dir)],
+                capture_output=True, text=True, timeout=30, check=False).stdout
+            return json.loads(out)
+
+        assert timing()["status"] == "absent"
+
+        subprocess.run(
+            [sys.executable, str(HOOKS / "step_state.py"), "write",
+             "--project", "rawgentic", "--workflow", "wf2", "--step", "7",
+             "--step-title", "Create Branch", "--issue", "976",
+             "--session-id", "sess-boot", "--state-dir", str(state_dir)],
+            capture_output=True, text=True, timeout=30, check=True)
+        _run_hook(ws, {"session_id": "sess-boot", "tool_name": "Bash",
+                       "tool_input": {"command": self.SIGNATURE_CMD}})
+
+        after = timing()
+        assert after["status"] != "absent"
+        assert [s["step"] for s in after["steps"]] == ["7", "12"]

--- a/tests/test_wf2_prose_budget.py
+++ b/tests/test_wf2_prose_budget.py
@@ -69,7 +69,15 @@ SKILL_DIR = REPO_ROOT / "skills" / "implement-feature"
 # residual growth over the pre-#761 4_108 is a genuinely NEW gated sub-step, not commentary —
 # resolve-and-snapshot did not exist before, and its three failure gates are the Step-8a/Step-11
 # findings. That is the honest distinction: trim commentary, keep operative prose.
-TOTAL_CEILING_BYTES = 253_190
+# #976 follow-up (2026-08-07): step-07.md 2_124 -> 2_545 and the total 253_190 -> 253_611.
+# TRIMMED FIRST, per the #903 precedent: the rationale was cut twice (3_142 -> 2_501 -> 2_422)
+# before any raise. The residual is a genuinely NEW operative sub-step, not commentary — a
+# MANDATORY `step_state.py write` at the branch cut. Without it the PostToolUse hook can never
+# stamp a signature command, because it stamps only once the step-state pointer names this
+# session, and only a `— DONE` marker or that write creates the pointer. The #976 run proved
+# the cost: `{"status": "absent", "steps": [], "skipped_lines": 0}` — a whole run with no
+# timing. Trim commentary, keep operative prose: the command and its four-line why are operative.
+TOTAL_CEILING_BYTES = 253_611
 PER_FILE_CEILING_BYTES = {
     "SKILL.md": 46_099,
     "references/quality-bar.md": 3_616,
@@ -83,7 +91,7 @@ PER_FILE_CEILING_BYTES = {
     "references/step-04.md": 23_727,
     "references/step-05.md": 7_818,
     "references/step-06.md": 2_995,
-    "references/step-07.md": 2_124,
+    "references/step-07.md": 2_545,
     "references/step-08.md": 23_557,
     "references/step-09.md": 6_416,
     "references/step-10.md": 1_201,


### PR DESCRIPTION
Follow-up to #976. No issue was filed — the issue throttle (D179) leaves that call to you.

## The bug

The #976 run finished having recorded **no timing at all**:

```
step_state.py timing --project rawgentic --issue 976
{"status": "absent", "steps": [], "skipped_lines": 0}
```

Its whole purpose was a clean efficiency measurement.

## Root cause

`step_state_post.main` stamps a signature command (`git commit`, `gh pr create`, `broker-merge`, `work_summary.py summarize`) **only when the step-state pointer already names the current session**. The pointer is created by exactly two things: a session-note `— DONE` marker, or an explicit `step_state.py write`.

Every workflow skill called that write **"OPTIONAL belt-and-suspenders"** and claimed the hook needed **"no per-step action required"**. Together those mean a run that writes no markers can never stamp anything — so it contributes no timing, silently.

On #976 the live pointer additionally still belonged to the **previous run's session** (`270841f8`, issue 964, written one minute before this run started), so the foreign-session guard dropped every stamp for the entire run.

## Fix

The write is **MANDATORY once per run at the branch cut** — WF2 Step 7, WF3 Step 6. That is the one place where the workflow and the issue number are both known unambiguously, and it happens before any signature command. The false "no per-step action required" sentence is gone from all four skills that carried it.

WF1 and WF5 keep the call `OPTIONAL`, and now say why: they cut no branch and carry no issue, so they have no per-run timing to protect.

## Deliberately not changed

- **The foreign-session guard.** It is correct — panes share one pointer per project — and `test_branch_cut_never_stamps_foreign_session` pins it.
- **Teaching the hook to guess a workflow from a branch cut.** `git checkout -b ` maps to wf2 step 7 **and** wf3 step 6. Guessing would mislabel runs, and wrong timing is worse than absent timing.

## Verification

Three behavioral tests pin the mechanism, and I ran the sequence live before writing them:

1. a signature command alone never bootstraps the pointer — nothing is written;
2. one bootstrap write makes **the same command** stamp Step 12;
3. timing goes from `absent` to real steps `["7", "12"]`.

Three prose guards pin the wording. I also verified the command **as written in the skill** (no `--state-dir`) resolves from the project root to `/home/rocky00717/rawgentic/claude_docs/wal` — exactly where the hook reads.

- Suite **6317 → 6323, exit 0**
- Both pylint lanes 10.00/10
- Security scan PASS, one visible skip (`iac`, not applicable)
- No workflow-spine change → **no diagram REV**

## Prose ceiling raised, with the reason

`step-07.md` 2_124 → 2_545 (total 253_190 → 253_611). **Trimmed first**, per the #903 precedent: 3_142 → 2_501 → 2_422 before any raise. The residual is a new *operative* sub-step — a required command — not commentary.

## Not covered by this fix

This makes a run *able* to record timing. It does not make the WF2 session-note `— DONE` markers happen; those remain prose, and #976 skipped them too. The bootstrap is what turns that from "no data" into "signature-derived data".

🤖 Generated with [Claude Code](https://claude.com/claude-code)