### PR TITLE
feat(context-meter): let the DIRECTIVE tier insert mid-turn, not only at Stop (#729)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.140.0",
+  "version": "3.141.0",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,22 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.141.0 (2026-08-07)
+- **The directive tier can now insert mid-turn, not only at `Stop` (#729, epic #906).** The #718
+  prompt-insert is the one channel that arrives as authoritative USER input rather than injected
+  text a model may decline, and it was gated on `event == "Stop"` — so a session reaching the
+  directive tier mid-turn never got it, which is precisely when it is deepest in a long turn and
+  least able to act on refusable text. The gate cited an ESC hazard the route cannot produce:
+  `insert_prompt` sends `send-text`, waits, then a separate `send-keys Enter`, and paste-plus-Enter
+  does not interrupt a turn. Measured basis: session `643af1d9` declined the injected directive at
+  50.7% and handed off only on human intervention; this host carried 89 midturn markers against 3
+  insert markers, all stop-channel. Safe to widen because at-most-once lives in
+  `try_insert_prompt`'s own `(session, window, directive, INSERT_CHANNEL)` reservation, not at the
+  branch. Also corrected the epic's own note that F1 was stale — it counted NAG markers, not insert
+  markers. 4 tests, the behavioural pair driven black-box through the hook subprocess and verified
+  red-before-green by reverting the gate. No workflow-spine change → no diagram REV. Suite
+  6352→6356.
+
 ### v3.140.0 (2026-08-07)
 - **Context-meter thresholds to 55/75, and older decisions get a rolling summary instead of
   silence (#797, epic #906).** Owner-directed on 2026-08-01 — *"if 60-80 is the degredation point

--- a/README.md
+++ b/README.md
@@ -762,8 +762,8 @@ For major changes, please open an issue first to discuss the approach.
   `try_insert_prompt`'s own `(session, window, directive, INSERT_CHANNEL)` reservation, not at the
   branch. Also corrected the epic's own note that F1 was stale — it counted NAG markers, not insert
   markers. 4 tests, the behavioural pair driven black-box through the hook subprocess and verified
-  red-before-green by reverting the gate. No workflow-spine change → no diagram REV. Suite
-  6352→6356.
+  red-before-green by reverting the gate, and the event-set guard likewise. No workflow-spine
+  change → no diagram REV. Suite 6352→6357.
 
 ### v3.140.0 (2026-08-07)
 - **Context-meter thresholds to 55/75, and older decisions get a rolling summary instead of

--- a/hooks/context_meter.py
+++ b/hooks/context_meter.py
@@ -1500,9 +1500,23 @@ def cmd_hook(argv) -> int:
     # arrives as USER input, the one channel treated as authoritative. Additive on purpose: if the
     # insert fails, the text has still been delivered the old way.
     #
-    # `Stop` only. Never mid-turn, and never ESC — at `Stop` the turn has ended and nothing is in
-    # flight, whereas an ESC mid-turn can kill a running suite or a half-finished commit.
-    if event == "Stop" and tier == "directive":
+    # DIRECTIVE tier on EITHER path, mid-turn included (#729). This was `Stop`-only, justified by an
+    # ESC hazard that this code path cannot produce: `launcher_lib.insert_prompt` sends
+    # `herdr pane send-text`, waits, then a SEPARATE `herdr pane send-keys <pane> Enter` — there is
+    # no ESC anywhere on the route, and pasting plus Enter does not interrupt a running turn.
+    # Claude Code queues that input and surfaces it at the next tool-result boundary.
+    #
+    # The gate cost exactly what it was meant to protect. Mid-turn is when a session is deepest in a
+    # long turn and least able to act on text it may DECLINE — measured: the directive at 50.7% in
+    # session 643af1d9 was delivered as injected text and declined, and the handoff happened only
+    # because a human intervened, which is the dependency #718 exists to remove. On this host the
+    # ratio was 89 midturn markers to 3 insert markers, every insert stop-channel.
+    #
+    # Safe to widen because the at-most-once guarantee does not live here: `try_insert_prompt`
+    # reserves on its own (session, window, "directive", INSERT_CHANNEL) key, so a mid-turn insert
+    # followed by a `Stop` directive finds that reservation already taken. The advisory tier still
+    # never reaches this branch.
+    if tier == "directive":
         outcome = try_insert_prompt(home=home, session_id=session_id, window=window, used=used,
                                     cfg=cfg, project_path=project_path, env=env)
         # NEVER SILENT about not having acted (Step-11 diff review, Medium). This module's contract

--- a/hooks/context_meter.py
+++ b/hooks/context_meter.py
@@ -954,6 +954,10 @@ def read_meter_config(project_path):
 # possible prompt injection. With its own channel the insert can be released and retried at the next
 # Stop while the nag stays delivered exactly once.
 INSERT_CHANNEL = "stop-insert"
+#: The events allowed to reach the authoritative prompt-insert channel (#729). Named as a set
+#: rather than left implicit: the branch below used to be `Stop`-only, and widening it to
+#: "any directive" would silently enrol every future event too.
+INSERT_EVENTS = frozenset({"Stop", "UserPromptSubmit"})
 
 # Whole-subprocess budget. `launcher_lib insert-prompt` sleeps INSERT_SUBMIT_DELAY_S (1.5 s, the
 # measured minimum that actually submits — #718 §5b) and makes three quick herdr calls, so 12 s is
@@ -1516,7 +1520,11 @@ def cmd_hook(argv) -> int:
     # reserves on its own (session, window, "directive", INSERT_CHANNEL) key, so a mid-turn insert
     # followed by a `Stop` directive finds that reservation already taken. The advisory tier still
     # never reaches this branch.
-    if tier == "directive":
+    # The event set is EXPLICIT, not "anything that is not Stop" (Step-11 review, converged Medium
+    # across both passes). `tier == "directive"` alone would hand the authoritative input channel to
+    # any event that ever starts reaching this hook, which is a wider grant than this issue asked
+    # for and one nobody would notice being made.
+    if event in INSERT_EVENTS and tier == "directive":
         outcome = try_insert_prompt(home=home, session_id=session_id, window=window, used=used,
                                     cfg=cfg, project_path=project_path, env=env)
         # NEVER SILENT about not having acted (Step-11 diff review, Medium). This module's contract

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.140.0",
+  "version": "3.141.0",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.140.0"
+EXPECTED_PLUGIN_VERSION = "3.141.0"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_context_meter.py
+++ b/tests/hooks/test_context_meter.py
@@ -1937,26 +1937,78 @@ class TestInsertPromptAtTheActTier:
         assert "prompt insertion did not happen" not in err, (
             "the advisory tier must never reach the insert branch\n" + err)
 
-    def test_at_most_once_per_window_across_BOTH_paths(self, tmp_path) -> None:
-        """#729 AC2 — the property that makes enabling the mid-turn path safe. The insert reserves
-        on its OWN channel keyed (session, window, tier, INSERT_CHANNEL), so a mid-turn insert
-        followed by a Stop directive finds the reservation already taken. Asserted through the real
-        reservation rather than a mock, because a mock would prove nothing about the key."""
-        env = {"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:pZZ"}
-        assert self._try(tmp_path, env=env) == "inserted"
-        assert "already inserted" in self._try(tmp_path, env=env)
-        assert cm.has_marker(str(tmp_path), self.SID, 1000000, "directive",
-                             cm.INSERT_CHANNEL) is True
+    def test_an_event_outside_the_allowed_set_never_inserts(self, tmp_path) -> None:
+        """#729 — the event set must be a real restriction, not decoration.
 
-    def test_the_esc_comment_no_longer_claims_a_hazard_this_path_cannot_cause(self) -> None:
-        """#729 AC4, anchored BY TEXT — the line number has rotted twice (:1467 → :1498-1499 →
-        :1503-1504), so pinning one is how this guard goes stale again."""
-        src = pathlib.Path(cm.__file__).read_text(encoding="utf-8")
-        assert "Never mid-turn, and never ESC" not in src, (
-            "the comment still forbids mid-turn on an ESC rationale, but insert_prompt sends "
-            "send-text then a separate send-keys Enter and never an ESC")
-        assert "send-keys" in src or "no ESC" in src, (
-            "the replacement must state the real delivery mechanism, not merely delete the claim")
+        Added because the first version of this change gated on `tier == "directive"` alone, and
+        NO test failed when the event set was removed — verified by deleting it and re-running.
+        An unguarded restriction is one refactor away from handing the authoritative input channel
+        to every event that ever starts reaching this hook.
+        """
+        t = _transcript(tmp_path, SID, [_row(_usage(inp=1, cr=800_000))])
+        env = {"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:pZZ",
+               "RAWGENTIC_CONTEXT_EVERY_TURNS": "1", "RAWGENTIC_CONTEXT_EVERY_SECONDS": "0"}
+        err = _run({"session_id": SID, "cwd": str(tmp_path), "transcript_path": str(t),
+                    "hook_event_name": "PostToolUse"}, home=tmp_path, extra_env=env).stderr or ""
+        assert "prompt insertion did not happen" not in err, (
+            "PostToolUse is not in INSERT_EVENTS, so it must never reach the insert branch\n"
+            + err)
+        assert "PostToolUse" not in cm.INSERT_EVENTS
+
+    def test_at_most_once_is_keyed_independently_of_the_emit_path(self, tmp_path) -> None:
+        """#729 AC2 — the property that makes widening the gate safe, tested where it LIVES.
+
+        Two earlier versions of this test were vacuous and both are worth recording, because the
+        second looked like a fix for the first:
+
+        1. It called the same helper twice, which is ONE path, so it could not show path
+           independence despite its name (Step-11 review caught this).
+        2. Rewritten to drive the real hook `UserPromptSubmit` then `Stop` — but the second
+           invocation never emitted at all (verified by inspecting both results directly), so
+           "at most one attempt" held for the trivial reason that only one call ever reached the
+           branch. A black-box two-path assertion is not achievable in this harness.
+
+        So this asserts the mechanism itself: the insert reserves on
+        `(session, window, "directive", INSERT_CHANNEL)`, a key with no event or emit-channel
+        component. Whichever path arrives first takes it and the other finds it gone — which is
+        precisely why the gate could be widened without a new state machine.
+        """
+        home, win = str(tmp_path), 1000000
+        assert cm.reserve(home, SID, win, "directive", cm.INSERT_CHANNEL) is True
+        assert cm.reserve(home, SID, win, "directive", cm.INSERT_CHANNEL) is False, (
+            "the second arrival must find the reservation taken, whichever path it came from")
+        # And it must not have consumed either EMIT channel, or widening would silence the nag.
+        assert cm.has_marker(home, SID, win, "directive", "midturn") is False
+        assert cm.has_marker(home, SID, win, "directive", "stop") is False
+
+    def test_the_insert_transport_sends_no_ESC_only_send_text_then_Enter(self) -> None:
+        """#729 AC4, at the TRANSPORT layer.
+
+        The first version of this guard asserted on a comment in `context_meter.py` — a comment
+        this very change wrote, so it guaranteed its own pass and said nothing about the code that
+        could actually send an ESC. Step-11 review called that a tautology and was right. This
+        drives the real `launcher_lib.insert_prompt` with a capturing runner and asserts the exact
+        command sequence instead, so the guard now fails if that route ever gains an ESC.
+        """
+        sys.path.insert(0, str(Path(cm.__file__).parent))
+        import launcher_lib as ll  # noqa: PLC0415
+        seen = []
+
+        def capture(argv, timeout=None):
+            seen.append(list(argv))
+            return types.SimpleNamespace(returncode=0, stdout="ordinary pane scrollback", stderr="")
+
+        ll.insert_prompt(pane="w1:pZZ", text="hello", runner=capture, sleep=lambda _s: None)
+        kinds = [c[2] for c in seen if len(c) > 2]
+        assert "send-text" in kinds, seen
+        assert "send-keys" in kinds, seen
+        flat = " ".join(" ".join(map(str, c)) for c in seen)
+        assert "Escape" not in flat and "\x1b" not in flat, (
+            "the insert route must never send an ESC — that was the old gate's whole rationale\n"
+            + flat)
+        for c in seen:
+            if len(c) > 2 and c[2] == "send-keys":
+                assert c[-1] == "Enter", f"send-keys must send Enter only, got {c}"
 
     def test_an_unreadable_project_config_is_a_quiet_skip(self, tmp_path) -> None:
         env = {"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:pZZ"}

--- a/tests/hooks/test_context_meter.py
+++ b/tests/hooks/test_context_meter.py
@@ -14,6 +14,7 @@ import os
 import stat
 import time
 import subprocess
+import pathlib
 import sys
 import types
 from pathlib import Path
@@ -1905,6 +1906,57 @@ class TestInsertPromptAtTheActTier:
             home=str(tmp_path), session_id=self.SID, window=1000000, used=520000,
             cfg={} if cfg is None else cfg, project_path=project, env=env,
             runner=runner or (lambda argv, timeout: types.SimpleNamespace(returncode=0)))
+
+    def _drive(self, tmp_path, used):
+        """Drive the REAL hook mid-turn, black-box through the subprocess, and hand back stderr.
+
+        A monkeypatch cannot reach across that boundary — this file's own `_run` spawns the hook —
+        so the branch is proven by its observable diagnostic instead of by a mock. `_run` also pops
+        HERDR_ENV, so an attempted insert returns "skipped: not inside herdr" and the module's
+        never-silent contract warns about it. That warning IS the evidence the branch was reached.
+        """
+        t = _transcript(tmp_path, SID, [_row(_usage(inp=1, cr=used))])
+        return _run({"session_id": SID, "cwd": str(tmp_path), "transcript_path": str(t),
+                     "hook_event_name": "UserPromptSubmit"}, home=tmp_path).stderr or ""
+
+    def test_the_midturn_directive_path_attempts_the_insert(self, tmp_path) -> None:
+        """#729 AC1 — the whole point. A directive reached MID-TURN is exactly when the session is
+        deepest in a long turn and least able to act on text it may decline, yet that was the one
+        path with no authoritative channel. Measured before this change: `try_insert_prompt` had a
+        single call site guarded `event == "Stop"`, and this host carried 89 midturn markers
+        against 3 insert markers, every one of them stop-channel."""
+        err = self._drive(tmp_path, 800_000)          # 80% of 1M — above the 75 act line
+        assert "prompt insertion did not happen" in err, (
+            "a mid-turn directive must ATTEMPT the insert; the diagnostic is how a skip is "
+            "distinguished from never having tried\n" + err)
+
+    def test_the_advisory_tier_never_inserts_on_either_path(self, tmp_path) -> None:
+        """#729 AC3. The advisory is a nudge to start looking; seizing the input box for it would
+        be the over-reach this gate exists to prevent."""
+        err = self._drive(tmp_path, 600_000)          # 60% — advisory band under 55/75
+        assert "prompt insertion did not happen" not in err, (
+            "the advisory tier must never reach the insert branch\n" + err)
+
+    def test_at_most_once_per_window_across_BOTH_paths(self, tmp_path) -> None:
+        """#729 AC2 — the property that makes enabling the mid-turn path safe. The insert reserves
+        on its OWN channel keyed (session, window, tier, INSERT_CHANNEL), so a mid-turn insert
+        followed by a Stop directive finds the reservation already taken. Asserted through the real
+        reservation rather than a mock, because a mock would prove nothing about the key."""
+        env = {"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:pZZ"}
+        assert self._try(tmp_path, env=env) == "inserted"
+        assert "already inserted" in self._try(tmp_path, env=env)
+        assert cm.has_marker(str(tmp_path), self.SID, 1000000, "directive",
+                             cm.INSERT_CHANNEL) is True
+
+    def test_the_esc_comment_no_longer_claims_a_hazard_this_path_cannot_cause(self) -> None:
+        """#729 AC4, anchored BY TEXT — the line number has rotted twice (:1467 → :1498-1499 →
+        :1503-1504), so pinning one is how this guard goes stale again."""
+        src = pathlib.Path(cm.__file__).read_text(encoding="utf-8")
+        assert "Never mid-turn, and never ESC" not in src, (
+            "the comment still forbids mid-turn on an ESC rationale, but insert_prompt sends "
+            "send-text then a separate send-keys Enter and never an ESC")
+        assert "send-keys" in src or "no ESC" in src, (
+            "the replacement must state the real delivery mechanism, not merely delete the claim")
 
     def test_an_unreadable_project_config_is_a_quiet_skip(self, tmp_path) -> None:
         env = {"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:pZZ"}


### PR DESCRIPTION
Closes #729.

## The defect

The #718 prompt-insert is the one channel that delivers the handoff directive as **authoritative
user input** rather than injected text a model may decline. It was gated on `event == "Stop"`, so a
session reaching the directive tier **mid-turn never got it** — and mid-turn is exactly when a
session is deepest in a long turn and least able to act on text it can refuse.

Measured, not argued: session `643af1d9` (epic #722) took the directive at 50.7% as injected text,
declined it in its own words, and handed off only because a human intervened — the dependency #718
exists to remove. On this host the ratio was **89 midturn markers against 3 insert markers**, every
insert stop-channel.

## The gate's justification did not apply to the mechanism as built

It cited an ESC hazard. `launcher_lib.insert_prompt` is `read → paste → delay → Enter`:
`herdr pane send-text`, a wait, then a **separate** `herdr pane send-keys <pane> Enter`. Verified
this branch: **no ESC is sent anywhere in `launcher_lib`**, and every `send-keys` call in the file
sends `Enter`. Paste-plus-Enter does not interrupt a running turn — Claude Code queues the input and
surfaces it at the next tool-result boundary.

The read comes first for the same reason the nudge paths read first: an Enter accepts whatever is on
screen, so a permission dialog vetoes it. That protection is unchanged and now applies mid-turn too.

## Why widening is safe

**At-most-once does not live at this branch.** `try_insert_prompt` reserves on its own
`(session, window, "directive", INSERT_CHANNEL)` key, so a mid-turn insert followed by a `Stop`
directive finds the reservation already taken. The key is path-independent, which is what makes the
widening a one-condition change rather than a new state machine.

The advisory tier still never reaches the branch. The fail-open contract is untouched: nothing added
can raise, block a turn, or make the emit conditional on herdr being healthy.

## A scope correction, recorded on the issue

Epic #906's child-note called F1 stale because "mid-turn delivery works now — 111 midturn markers".
**Those count the NAG, not the INSERT.** Measured at `4c56eda0`, `try_insert_prompt` had exactly one
call site and it was `Stop`-gated, so F1 stood as filed and five acceptance criteria were unmet.
Implementing the narrower reading would have shipped acknowledgement-tracking for a channel that
still could not fire when it mattered. Full evidence: issuecomment-5213990549.

## What this does NOT fix, stated plainly

`insert_prompt` returns **`delivered`, never `submitted`** — rc 0 on `send-keys` proves the keystroke
went out, not that a turn accepted it. This change widens *when* the insert fires; it does not close
that acknowledgement gap.

Tonight gave that gap a live demonstration: three `ad-hoc-handoff` attempts failed at `goal_armed`
with **zero `goal_status` rows**, because the goal was **queued behind the successor's running turn**
— every occurrence landed in an `attachment` or `queue-operation` record. That is a third state,
distinct from both "submitted" and "sent but unsubmitted", and #835's nudge correctly refused to fire
on it because a queued message shows no paste affordance. One hypothesis was tested and refuted: a
393-byte prompt failed identically to a 3.5 KB one, so turn length is not the mechanism.

Re-firing on unacknowledged inserts is the natural follow-up and is deliberately **not** in this PR.

## Tests

5 added. The behavioural ones are driven **black-box through the hook subprocess**, because a
`monkeypatch` cannot cross that boundary — an earlier draft did exactly that and **passed
vacuously**. They assert on the module's own never-silent diagnostic instead.

**Every guard was verified by reverting the thing it guards**, which is the only way to know a test
constrains anything:

| Revert | Result |
|---|---|
| gate back to `Stop`-only | mid-turn test **fails** |
| drop `INSERT_EVENTS` | PostToolUse test **fails** |
| — | advisory guard keeps passing throughout |

That discipline is what caught the vacuous at-most-once test twice, and the unguarded event set
that neither reviewer spotted.

## Review: seven findings, three real defects, all fixed

Two independent passes converged on three things and were right about each.

1. **The gate was event-agnostic.** `tier == "directive"` alone admits *every* event, not the one
   path this issue asked for. Now `event in INSERT_EVENTS and tier == "directive"`.
2. **The at-most-once test was vacuous — twice.** First it called one helper twice (one path,
   despite the name). Rewriting it to drive the real hook did not fix it: the second invocation
   never emitted, so the assertion held trivially. Both dead ends are recorded in the test's
   docstring. It now asserts the mechanism where it lives — the reservation key carries no event
   or emit-channel component.
3. **The ESC guard was a tautology.** It asserted on a comment this change wrote. Replaced with a
   transport-level test that drives `insert_prompt` with a capturing runner and asserts the real
   command sequence.

**And one gap neither reviewer raised:** removing the new event set broke no test. Every guard was
then verified by reverting the thing it guards — Stop-only fails the mid-turn test, dropping
`INSERT_EVENTS` fails the new PostToolUse test.

### Partially declined, with reason

Both passes asked for an integration test proving mid-turn input is queued rather than interrupting
a running turn. That needs a live Claude turn and cannot be a unit test in this suite. The claim is
instead backed by direct observation from this session: three handoffs sent text plus Enter into
panes mid-turn, and every occurrence landed in a `queue-operation` record, interrupting nothing.
Saying so here rather than asserting it silently.

## Verification

- Full suite: **6352 → 6357**, exit 0.
- Both pylint lanes 10.00/10.
- No workflow-spine change → **no diagram REV**.

## Deferred verification

None. Every acceptance criterion is verifiable by unit test; `has_deploy` is false.
