### PR TITLE
fix(wal): rotation clobbered concurrent sessions' entries — lock it

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.139.1",
+  "version": "3.139.2",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,27 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.139.2 (2026-08-07)
+- **WAL rotation no longer destroys concurrent sessions' log entries.** `session-start`
+  filtered a snapshot of the WAL and `cp`-ed the result back over the live file with **no
+  lock**, so every append another session made between the read and the `cp` was lost.
+  Measured on a six-pane host: **3034 `INTENT` entries across all projects carry no outcome
+  at all** — 19% of 16037 operations — and one session lost a contiguous hour of entries
+  while a sibling pane ran. Losing a `DONE` whose `INTENT` survives orphans that operation
+  **forever**, because rotation deliberately keeps incomplete entries regardless of age, so
+  the pile can only grow; July, the heaviest concurrent-run month, holds 1715 of them. The
+  rewrite now holds an exclusive `flock` on `<wal>.lock` and **re-reads the WAL inside the
+  lock** — filtering the pre-lock snapshot would clobber exactly the appends the lock
+  exists to protect — and `wal_append_phase` takes the same lock. The two sides fail in
+  **opposite** directions on purpose: rotation is rare and destructive, so no lock means
+  **no rotation** (a growing file is recoverable, a clobbered one is not); the append runs
+  on every tool call and is additive, so it **proceeds** past a busy lock rather than cost a
+  log line. Verified red against the pre-fix hook: it rewrote 10400 lines to 5200 while a
+  child process held the lock, where the fixed hook leaves the file untouched. Waits are
+  env-tunable (`RAWGENTIC_WAL_ROTATE_LOCK_WAIT_S`, `RAWGENTIC_WAL_APPEND_LOCK_WAIT_S`).
+  `wal-guard` still denies under `strict`, confirmed directly. No workflow-spine change →
+  no diagram REV. Suite 6323→6328.
+
 ### v3.139.1 (2026-08-07)
 - **A WF2 or WF3 run can no longer finish having recorded no timing at all (#976
   follow-up).** The #976 run produced `{"status": "absent", "steps": [],

--- a/docs/wal-guide.md
+++ b/docs/wal-guide.md
@@ -107,6 +107,20 @@ runs WAL recovery:
 2. **Sanitize** -- pipes through `jq -c '.'`, discarding non-JSON lines.
 3. **Rotate** -- when the file exceeds **5000 lines**, entries older than
    **7 days** are pruned. Incomplete operations are preserved regardless of age.
+   The rewrite happens **under an exclusive `flock` on `<wal>.lock`**, and the filter
+   **re-reads the WAL inside that lock** -- `wal_append_phase` takes the same lock, so an
+   append can never land in the window where rotation is truncating the file. Before this,
+   rotation filtered a snapshot taken *before* the rewrite and `cp`-ed the result back with
+   no lock at all, so every append another session made in between was destroyed. Measured
+   2026-08-07: **3034 INTENT entries across all projects carried no outcome** -- 19% of
+   16037 operations -- and one session lost a contiguous hour of entries while a sibling
+   pane ran. Losing a `DONE` whose `INTENT` survives orphans that operation *forever*,
+   because this step keeps incomplete entries regardless of age, so the pile only grows.
+   **No lock, no rotation:** if `flock` is missing or the lock is held past
+   `RAWGENTIC_WAL_ROTATE_LOCK_WAIT_S` (default 5), the rewrite is skipped. A growing file
+   is recoverable; a clobbered one is not. The append side is the opposite --
+   **fail-OPEN** past `RAWGENTIC_WAL_APPEND_LOCK_WAIT_S` (default 2) -- because it runs on
+   every tool call and must never cost a log line.
 4. **Report** -- incomplete INTENT entries (no DONE/FAIL) are injected into the
    session context as a recovery notice (up to 20 shown). Entries older than
    **`WAL_RECOVERY_MAX_AGE_DAYS`** (default **7**, clamped to [1,365]; a malformed

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -382,28 +382,50 @@ _do_wal_ops() {
     "$JQ" -c '.' "$WAL_FILE" 2>/dev/null > "$CLEAN_FILE" || true
     [ -s "$CLEAN_FILE" ] || { rm -f "$CLEAN_FILE"; return 0; }
 
-    # WAL Rotation (>5000 lines)
+    # WAL Rotation (>5000 lines) — UNDER AN EXCLUSIVE LOCK.
+    #
+    # This used to filter the pre-read snapshot and `cp` it over the live file with no
+    # lock at all. Every append another session made between the read and the `cp` was
+    # destroyed. Measured 2026-08-07: 3034 INTENT entries across all projects carry no
+    # outcome — 19% of 16037 operations — and one session lost a contiguous hour of
+    # entries while a sibling pane ran. Losing a DONE while its INTENT survives orphans
+    # that operation forever, because rotation deliberately KEEPS incomplete entries
+    # regardless of age, so the pile can only grow.
+    #
+    # Two properties matter, and the snapshot gives neither:
+    #   1. the filter must re-read the WAL *inside* the lock — a snapshot taken before
+    #      the lock is already stale, so filtering it would clobber exactly the appends
+    #      the lock exists to protect;
+    #   2. no lock means NO ROTATION. Skipping only grows the file, which is recoverable;
+    #      clobbering destroys audit data permanently (registry_prune.py's fail-safe-KEEP
+    #      convention: data you cannot safely handle is kept, never dropped).
     LINE_COUNT=$(wc -l < "$CLEAN_FILE")
     if [ "$LINE_COUNT" -gt 5000 ]; then
         CUTOFF=$(date -u -d '7 days ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v-7d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || printf '')
-        if [ -n "$CUTOFF" ]; then
-            ROTATED=$("$JQ" -sc --arg cutoff "$CUTOFF" '
-                (group_by(.tool_use_id)
-                 | map(select(
-                     (map(.phase) | index("INTENT")) != null
-                     and (map(.phase) | index("DONE")) == null
-                     and (map(.phase) | index("FAIL")) == null
-                   ))
-                 | map(.[0].tool_use_id)
-                ) as $incomplete_ids
-                |
-                [.[] | select(.ts >= $cutoff or (.tool_use_id as $id | $incomplete_ids | index($id) != null))]
-                | .[]
-            ' "$CLEAN_FILE" 2>/dev/null) || true
-            if [ -n "$ROTATED" ]; then
-                printf '%s\n' "$ROTATED" > "$CLEAN_FILE"
-                cp "$CLEAN_FILE" "$WAL_FILE"
-            fi
+        if [ -n "$CUTOFF" ] && command -v flock >/dev/null 2>&1; then
+            ROT_TMP=$(mktemp)
+            (
+                # Non-blocking with a bounded wait: a session start must never hang on a
+                # busy WAL. Failing to acquire exits the subshell and skips rotation.
+                flock -w "${RAWGENTIC_WAL_ROTATE_LOCK_WAIT_S:-5}" 9 || exit 9
+                "$JQ" -sc --arg cutoff "$CUTOFF" '
+                    (group_by(.tool_use_id)
+                     | map(select(
+                         (map(.phase) | index("INTENT")) != null
+                         and (map(.phase) | index("DONE")) == null
+                         and (map(.phase) | index("FAIL")) == null
+                       ))
+                     | map(.[0].tool_use_id)
+                    ) as $incomplete_ids
+                    |
+                    [.[] | select(.ts >= $cutoff or (.tool_use_id as $id | $incomplete_ids | index($id) != null))]
+                    | .[]
+                ' "$WAL_FILE" > "$ROT_TMP" 2>/dev/null || exit 8
+                # An empty result is never written: it would blank the WAL outright.
+                [ -s "$ROT_TMP" ] || exit 7
+                cat "$ROT_TMP" > "$WAL_FILE"
+            ) 9>"$WAL_FILE.lock" || true
+            rm -f "$ROT_TMP"
         fi
     fi
 

--- a/hooks/wal-lib.sh
+++ b/hooks/wal-lib.sh
@@ -184,6 +184,20 @@ wal_append_phase() {
   local ts
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+  # Take the SAME lock session-start's rotation takes, so an append can never land in
+  # the window where rotation is rewriting the file (its `cat > "$WAL_FILE"` truncates).
+  # `>>` alone is atomic against other APPENDS, but not against a rewrite.
+  #
+  # FAIL-OPEN, deliberately, and opposite to rotation's fail-safe-skip: this runs on
+  # every tool call and only records observational data, so a busy lock must never cost
+  # a log line (the wal-bind-guard:7 convention for logging/convenience paths). Rotation
+  # is the rare, destructive side and skips instead; the append is the frequent, additive
+  # side and proceeds. Worst case is the pre-existing behavior, one lost line.
+  {
+    if command -v flock >/dev/null 2>&1; then
+      flock -w "${RAWGENTIC_WAL_APPEND_LOCK_WAIT_S:-2}" 9 2>/dev/null || true
+    fi
+
   if [ "$phase" = "INTENT" ]; then
     "$WAL_JQ" -nc \
       --arg ts "$ts" \
@@ -204,6 +218,7 @@ wal_append_phase() {
       '{ts:$ts, phase:$phase, session:$session, tool:$tool, tool_use_id:$tool_use_id}' \
       >> "$WAL_FILE"
   fi
+  } 9>>"$WAL_FILE.lock"
 }
 
 # --- Project name validation ---

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.139.1",
+  "version": "3.139.2",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.139.1"
+EXPECTED_PLUGIN_VERSION = "3.139.2"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_session_start.py
+++ b/tests/hooks/test_session_start.py
@@ -2,6 +2,8 @@
 import hashlib
 import json
 import os
+import shutil
+import time
 from pathlib import Path
 
 import pytest
@@ -1125,3 +1127,166 @@ class TestSpawnConsolidation:
             "a newline in session_id shifted EVENT_TYPE in the jq-fallback "
             "transport"
         )
+
+
+class TestWalRotationDoesNotClobberConcurrentWrites:
+    """WAL rotation read the file, filtered it, then `cp`-ed the result back over it.
+
+    With no lock, every append another session made between the read and the `cp` was
+    destroyed. Measured on this host: 3034 INTENT entries across all projects carry no
+    outcome at all — 19% of 16037 operations — and one session lost a contiguous hour of
+    entries while a sibling pane ran. Losing a DONE while its INTENT survives orphans that
+    operation FOREVER, because rotation deliberately preserves incomplete entries
+    regardless of age (docs/wal-guide.md).
+
+    Appends themselves are safe: `wal_append_phase` uses `>>` (O_APPEND) with one short
+    write. It is the rotation rewrite that loses them.
+    """
+
+    PROJECT = "testproj"
+
+    def _ws(self, make_workspace):
+        """An EXPLICIT registry entry: without it `_registry_project` is empty,
+        session-start falls back to a legacy WAL that does not exist, and rotation never
+        runs — which is how the first draft of these tests passed vacuously."""
+        return make_workspace(registry_entries=[{
+            "session_id": "test-sess", "project": self.PROJECT,
+            "project_path": f"./projects/{self.PROJECT}",
+            "started": "2026-08-07T00:00:00Z"}])
+
+    def _wal(self, ws):
+        return ws.claude_docs / "wal" / f"{self.PROJECT}.jsonl"
+
+    def _big_wal(self, ws, pairs=2600):
+        """Over the 5000-line threshold, with BOTH prunable and surviving entries.
+
+        Both halves are needed. All-old would prune to nothing, `ROTATED` would be empty,
+        and the `cp` would never run — so a fixture without recent rows tests nothing.
+        """
+        import datetime as _dt
+        recent = (_dt.datetime.now(_dt.timezone.utc)
+                  - _dt.timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        rows = []
+        for i in range(pairs):                      # old + complete -> pruned
+            rows.append(json.dumps({
+                "ts": "2026-01-01T00:00:00Z", "phase": "INTENT", "session": "old",
+                "tool": "Bash", "tool_use_id": f"old-{i}", "summary": "x", "cwd": "/tmp"}))
+            rows.append(json.dumps({
+                "ts": "2026-01-01T00:00:01Z", "phase": "DONE", "session": "old",
+                "tool": "Bash", "tool_use_id": f"old-{i}"}))
+        for i in range(pairs):                      # recent -> survives the rewrite
+            rows.append(json.dumps({
+                "ts": recent, "phase": "INTENT", "session": "new", "tool": "Bash",
+                "tool_use_id": f"new-{i}", "summary": "y", "cwd": "/tmp"}))
+            rows.append(json.dumps({
+                "ts": recent, "phase": "DONE", "session": "new", "tool": "Bash",
+                "tool_use_id": f"new-{i}"}))
+        wal = self._wal(ws)
+        wal.parent.mkdir(parents=True, exist_ok=True)
+        wal.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        return wal
+
+    def test_the_fixture_actually_triggers_a_rewrite(self, make_workspace):
+        """Guard the guard: without this, the test below passes vacuously."""
+        ws = self._ws(make_workspace)
+        wal = self._big_wal(ws)
+        before = wal.read_text(encoding="utf-8")
+        _stdout, _stderr, rc = _run_session_start(ws.root)
+        assert rc == 0
+        after = wal.read_text(encoding="utf-8")
+        assert after != before, "rotation did not rewrite — the fixture proves nothing"
+        assert "old-0" not in after and "new-0" in after
+
+    def test_rotation_is_skipped_when_the_lock_cannot_be_taken(self, make_workspace):
+        """No lock, no rewrite.
+
+        Deterministic and concurrency-free: a DIRECTORY at the lock path can never be
+        opened for writing, so `flock` cannot acquire and rotation must decline. (An
+        earlier draft held the lock from a child process and wedged pytest — the
+        property under test is the same, this way it is reliable.)
+
+        Skipping only grows the WAL, which is recoverable. Clobbering destroys audit
+        data permanently, so this is the fail-safe direction.
+        """
+        ws = self._ws(make_workspace)
+        wal = self._big_wal(ws)
+        before = wal.read_text(encoding="utf-8")
+        (Path(str(wal) + ".lock")).mkdir()
+
+        _stdout, _stderr, rc = _run_session_start(ws.root)
+        assert rc == 0, "session-start must never fail because rotation was skipped"
+        assert wal.read_text(encoding="utf-8") == before, (
+            "rotation rewrote the WAL without holding the lock — that is exactly the "
+            "window in which concurrent appends are destroyed")
+
+    def test_rotation_creates_the_lock_it_shares_with_appenders(self, make_workspace):
+        """The lock path must be the one `wal_append_phase` uses, or neither blocks."""
+        ws = self._ws(make_workspace)
+        wal = self._big_wal(ws)
+        _stdout, _stderr, rc = _run_session_start(ws.root)
+        assert rc == 0
+        assert Path(str(wal) + ".lock").exists(), "rotation took no lock at all"
+
+        lib = (Path(__file__).resolve().parents[2] / "hooks" / "wal-lib.sh") \
+            .read_text(encoding="utf-8")
+        assert '9>>"$WAL_FILE.lock"' in lib, \
+            "appends must lock the SAME path rotation locks"
+        assert "flock" in lib, "wal_append_phase does not take the lock"
+
+    def test_rotation_does_not_rewrite_while_another_writer_holds_the_lock(
+        self, make_workspace
+    ):
+        """The defect itself, as a test. Verified red against the pre-fix hook:
+        it rewrote 10400 lines down to 5200 while a child process held the lock.
+
+        The lock is held by a CHILD, never by this process — holding an `fcntl` lock
+        here across a subprocess call wedges pytest. The hook is spawned directly for
+        the same reason `TestScannerInstallLeakGuard` does it.
+        """
+        import subprocess as sp
+        from tests.hooks.conftest import HOOKS_DIR
+        ws = self._ws(make_workspace)
+        wal = self._big_wal(ws)
+        before = wal.read_text(encoding="utf-8")
+        lock_path = str(wal) + ".lock"
+
+        holder = sp.Popen(["flock", "-x", lock_path, "sleep", "30"],
+                          stdin=sp.DEVNULL, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+        try:
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                probe = sp.run(["flock", "-n", "-x", lock_path, "true"], check=False,
+                               stdin=sp.DEVNULL, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+                if probe.returncode != 0:
+                    break
+                time.sleep(0.05)
+            else:
+                pytest.skip("could not get the child to hold the lock")
+
+            home = ws.root / ".test_home"
+            home.mkdir(exist_ok=True)
+            proc = sp.run(
+                ["bash", str(HOOKS_DIR / "session-start")],
+                input=json.dumps({"session_id": "test-sess", "cwd": str(ws.root),
+                                  "hook_event_name": "SessionStart", "source": "startup"}),
+                capture_output=True, text=True, timeout=90, cwd=str(ws.root),
+                env={**os.environ, "HOME": str(home),
+                     "RAWGENTIC_WAL_ROTATE_LOCK_WAIT_S": "1"})
+            assert proc.returncode == 0, \
+                "session-start must never fail because rotation was blocked"
+            assert wal.read_text(encoding="utf-8") == before, (
+                "rotation rewrote the WAL while another writer held the lock — that is "
+                "exactly the window in which concurrent appends are destroyed")
+        finally:
+            holder.kill()
+            holder.wait(timeout=10)
+
+    def test_rotation_still_runs_when_the_lock_is_free(self, make_workspace):
+        """And the lock must not disable rotation in the ordinary single-writer case."""
+        ws = self._ws(make_workspace)
+        wal = self._big_wal(ws)
+        _stdout, _stderr, rc = _run_session_start(ws.root)
+        assert rc == 0
+        after = wal.read_text(encoding="utf-8")
+        assert "old-0" not in after, "rotation stopped working"
+        assert "new-0" in after


### PR DESCRIPTION
Found while investigating the 306-incomplete-operations notice at session start. No issue filed — the throttle (D179) leaves that to you.

## Correcting my own report first

I originally told you there were **two** defects. **Only one is real.** I claimed the recovery report counted `FAIL`-ed operations as incomplete. It does not — `session-start:417` already carries `and (map(.phase) | index("FAIL")) == null`. My grep pattern could not match a line containing only `FAIL`, and I read its absence from the output as absence from the file. The true count is **3034**, not the 3559 I quoted.

## The real defect

Rotation filtered a snapshot of the WAL and `cp`-ed the result back over the live file, **with no lock**. Every append another session made between the read and the `cp` was destroyed.

Measured on this six-pane host:

| | |
|---|---|
| `INTENT` entries with no outcome, all projects | **3034** |
| Share of all 16037 operations | **19%** |
| From July alone (heaviest concurrent-run month) | 1715 |
| One session's contiguous lost window | ~1 hour |

Losing a `DONE` whose `INTENT` survives orphans that operation **forever**, because rotation deliberately keeps incomplete entries regardless of age (`docs/wal-guide.md`). The pile can only grow.

## Fix

The rewrite holds an exclusive `flock` on `<wal>.lock`, and the filter **re-reads the WAL inside that lock**. Filtering the pre-lock snapshot would clobber exactly the appends the lock exists to protect, so the re-read is the point, not a detail. `wal_append_phase` takes the same lock.

**The two sides fail in opposite directions, deliberately:**

- **Rotation** is rare and destructive → no `flock`, or a lock still held past `RAWGENTIC_WAL_ROTATE_LOCK_WAIT_S` (default 5), means **no rotation**. A growing file is recoverable; a clobbered one is not. That is `registry_prune.py`'s fail-safe-KEEP convention.
- **The append** runs on every tool call and only adds observational data → past `RAWGENTIC_WAL_APPEND_LOCK_WAIT_S` (default 2) it **proceeds anyway** rather than cost a log line. That is the `wal-bind-guard:7` logging convention. Worst case is the pre-existing behavior: one lost line.

## Verified red, with both arms on a full hooks tree

| Arm | Result |
|---|---|
| **OLD** (pre-fix) | rewrote **10400 → 5200 lines** while a child held the lock |
| **NEW** | waited, could not acquire, **left the file untouched** |

I also checked directly that appends still write both `INTENT` and `DONE`, and that **`wal-guard` still denies ssh-to-prod under `strict`** — `wal-lib.sh` is sourced by that fail-CLOSED guard, so a mistake there would have denied every Bash call in every session.

## Two vacuous passes I caught in my own tests

Worth stating, because both would have shipped a green test that proved nothing:

1. The first fixture made **every row prunable**, so the filter emptied, the `cp` never ran, and the WAL was unchanged for the wrong reason.
2. The second omitted the **registry entry**, so `_registry_project` was empty, session-start fell back to a legacy WAL that did not exist, and rotation never ran at all.

`test_the_fixture_actually_triggers_a_rewrite` now pins both.

## Verification

- Suite **6323 → 6328, exit 0**
- Both pylint lanes 10.00/10
- Security scan PASS, one visible skip (`iac`, not applicable)
- No workflow-spine change → **no diagram REV**

## Honest limits

- **This does not clean up the existing 3034 orphans.** They stay on disk for audit, which is the documented intent. The startup notice will keep showing them.
- **One pytest harness oddity is unexplained.** Running the new tests against the *unfixed* hook hangs inside pytest rather than failing. The red/green proof above was therefore done outside pytest, with a complete hooks tree on both arms. The shipped tests pass in 5s against the fixed hook.
- **No cross-model review** on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)