### PR TITLE
fix(launcher): recover an unsubmitted goal paste inside send 3 (#835)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.139.3",
+  "version": "3.139.4",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,21 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.139.4 (2026-08-07)
+- **The `/goal` send now recovers an unsubmitted paste, so a handoff stops dying at `goal_armed`
+  (#835, epic #906).** SEND 3 of `perform_handoff` pasted the goal and polled, with no recovery
+  between: rc 0 on a send proves transport, not arrival — the lesson #700 already learned for the
+  prompt and never extended to the goal. It is not a race but the normal case, because the goal is
+  sent last while the successor is mid-turn on the prompt that just landed, and Claude Code buffers
+  input during a turn and flushes at turn end. `hooks/launcher_lib.py` gains `GOAL_NUDGE_ROUNDS`
+  and a bounded loop mirroring the prompt path — pane read, `pane_shows_unsubmitted_paste`, bare
+  Enter, re-poll — that never re-sends the goal text (#696), reports a failed nudge as its own
+  `send_goal_nudge` step, and still fails closed with the predecessor intact. 12 tests added
+  (`TestGoalNudge`, `TestGoalNudgeSafety`) mirroring the prompt-path pair, plus a
+  `goal_row_after_nudges` fixture knob, and 2 more pinning that a failed nudge keeps herdr's error
+  body (#731's choke point attaches it only when the note is absent). No workflow-spine change →
+  no diagram REV. Suite 6328→6342.
+
 ### v3.139.3 (2026-08-07)
 - **Retired the superseded `epic-run-analysis` workspace skill (#534).** Its plugin-native
   successor `/rawgentic:epic-post-mortem` (WF19, #508, epic #509) shipped in v3.71.0, and the

--- a/hooks/launcher_lib.py
+++ b/hooks/launcher_lib.py
@@ -2868,27 +2868,27 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
         # pass where the buffer was intact all along. Never a re-paste (#696): once the buffered
         # Enter flushes, a second copy of the text would submit twice.
         #
-        # TWO honest limits, both inherited from the prompt path and neither closable here
-        # (Step-8a cross-model review, two High findings — the observations are right, their
-        # recommended fixes are not implementable against this transport):
+        # Three properties of this recovery, stated so they are not mistaken for guarantees. Each
+        # is shared with the prompt path above, which has the same read-then-send shape.
         #
-        # 1. The guard is an AFFORDANCE check, NOT an identity check, and it cannot be made one:
-        #    a collapsed paste renders as `[Pasted text #N]`, so the pane never displays the
-        #    content to compare against `expected_condition`. `prompt_landed` proves the PROMPT
-        #    was submitted; it does NOT prove the paste on screen now is this goal's. So the
-        #    residual risk is real — an Enter submits whatever is staged. What bounds it: the pane
-        #    is one this call just created, the permission-dialog veto runs before every Enter, and
-        #    every unknown screen fails closed. `pane_shows_unsubmitted_paste`'s own docstring
-        #    states the same narrower claim; do not re-widen it here.
-        # 2. Enters can QUEUE. The very buffering this recovery exists for means an rc-0 send-keys
-        #    may sit unflushed while the re-poll still reads false, so a later round can enqueue a
-        #    second Enter; at flush the first submits the goal and the rest land on an empty input
-        #    box. Rate-bounded by the full re-poll between rounds, and an empty submit is inert.
-        #    NOT fixed by dropping to one nudge — #700 measured that one Enter still lands inside
-        #    the running turn (see PROMPT_NUDGE_ROUNDS), which is the failure this exists to end.
+        # 1. The guard checks an AFFORDANCE, not identity. A collapsed paste renders as
+        #    `[Pasted text #N]`, so the pane does not expose paste contents and this guard cannot
+        #    verify that the pending paste is this goal's. `prompt_landed` establishes that the
+        #    prompt was submitted; it does not establish what is staged now. What narrows the
+        #    exposure: the pane was created by this call, the permission-dialog veto runs before
+        #    every Enter, and any unrecognised screen fails closed.
+        # 2. Enters can QUEUE. The buffering this recovery exists for means an rc-0 send-keys may
+        #    sit unflushed while the re-poll still reads false, so a later round can enqueue
+        #    another; at flush the first submits the goal and the rest land on an empty input box.
+        #    The full re-poll between rounds bounds the rate. A single round would not close this
+        #    and would reintroduce the measured failure: #700 found one Enter still lands inside
+        #    the running turn (see PROMPT_NUDGE_ROUNDS).
+        # 3. The read and the Enter are separate herdr calls, so the pane can change between them
+        #    — a dialog appearing in that gap would be accepted. `herdr pane` exposes read,
+        #    send-text and send-keys only; there is no compare-and-send or state token to bind the
+        #    check to the act. Closing this needs a conditional-send primitive from the transport.
         #
-        # A future reordering of the sends would also invalidate limit 1's mitigation and must
-        # revisit this.
+        # Reordering the sends would change the basis of property 1.
         for _ in range(GOAL_NUDGE_ROUNDS):
             if armed:
                 break
@@ -2916,6 +2916,10 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
                    note=("bare Enter — submit the intact goal paste, never re-send it (#835)"
                          if nudge_ok else None))
             if not nudge_ok:
+                # The receipt stays COMPLETE on this path: a consumer reading `goal_armed` gets
+                # False rather than a missing key. `armed` is False by construction here — the
+                # loop only reaches a nudge when the poll has not passed.
+                out["results"]["goal_armed"] = armed
                 # Named distinctly, for the reason `send_resume_nudge` is: reporting this as
                 # `goal_armed` would blame the successor's timing for a failed herdr call.
                 out["failed_step"] = "send_goal_nudge"

--- a/hooks/launcher_lib.py
+++ b/hooks/launcher_lib.py
@@ -167,6 +167,17 @@ GOAL_POLL_ATTEMPTS = 12
 # have landed inside that turn. Four rounds of {bare Enter, re-poll} is ~90 s worst case, past a
 # first turn of the observed length, and costs nothing on a handoff that submits normally.
 PROMPT_NUDGE_ROUNDS = 4
+# #835 — the SAME unsubmitted-Enter recovery on SEND 3, and the goal needs it MORE than the prompt
+# did. The goal is sent last, deliberately, while the successor is already working the prompt that
+# just landed, so its Enter is always delivered into a pane that is certainly mid-turn — where #700
+# only had to survive a bind turn that MIGHT still be running. The mechanism is a deferral, not a
+# loss: Claude Code buffers input during a turn and flushes at turn end (measured 2026-07-28), so a
+# bounded retry that outlives the turn is the right shape — and re-sending the TEXT would
+# double-submit at that flush, which is why the recovery is a bare Enter only (#696).
+# Its own constant rather than sharing the prompt's, for the reason the block above already gives
+# for GOAL_POLL_ATTEMPTS vs SWITCH_POLL_ATTEMPTS: the two waits are different in kind, and one
+# name would have to be re-tuned for both at once. Same value as the prompt's, same measured basis.
+GOAL_NUDGE_ROUNDS = 4
 # A marker must be distinctive, not merely present in the prompt (#700 design review, High 1):
 # `transcript_has_marker` is a plain substring scan, so a short common word would match unrelated
 # tail content and pass `prompt_landed` before the prompt ever submitted. A length floor is a
@@ -2842,9 +2853,54 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
             return tail is not None and transcript_has_unmet_goal(
                 tail, expected_condition=expected)
 
-        out["results"]["goal_armed"] = _poll_for(
+        armed = _poll_for(
             _goal_is_armed,
             attempts=GOAL_POLL_ATTEMPTS, delay_s=GOAL_POLL_DELAY_S, sleeper=sleeper)
+
+        # #835 — the goal paste may be INTACT BUT UNSUBMITTED, the same third state #700 found for
+        # the prompt, and here it is the NORMAL case rather than a race: this send is deliberately
+        # last, while the successor is already mid-turn on the prompt, so its Enter is buffered
+        # until that turn ends. Observed live 2026-08-01 (pane w1:pGG, session a02dcfc0): the
+        # successor's transcript held three copies of the prompt marker and ZERO `/goal`.
+        #
+        # Recovery inside send 3 — NOT a change to the send order and NOT a weakened gate:
+        # `goal_armed` still has to pass on the same artifact below, and a nudge can only let it
+        # pass where the buffer was intact all along. Never a re-paste (#696): once the buffered
+        # Enter flushes, a second copy of the text would submit twice.
+        #
+        # The safety of nudging HERE rests on `prompt_landed` having already passed above — that
+        # proves the prompt was submitted, so a paste affordance on screen now can only be the
+        # goal's. A future reordering of the sends would invalidate that and must revisit this.
+        for _ in range(GOAL_NUDGE_ROUNDS):
+            if armed:
+                break
+            # An Enter accepts whatever is on screen, so read the pane FIRST and let anything
+            # other than a clear "safe" abandon the recovery — which leaves exactly today's
+            # behaviour.
+            read_argv = build_pane_read_argv(new_pane)
+            proc = runner(read_argv)
+            if getattr(proc, "returncode", 1) != 0:
+                record("pane_read", read_argv, proc,
+                       note="goal nudge SKIPPED: pane read failed, so the pane's state is unknown")
+                break
+            safe, why = pane_shows_unsubmitted_paste(getattr(proc, "stdout", "") or "")
+            record("pane_read", read_argv, proc,
+                   note=f"goal nudge {'PERMITTED' if safe else 'SKIPPED'}: {why}")
+            if not safe:
+                break
+            nudge_argv = build_send_enter_argv(new_pane)
+            proc = runner(nudge_argv)
+            record("send_goal_nudge", nudge_argv, proc,
+                   note="bare Enter — submit the intact goal paste, never re-send it (#835)")
+            if getattr(proc, "returncode", 1) != 0:
+                # Named distinctly, for the reason `send_resume_nudge` is: reporting this as
+                # `goal_armed` would blame the successor's timing for a failed herdr call.
+                out["failed_step"] = "send_goal_nudge"
+                return out
+            armed = _poll_for(_goal_is_armed, attempts=GOAL_POLL_ATTEMPTS,
+                              delay_s=GOAL_POLL_DELAY_S, sleeper=sleeper)
+
+        out["results"]["goal_armed"] = armed
         if not out["results"]["goal_armed"]:
             out["failed_step"] = "goal_armed"
             out["failure_detail"] = (

--- a/hooks/launcher_lib.py
+++ b/hooks/launcher_lib.py
@@ -2868,9 +2868,27 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
         # pass where the buffer was intact all along. Never a re-paste (#696): once the buffered
         # Enter flushes, a second copy of the text would submit twice.
         #
-        # The safety of nudging HERE rests on `prompt_landed` having already passed above — that
-        # proves the prompt was submitted, so a paste affordance on screen now can only be the
-        # goal's. A future reordering of the sends would invalidate that and must revisit this.
+        # TWO honest limits, both inherited from the prompt path and neither closable here
+        # (Step-8a cross-model review, two High findings — the observations are right, their
+        # recommended fixes are not implementable against this transport):
+        #
+        # 1. The guard is an AFFORDANCE check, NOT an identity check, and it cannot be made one:
+        #    a collapsed paste renders as `[Pasted text #N]`, so the pane never displays the
+        #    content to compare against `expected_condition`. `prompt_landed` proves the PROMPT
+        #    was submitted; it does NOT prove the paste on screen now is this goal's. So the
+        #    residual risk is real — an Enter submits whatever is staged. What bounds it: the pane
+        #    is one this call just created, the permission-dialog veto runs before every Enter, and
+        #    every unknown screen fails closed. `pane_shows_unsubmitted_paste`'s own docstring
+        #    states the same narrower claim; do not re-widen it here.
+        # 2. Enters can QUEUE. The very buffering this recovery exists for means an rc-0 send-keys
+        #    may sit unflushed while the re-poll still reads false, so a later round can enqueue a
+        #    second Enter; at flush the first submits the goal and the rest land on an empty input
+        #    box. Rate-bounded by the full re-poll between rounds, and an empty submit is inert.
+        #    NOT fixed by dropping to one nudge — #700 measured that one Enter still lands inside
+        #    the running turn (see PROMPT_NUDGE_ROUNDS), which is the failure this exists to end.
+        #
+        # A future reordering of the sends would also invalidate limit 1's mitigation and must
+        # revisit this.
         for _ in range(GOAL_NUDGE_ROUNDS):
             if armed:
                 break
@@ -2890,9 +2908,14 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
                 break
             nudge_argv = build_send_enter_argv(new_pane)
             proc = runner(nudge_argv)
+            # note=None on failure DELIBERATELY: #731 made `record` attach the herdr error body
+            # whenever the note is absent, so passing an explanatory string here would silence the
+            # one record that most needs the real cause. Explain on success, diagnose on failure.
+            nudge_ok = getattr(proc, "returncode", 1) == 0
             record("send_goal_nudge", nudge_argv, proc,
-                   note="bare Enter — submit the intact goal paste, never re-send it (#835)")
-            if getattr(proc, "returncode", 1) != 0:
+                   note=("bare Enter — submit the intact goal paste, never re-send it (#835)"
+                         if nudge_ok else None))
+            if not nudge_ok:
                 # Named distinctly, for the reason `send_resume_nudge` is: reporting this as
                 # `goal_armed` would blame the successor's timing for a failed herdr call.
                 out["failed_step"] = "send_goal_nudge"

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.139.3",
+  "version": "3.139.4",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adhoc_pane_handoff.py
+++ b/tests/hooks/test_adhoc_pane_handoff.py
@@ -132,13 +132,18 @@ class Artifacts:
     `marker_after_nudges` is the point of this fake: the marker appears only once the runner has
     issued that many bare Enters, which is exactly the live failure — the paste is intact and
     unsubmitted until something submits it.
+
+    `goal_row_after_nudges` is the same idea for the GOAL paste (#835). It defaults to 0, so the
+    predicate is always true and every test written before it behaves identically; a goal-nudge
+    test raises it to express the state the goal recovery exists for.
     """
 
     def __init__(self, runner, *, marker_after_nudges=0, goal_row=GOAL_ROW,
-                 registry_row=None):
+                 goal_row_after_nudges=0, registry_row=None):
         self.runner = runner
         self.marker_after_nudges = marker_after_nudges
         self.goal_row = goal_row
+        self.goal_row_after_nudges = goal_row_after_nudges
         # #800 — which REPRESENTATION the successor writes for `project_path`. Defaults to the
         # workspace-relative row every other test in this file assumes, so their behaviour is
         # unchanged; the absolute variant is the live failure the gate used to refuse.
@@ -155,7 +160,9 @@ class Artifacts:
         text = ""
         if len(self.runner.nudges()) >= self.marker_after_nudges:
             text += RESUME_PROMPT + "\n"
-        return text + self.goal_row + "\n"
+        if len(self.runner.nudges()) >= self.goal_row_after_nudges:
+            text += self.goal_row + "\n"
+        return text
 
 
 def _handoff(runner, **over):

--- a/tests/hooks/test_adhoc_pane_handoff.py
+++ b/tests/hooks/test_adhoc_pane_handoff.py
@@ -269,6 +269,125 @@ class TestPromptNudge:
         assert out["failed_step"] == "send_resume_nudge", out["failed_step"]
 
 
+class TestGoalNudge:
+    """#835 — the same recovery on SEND 3.
+
+    Every test here sets `marker_after_nudges=0`, so the prompt lands on its first poll and the
+    only Enters `nudges()` can report are GOAL nudges. That is what lets the existing positional
+    helper serve both paths without learning to tell them apart.
+
+    Why the goal needs this at all, and why it is not a flake: the goal is sent LAST, deliberately,
+    while the successor is already working the prompt that just landed. Claude Code buffers input
+    during a turn and flushes at turn end, so the goal's Enter is DEFERRED, not lost — which is
+    also why re-sending the text would double-submit once the buffer flushes.
+    """
+
+    def test_a_goal_that_arms_first_time_is_never_nudged(self) -> None:
+        """The happy path must be byte-identical to before this change — including no pane read,
+        so a healthy handoff gains no extra herdr round trip."""
+        r = Runner(_responses())
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=0)))
+        assert out["ok"] is True, out["failed_step"]
+        assert r.nudges() == [], "an armed goal must not be nudged"
+        assert not any(Runner.key(c) == "herdr pane read" for c in r.calls), \
+            "no pane read either — the recovery path must not run at all"
+
+    def test_one_nudge_recovers_the_unsubmitted_goal(self) -> None:
+        """The observed 2026-08-01 failure: the paste sat unsubmitted and a bare Enter freed it."""
+        r = Runner(_responses())
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=1)))
+        assert out["ok"] is True, out["failed_step"]
+        assert out["results"]["goal_armed"] is True
+        assert len(r.nudges()) == 1
+        assert r.nudges()[0] == ["herdr", "pane", "send-keys", "w1:pZZ", "Enter"]
+
+    def test_the_nudge_never_re_sends_the_goal_text(self) -> None:
+        """AC2 / #696: a re-paste risks double submission once the buffer flushes."""
+        r = Runner(_responses())
+        ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=2)))
+        goal_sends = [t for t in r.sent_text() if t.startswith("/goal")]
+        assert len(goal_sends) == 1, "the goal text was sent more than once"
+        assert goal_sends[0].count(GOAL_CONDITION) == 1
+
+    def test_nudging_is_bounded_and_then_fails_closed(self) -> None:
+        """AC6: exhausting the rounds still fails the gate, and the predecessor still survives."""
+        r = Runner(_responses())
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=99)))
+        assert out["ok"] is False and out["failed_step"] == "goal_armed"
+        assert len(r.nudges()) <= ll.GOAL_NUDGE_ROUNDS
+        assert not any(c[:3] == ["herdr", "pane", "close"] and c[3] == "w1:p1"
+                       for c in r.calls), "the predecessor must survive a failed handoff"
+
+    def test_each_nudge_is_recorded_as_its_own_step(self) -> None:
+        """AC3: the recovery attempt is verifiable from the returned record."""
+        r = Runner(_responses())
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=1)))
+        assert [s for s in out["steps"] if s["kind"] == "send_goal_nudge"]
+
+    def test_a_failed_nudge_send_is_its_own_failure_not_poll_exhaustion(self) -> None:
+        """AC3: a broken `send-keys` must not be reported as `goal_armed` timing out."""
+        class NudgeFails(Runner):
+            def __call__(self, argv, timeout=180):
+                proc = super().__call__(argv, timeout)
+                if argv[:3] == ["herdr", "pane", "send-keys"] \
+                        and self.calls[-2][:3] != ["herdr", "pane", "send-text"]:
+                    return FakeProc(returncode=1)
+                return proc
+
+        r = NudgeFails(_responses())
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=99)))
+        assert out["ok"] is False
+        assert out["failed_step"] == "send_goal_nudge", out["failed_step"]
+
+    def test_the_send_order_is_unchanged(self) -> None:
+        """AC5: recovery lives INSIDE send 3 — it does not reorder or add a send."""
+        r = Runner(_responses())
+        ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=1)))
+        texts = r.sent_text()
+        assert len(texts) == 3
+        assert texts[0].startswith(ll._driver_lib().BIND_DIRECTIVE)
+        assert texts[1] == RESUME_PROMPT
+        assert texts[2].startswith("/goal")
+
+
+class TestGoalNudgeSafety:
+    """AC4 — an Enter accepts whatever is on screen, so every unknown resolves to "do not nudge"."""
+
+    @pytest.mark.parametrize("pane_read,why", [
+        (PANE_PERMISSION_DIALOG, "a permission dialog would be accepted"),
+        ("", "an empty read proves nothing"),
+        ("some unrelated scrollback\n", "no paste affordance means no known buffer"),
+    ])
+    def test_an_unsafe_or_unknown_pane_is_not_nudged(self, pane_read, why) -> None:
+        r = Runner(_responses(pane_read=pane_read))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=99)))
+        assert out["ok"] is False and out["failed_step"] == "goal_armed"
+        assert r.nudges() == [], why
+
+    def test_a_failed_pane_read_is_not_a_licence_to_nudge(self) -> None:
+        r = Runner(_responses(), fail_on="herdr pane read")
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=99)))
+        assert out["ok"] is False and r.nudges() == []
+
+    def test_the_goal_read_is_recorded_distinguishably(self) -> None:
+        """Step-4 Finding #3: one receipt can carry two `pane_read` entries, so the goal path's
+        note must say which send it belongs to."""
+        r = Runner(_responses(pane_read=PANE_PERMISSION_DIALOG))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=99)))
+        notes = [str(s.get("note")) for s in out["steps"] if s["kind"] == "pane_read"]
+        assert any("goal" in n.lower() for n in notes), notes
+
+
 class TestNudgeSafety:
     """An Enter accepts whatever is on screen. Every unknown must resolve to "do not nudge"."""
 

--- a/tests/hooks/test_adhoc_pane_handoff.py
+++ b/tests/hooks/test_adhoc_pane_handoff.py
@@ -345,6 +345,36 @@ class TestGoalNudge:
         assert out["ok"] is False
         assert out["failed_step"] == "send_goal_nudge", out["failed_step"]
 
+    def test_a_failed_nudge_keeps_the_herdr_error_body(self) -> None:
+        """#731's choke point attaches the error body only when the note is absent, so the goal
+        nudge must not hand `record` an explanatory string on the failure path — that would
+        silence the one record that most needs the real cause."""
+        class NudgeFailsLoudly(Runner):
+            def __call__(self, argv, timeout=180):
+                proc = super().__call__(argv, timeout)
+                if argv[:3] == ["herdr", "pane", "send-keys"] \
+                        and self.calls[-2][:3] != ["herdr", "pane", "send-text"]:
+                    return FakeProc(returncode=1,
+                                    stdout='{"error": {"code": "pane_gone", "message": "no pane"}}')
+                return proc
+
+        r = NudgeFailsLoudly(_responses())
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=99)))
+        assert out["failed_step"] == "send_goal_nudge"
+        notes = [str(s.get("note")) for s in out["steps"] if s["kind"] == "send_goal_nudge"]
+        assert notes, "the failed nudge was not recorded at all"
+        assert any("pane_gone" in n for n in notes), notes
+
+    def test_a_successful_nudge_still_explains_itself(self) -> None:
+        """The other half of the same rule: on success there is no error body to preserve, so the
+        record carries the explanatory note instead of nothing."""
+        r = Runner(_responses())
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=1)))
+        notes = [str(s.get("note")) for s in out["steps"] if s["kind"] == "send_goal_nudge"]
+        assert any("never re-send" in n for n in notes), notes
+
     def test_the_send_order_is_unchanged(self) -> None:
         """AC5: recovery lives INSIDE send 3 — it does not reorder or add a send."""
         r = Runner(_responses())

--- a/tests/hooks/test_adhoc_pane_handoff.py
+++ b/tests/hooks/test_adhoc_pane_handoff.py
@@ -304,10 +304,17 @@ class TestGoalNudge:
         assert r.nudges()[0] == ["herdr", "pane", "send-keys", "w1:pZZ", "Enter"]
 
     def test_the_nudge_never_re_sends_the_goal_text(self) -> None:
-        """AC2 / #696: a re-paste risks double submission once the buffer flushes."""
+        """AC2 / #696: a re-paste risks double submission once the buffer flushes.
+
+        Asserts the recovery actually took TWO rounds and then succeeded, not just that the text
+        appears once: a one-round implementation would satisfy a bare send-count assertion while
+        still failing the longer buffered-turn case that four rounds exist for.
+        """
         r = Runner(_responses())
-        ll.perform_handoff(**_handoff(
+        out = ll.perform_handoff(**_handoff(
             r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=2)))
+        assert out["ok"] is True, out["failed_step"]
+        assert len(r.nudges()) == 2
         goal_sends = [t for t in r.sent_text() if t.startswith("/goal")]
         assert len(goal_sends) == 1, "the goal text was sent more than once"
         assert goal_sends[0].count(GOAL_CONDITION) == 1
@@ -318,7 +325,9 @@ class TestGoalNudge:
         out = ll.perform_handoff(**_handoff(
             r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=99)))
         assert out["ok"] is False and out["failed_step"] == "goal_armed"
-        assert len(r.nudges()) <= ll.GOAL_NUDGE_ROUNDS
+        # EXACTLY the bound, not merely `<=`: a `<=` assertion is satisfied by zero nudges, so it
+        # would pass against a build where the recovery never ran at all.
+        assert len(r.nudges()) == ll.GOAL_NUDGE_ROUNDS
         assert not any(c[:3] == ["herdr", "pane", "close"] and c[3] == "w1:p1"
                        for c in r.calls), "the predecessor must survive a failed handoff"
 
@@ -365,6 +374,9 @@ class TestGoalNudge:
         notes = [str(s.get("note")) for s in out["steps"] if s["kind"] == "send_goal_nudge"]
         assert notes, "the failed nudge was not recorded at all"
         assert any("pane_gone" in n for n in notes), notes
+        # The receipt must stay COMPLETE on this path — a consumer reading the result gets False,
+        # never a missing key.
+        assert out["results"]["goal_armed"] is False
 
     def test_a_successful_nudge_still_explains_itself(self) -> None:
         """The other half of the same rule: on success there is no error body to preserve, so the

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.139.3"
+EXPECTED_PLUGIN_VERSION = "3.139.4"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",


### PR DESCRIPTION
Closes #835.

## The bug

`ad-hoc-handoff` reliably failed at `goal_armed`. The goal text was pasted into the successor and
**never submitted**, so a successor that had already bound and started work was torn down and the
whole handoff abandoned — at the least recoverable moment, since a pane-handoff is invoked
precisely when a session is running out of context.

Observed live 2026-08-01 (pane `w1:pGG`, session `a02dcfc0`): `spawned`, `project_switched` and
`prompt_landed` all passed, `goal_armed` failed, and the successor's transcript held **three copies
of the prompt marker and zero `/goal`**.

## Why it is systematic, not a flake

SEND 3 of `perform_handoff` sent the goal as `send_text` + `send_keys Enter` and then polled, with
no recovery in between. **rc 0 on a send proves transport, not arrival** — exactly the lesson #700
already learned for the prompt, and never extended to the goal.

And it is the *normal* case rather than a race. The goal is sent last, deliberately, while the
successor is already mid-turn on the prompt that just landed. Claude Code buffers input during a
turn and flushes at turn end, so the goal's Enter is **deferred, not lost**. That one fact drives
the whole design: a bounded retry that outlives the turn is the right shape, and re-sending the
text would **double-submit** once the buffer flushes.

## The change

A bounded recovery loop inside send 3, mirroring the prompt path ~45 lines above:

> pane read → `pane_shows_unsubmitted_paste` → bare Enter → re-poll, up to `GOAL_NUDGE_ROUNDS`

- **The gate is not weakened.** `out["results"]["goal_armed"]` is assigned exactly once, after the
  loop. A nudge can only let the gate pass where the buffer was intact all along.
- **The send order is unchanged.** Recovery lives inside send 3; no send is added, removed or moved.
- **Never a re-paste** (#696) — only `build_send_enter_argv` is called in the loop, and a test
  asserts the goal text is sent exactly once.
- **Fails closed.** Every abandonment path leaves `goal_armed` False and the predecessor alive.
- **A failed nudge is its own step**, `send_goal_nudge`, so a broken herdr call is never reported
  as the successor timing out.

`GOAL_NUDGE_ROUNDS` is its own constant rather than sharing the prompt's, for the reason the
existing block already gives for `GOAL_POLL_ATTEMPTS` vs `SWITCH_POLL_ATTEMPTS`: the two waits are
different in kind.

### One thing worth knowing if you ever reorder the sends

The safety of nudging here rests on `prompt_landed` having already passed — that proves the prompt
was submitted, so a paste affordance on screen now can only be the goal's. A reordering would
invalidate that argument. It is recorded in a comment at the call site, not just here.

## Tests

12 new tests mirroring the prompt-path pair case-for-case:

- `TestGoalNudge` — armed-first-time is never nudged (and issues no pane read), one nudge
  recovers, never re-sends the text, bounded then fails closed, each nudge its own step, a failed
  nudge send is its own failure, send order unchanged.
- `TestGoalNudgeSafety` — unsafe/unknown pane not nudged (permission dialog, empty read, unrelated
  scrollback), a failed pane read is not a licence to nudge, and the goal path's pane read is
  recorded distinguishably from the prompt's.

The shared `Artifacts` fixture gains `goal_row_after_nudges`, defaulted to 0 so the predicate is
always true; verified behaviour-neutral (the file was 154 passed before and after that commit).

Red before green: all five behaviour tests failed for the right reasons first, including
`AttributeError: module 'launcher_lib' has no attribute 'GOAL_NUDGE_ROUNDS'`.

## Three properties, stated so they are not mistaken for guarantees

All three are shared with the prompt path, which has the same read-then-send shape. They are
documented at the call site, not just here.

1. **The guard checks an affordance, not identity.** A collapsed paste renders as
   `[Pasted text #N]`, so the pane does not expose contents and the guard cannot verify the
   pending paste is this goal's.
2. **Enters can queue.** An rc-0 `send-keys` may sit unflushed while the re-poll reads false, so a
   later round can enqueue another; at flush the first submits and the rest land on an empty input
   box. The full re-poll between rounds bounds the rate.
3. **The read and the Enter are separate calls,** so the pane can change between them.

## Deferred, with rationale

**A TOCTOU window between the pane read and the Enter** (cross-model review, High, confidence
0.93). A permission dialog appearing in that gap would be accepted despite the veto.

Deferred rather than fixed, because it cannot be closed here: `herdr pane` exposes only `read`,
`send-text` and `send-keys` — there is no compare-and-send and no state token to bind the check to
the act. The alternative the review offered, disabling automated goal nudging, would abandon this
fix and equally condemn #700's prompt nudge, which has the byte-identical shape. Closing it needs a
conditional-send primitive from herdr.

Recorded in the run's deferrals and re-presented at the Step 11 exit gate, which resolved it on
independent concurrence (the inline pass verified the window and the missing primitive separately).

## Review

- **Step 8a** (task T3, high-risk): 2 High + 1 Medium. Both High observations accepted and
  documented; both recommended fixes declined with reasons — one was not implementable against a
  collapsed paste, the other would have reintroduced the failure #700 measured.
- **Step 11**: 1 High (deferred above) + 4 findings from the adversarial diff layer — 3 applied
  (a comment that told future reviewers not to revisit a boundary, an incomplete failure receipt,
  and two test assertions a weaker build could satisfy), 1 declined with reason.
- Nothing was silently dropped.

## Verification

- Full suite: **6328 → 6342**, exit 0. Baseline recorded at `5062764a` before any work began.
- Lint: both pylint lanes 10.00/10.
- Security scan (Step 11.5): **PASS**. One visible skip — `iac`, not applicable to this project.
  Recorded rather than silently passed.
- No workflow-spine change → **no diagram REV**.

## Deferred verification

None. Every acceptance criterion is verifiable by unit test; this project has `has_deploy: false`
and the change has no runtime surface that only appears on a deploy.
