### PR TITLE
chore(skills): retire the superseded epic-run-analysis workspace skill (#534)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.139.2",
+  "version": "3.139.3",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,19 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.139.3 (2026-08-07)
+- **Retired the superseded `epic-run-analysis` workspace skill (#534).** Its plugin-native
+  successor `/rawgentic:epic-post-mortem` (WF19, #508, epic #509) shipped in v3.71.0, and the
+  stopgap's own SKILL.md had carried a SUPERSEDED banner since 2026-07-19 saying final deletion was
+  the owner's call. That call came 2026-08-07. Coverage was confirmed before deleting:
+  epic-post-mortem carries the phase-split and wall-clock reconstruction, and delegates the
+  machinery assessment to WF14 batch mode (#392) rather than duplicating the rubric — so the
+  divergence hunt is covered by delegation, not inline, which is a real difference worth stating.
+  The skill lived at the workspace root (`.claude/skills/epic-run-analysis`), which is not a git
+  repo, so the deletion itself is not in this diff; what is here is the tracker entry. The
+  workspace manual's skill list was updated in place with a pointer to the successor. No
+  workflow-spine change → no diagram REV. Suite 6328→6328.
+
 ### v3.139.2 (2026-08-07)
 - **WAL rotation no longer destroys concurrent sessions' log entries.** `session-start`
   filtered a snapshot of the WAL and `cp`-ed the result back over the live file with **no

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.139.2",
+  "version": "3.139.3",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/scripts/backlog_tracker.py
+++ b/scripts/backlog_tracker.py
@@ -105,7 +105,7 @@ STRUCTURE = {
          "exit": "Superseded stopgaps gone; deploy-verify + skill-usage auditing workspace-wide; "
                  "toolchain preflight surfaces exact remediations.",
          "children": [
-             (534, "MED", "S", "retire epic-run-analysis (now actionable — #508 shipped)"),
+             (534, "MED", "S", "retire epic-run-analysis (DONE 2026-08-07 — workspace skill deleted)"),
              (535, "MED", "S", "rev-diagram snapshot script — fullPage dual-theme gate"),
              (399, "LOW", "S", "admit-to-org-runners auto-infer target group"),
              (536, "MED", "M", "generalize studio-deploy → workspace deploy-verify skill"),

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.139.2"
+EXPECTED_PLUGIN_VERSION = "3.139.3"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",


### PR DESCRIPTION
Closes #534. Owner authorized 2026-08-07.

## Why now

Its plugin-native successor `/rawgentic:epic-post-mortem` (WF19, #508, epic #509) shipped in v3.71.0. The stopgap's own `SKILL.md` has carried a SUPERSEDED banner since 2026-07-19 saying **final deletion is the owner's call**. That call came today.

## Coverage confirmed before deleting (the issue's first AC)

`epic-post-mortem` carries the phase-split and wall-clock reconstruction. It **delegates** the machinery assessment to WF14 batch mode (#392) rather than duplicating the rubric — so the divergence hunt is covered *by delegation, not inline*. That is a real difference, and it is stated rather than glossed.

## Why the deletion is not in this diff

The skill lived at `.claude/skills/epic-run-analysis` in the **workspace root**, which is not a git repo. So:

| Change | Where |
|---|---|
| Skill directory deleted | workspace root — not in git |
| Workspace manual skill list updated, with a pointer to the successor | workspace root — not in git |
| Backlog tracker entry marked done | **this PR** |
| Version + changelog | **this PR** |

A copy of the deleted `SKILL.md` sits in this session's scratchpad on the host if it is ever wanted back.

## Verification

- No test referenced the skill (checked `tests/`)
- Suite **6328 → 6328, exit 0**
- Both pylint lanes 10.00/10
- No workflow-spine change → **no diagram REV**

🤖 Generated with [Claude Code](https://claude.com/claude-code)