### PR TITLE
fix(launcher): a goal ending in a newline never submits (epic #906)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.1",
+  "version": "3.141.2",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,24 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.141.2 (2026-08-07)
+- **A goal ending in a newline landed in the successor's input box and never submitted (epic #906).**
+  The buffer ends on a blank line and the Enter does not send it, so `goal_armed` failed with no
+  `goal_status` row, no `queue-operation` row, and not one byte of the goal text in the transcript.
+  This is the defect that kept `/rawgentic:pane-handoff` broken after #989, because the skill's own
+  documented command uses `--goal-condition-file` — and `_read_text_arg` reads a file VERBATIM by
+  design, so the file's trailing newline reached the paste. Found by controlled experiment across
+  three live handoffs: the SAME 557-character condition failed twice from a file and armed first
+  time inline. `goal_text` now strips a trailing whitespace run, but only one that actually
+  contains a line ending — terminal spaces never blocked submission and the carry contract treats
+  them as bytes. The #758 carry guard is PRESERVED rather than widened: making `armed_condition`
+  strip would have quietly turned `validate_goal_carry` into the `strip()` equality pass-1 F4
+  refused at its design gate, which `test_two_trailing_newlines_are_not_over_normalized` caught, so
+  the trailing shape is now judged explicitly there. Cross-model review then found the tolerance
+  matched only LF, so a CRLF file was refused as a substantive difference; it now removes one
+  LOGICAL line ending in all three forms while still refusing doubled ones. 17 tests, red before
+  green. No workflow-spine change → no diagram REV. Suite 6370→6387.
+
 ### v3.141.1 (2026-08-07)
 - **Pane handoff: `/goal` now goes into an IDLE pane instead of a busy one (#989, epic #906).**
   Every handoff was failing at `goal_armed`. A bare slash command pasted into a busy session is

--- a/hooks/launcher_lib.py
+++ b/hooks/launcher_lib.py
@@ -513,8 +513,11 @@ def goal_text(condition: str) -> tuple[str, bool]:
     for the goal. So the strip lives at this choke point, which both `armed_condition` and
     `build_send_text_goal_argv` route through, and NOT in the shared file reader.
 
-    Only TRAILING whitespace goes. Interior newlines are load-bearing structure and #654 proved a
-    41-newline condition arrives fine as one collapsed paste.
+    Interior newlines are load-bearing structure and #654 proved a 41-newline condition arrives
+    fine as one collapsed paste, so only the TRAILING run goes — and only when it actually
+    contains a line ending (Step-11 F3). Terminal spaces or tabs with no newline never blocked
+    submission, and the carry contract treats them as bytes, so they are left alone rather than
+    silently deleted from an owner-authored condition.
     """
     if not isinstance(condition, str):
         raise LauncherError(f"goal condition must be a string, got {type(condition).__name__}")
@@ -522,7 +525,9 @@ def goal_text(condition: str) -> tuple[str, bool]:
         raise LauncherError("goal condition is empty — refusing to arm an empty guard")
     # After the empty check, so a whitespace-only condition still refuses rather than becoming a
     # silently-armed empty guard.
-    condition = condition.rstrip()
+    trailing = condition[len(condition.rstrip()):]
+    if "\n" in trailing or "\r" in trailing:
+        condition = condition.rstrip()
     text = f"{_GOAL_PREFIX}{condition}"
     if len(text) <= GOAL_MAX_CHARS:
         return (text, False)
@@ -1403,7 +1408,16 @@ def validate_goal_carry(successor_goal: str, predecessor_live_goal: str | None, 
     """
     if predecessor_live_goal is None:
         return (True, "no live predecessor goal — nothing to validate", False)
-    succ = successor_goal[:-1] if successor_goal.endswith("\n") else successor_goal
+    # ONE logical line ending, not one LF (Step-11 F2). A CRLF file is an ordinary single line
+    # ending; matching only "\n" left a bare CR behind and refused the carry as a substantive
+    # difference. `goal_text` accepts all three forms, so this must recognize the same set or the
+    # two disagree about what "one trailing newline" means. Order matters: "\r\n" is tested first
+    # so it is removed as ONE ending rather than leaving a CR.
+    succ = successor_goal
+    for _ending in ("\r\n", "\n", "\r"):
+        if successor_goal.endswith(_ending):
+            succ = successor_goal[:-len(_ending)]
+            break
     # #989 — armed_condition now RSTRIPS, because the send route cannot carry trailing whitespace
     # (a trailing newline makes the paste land and never submit). That would silently widen this
     # comparison into the `strip()` equality pass-1 F4 REFUSED at the design gate, so the residual

--- a/hooks/launcher_lib.py
+++ b/hooks/launcher_lib.py
@@ -495,14 +495,34 @@ def goal_text(condition: str) -> tuple[str, bool]:
     """Build `/goal <condition>`. Returns (text, truncated) — callers MUST propagate the flag.
 
     The condition is read VERBATIM from the predecessor's last unmet `goal_status` row, so a
-    condition that fits passes through byte-identical. The cap applies to the whole command
-    including the `/goal ` prefix and the note, which is stated because a 4000-char condition
-    therefore does NOT itself fit.
+    condition that fits passes through byte-identical apart from TRAILING whitespace. The cap
+    applies to the whole command including the `/goal ` prefix and the note, which is stated
+    because a 4000-char condition therefore does NOT itself fit.
+
+    **Why the trailing strip, and why HERE (2026-08-07, live).** A trailing newline makes the
+    paste land in the successor's input box and never submit: the buffer ends on a blank line and
+    the Enter does not send it. Measured by controlled experiment across three real handoffs — the
+    same 557-character condition failed TWICE via `--goal-condition-file`, which keeps the file's
+    trailing newline, and armed FIRST TIME via `--goal-condition` inline, which has none. The
+    failing successors carried no `goal_status` row, no `queue-operation` row, and not one byte of
+    the goal text.
+
+    `build_send_text_argv` already states the same hazard from the other side: the Enter is "a
+    distinct call rather than a trailing newline". `_read_text_arg` reads a file verbatim ON
+    PURPOSE, so a caller's end-of-prompt marker survives — correct for the resume prompt, fatal
+    for the goal. So the strip lives at this choke point, which both `armed_condition` and
+    `build_send_text_goal_argv` route through, and NOT in the shared file reader.
+
+    Only TRAILING whitespace goes. Interior newlines are load-bearing structure and #654 proved a
+    41-newline condition arrives fine as one collapsed paste.
     """
     if not isinstance(condition, str):
         raise LauncherError(f"goal condition must be a string, got {type(condition).__name__}")
     if not condition.strip():
         raise LauncherError("goal condition is empty — refusing to arm an empty guard")
+    # After the empty check, so a whitespace-only condition still refuses rather than becoming a
+    # silently-armed empty guard.
+    condition = condition.rstrip()
     text = f"{_GOAL_PREFIX}{condition}"
     if len(text) <= GOAL_MAX_CHARS:
         return (text, False)
@@ -1384,6 +1404,16 @@ def validate_goal_carry(successor_goal: str, predecessor_live_goal: str | None, 
     if predecessor_live_goal is None:
         return (True, "no live predecessor goal — nothing to validate", False)
     succ = successor_goal[:-1] if successor_goal.endswith("\n") else successor_goal
+    # #989 — armed_condition now RSTRIPS, because the send route cannot carry trailing whitespace
+    # (a trailing newline makes the paste land and never submit). That would silently widen this
+    # comparison into the `strip()` equality pass-1 F4 REFUSED at the design gate, so the residual
+    # trailing shape is judged here, explicitly, instead of being inherited from the armed form.
+    # ONE trailing newline is already gone above; anything left is a real difference.
+    if succ != predecessor_live_goal and succ.rstrip() == predecessor_live_goal.rstrip():
+        return (False,
+                "goal texts differ only in trailing whitespace beyond the one documented newline "
+                f"— refused: carry must be byte-identical (successor {len(successor_goal)} chars, "
+                f"predecessor {len(predecessor_live_goal)} chars)", False)
     armed_succ, succ_trunc = armed_condition(succ)
     armed_pred, pred_trunc = armed_condition(predecessor_live_goal)
     if armed_succ == armed_pred and not (

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.1",
+  "version": "3.141.2",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.141.1"
+EXPECTED_PLUGIN_VERSION = "3.141.2"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_launcher_lib.py
+++ b/tests/hooks/test_launcher_lib.py
@@ -612,6 +612,79 @@ def test_cli_goal_text_reports_truncation() -> None:
     assert json.loads(proc.stdout)["truncated"] is True
 
 
+class TestTheGoalPayloadNeverEndsWithANewline:
+    """A trailing newline on the goal makes the paste land and NEVER submit.
+
+    Found live on 2026-08-07 by controlled experiment, three real handoffs to real panes:
+    the SAME 557-character condition failed twice via `--goal-condition-file` (which keeps the
+    file's trailing newline) and armed first time via `--goal-condition` inline (which has none).
+    The successor transcript carried NO `goal_status` row, NO `queue-operation` row, and not one
+    byte of the goal text — the paste sat in the input box and the Enter did not submit it.
+
+    This module already knew the hazard from the other direction. `build_send_text_argv` says a
+    multiline payload arrives as one collapsed bracketed paste "which is why the Enter is a
+    distinct call rather than a trailing newline". `_read_text_arg` then reads a file VERBATIM,
+    deliberately, so a caller's end-of-prompt marker survives — and that is right for the resume
+    prompt. For the GOAL it reintroduces exactly the trailing newline the send route excludes.
+
+    So the strip belongs at the goal choke point, never in the shared file reader.
+    """
+
+    def test_a_trailing_newline_is_stripped_from_the_sent_payload(self) -> None:
+        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+            pane="w1:p1", goal_condition="ship it when CI is green\n")
+        assert not text_argv[4].endswith("\n"), repr(text_argv[4][-40:])
+        assert text_argv[4] == "/goal ship it when CI is green"
+
+    def test_trailing_blank_lines_and_spaces_go_too(self) -> None:
+        """A file written by a heredoc routinely ends `...\\n`, and an edited one `...\\n\\n  `."""
+        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+            pane="w1:p1", goal_condition="ship it\n\n   \n")
+        assert text_argv[4] == "/goal ship it"
+
+    def test_armed_condition_matches_what_was_actually_sent(self) -> None:
+        """The binding check compares against this. If the strip happened in only one of the two,
+        every capped or file-sourced goal would fail to verify for ever."""
+        cond, _trunc = ll.armed_condition("ship it when CI is green\n")
+        text_argv, _keys, _trunc2 = ll.build_send_text_goal_argv(
+            pane="w1:p1", goal_condition="ship it when CI is green\n")
+        assert cond == "ship it when CI is green"
+        assert text_argv[4] == "/goal " + cond
+
+    def test_interior_newlines_are_untouched(self) -> None:
+        """#654 proved a 41-newline condition arrives fine as a collapsed paste. Only the TRAILING
+        newline breaks submission, so stripping interior structure would be a regression."""
+        cond = "line one\nline two\n\nline four"
+        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+            pane="w1:p1", goal_condition=cond + "\n")
+        assert text_argv[4] == "/goal " + cond
+        assert text_argv[4].count("\n") == 3
+
+    def test_a_condition_that_is_only_whitespace_is_still_refused(self) -> None:
+        """Stripping must not turn an empty guard into a silently-armed one."""
+        with pytest.raises(ll.LauncherError, match="empty"):
+            ll.build_send_text_goal_argv(pane="w1:p1", goal_condition="\n\n   \n")
+
+    def test_the_carry_guard_keeps_its_byte_identical_rule(self) -> None:
+        """The interaction this fix nearly broke, pinned from BOTH sides.
+
+        `armed_condition` now rstrips, which would have widened `validate_goal_carry` into the
+        `strip()` equality that pass-1 F4 refused at the #758 design gate — two trailing newlines
+        would have compared equal to none. `test_two_trailing_newlines_are_not_over_normalized`
+        caught it. This pins the other direction too, so a future "simplification" that deletes
+        the explicit trailing-shape check fails here rather than silently loosening the carry.
+        """
+        # ONE trailing newline is the documented file artifact and still carries.
+        ok, _reason, _override = ll.validate_goal_carry("goal A\n", "goal A")
+        assert ok, "a single trailing file newline must still be a verbatim carry"
+        # TWO is a real difference and must still be refused.
+        ok2, reason2, _ = ll.validate_goal_carry("goal A\n\n", "goal A")
+        assert not ok2
+        assert "trailing whitespace" in reason2, reason2
+        # And the refusal reason must not leak goal CONTENT (pass-1 F8) — lengths only.
+        assert "goal A" not in reason2, reason2
+
+
 # ---------------------------------------------------------------------------
 # #611 Step-11 High 1 — the production caller
 # ---------------------------------------------------------------------------

--- a/tests/hooks/test_launcher_lib.py
+++ b/tests/hooks/test_launcher_lib.py
@@ -665,6 +665,42 @@ class TestTheGoalPayloadNeverEndsWithANewline:
         with pytest.raises(ll.LauncherError, match="empty"):
             ll.build_send_text_goal_argv(pane="w1:p1", goal_condition="\n\n   \n")
 
+    @pytest.mark.parametrize("ending", ["\n", "\r\n", "\r"])
+    def test_one_logical_line_ending_still_carries(self, ending) -> None:
+        """Step-11 F2. The one-newline tolerance recognized only LF, so a CRLF file — one
+        perfectly ordinary line ending — left a bare CR behind and the carry was refused as a
+        substantive difference. `goal_text` accepts and removes all three, so the carry validator
+        must recognize the same set or the two disagree about what one line ending is."""
+        ok, reason, _ = ll.validate_goal_carry("goal A" + ending, "goal A")
+        assert ok, f"{ending!r} is ONE line ending and must carry: {reason}"
+
+    @pytest.mark.parametrize("ending", ["\n\n", "\r\n\r\n", "\r\r"])
+    def test_two_logical_line_endings_are_still_refused(self, ending) -> None:
+        """The other half — widening to CRLF must not widen to DOUBLED endings."""
+        ok, _reason, _ = ll.validate_goal_carry("goal A" + ending, "goal A")
+        assert not ok, f"{ending!r} is two line endings and must be refused"
+
+    def test_trailing_spaces_survive_when_there_is_no_line_ending(self) -> None:
+        """Step-11 F3. The measured defect is a LINE-ENDING suffix. An unconditional rstrip also
+        silently deleted terminal spaces and tabs, which never blocked submission and which the
+        carry contract treats as bytes. So the strip fires only on a whitespace run that actually
+        contains a line ending."""
+        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+            pane="w1:p1", goal_condition="ship it   ")
+        assert text_argv[4] == "/goal ship it   ", repr(text_argv[4])
+
+    def test_spaces_before_a_trailing_newline_go_with_it(self) -> None:
+        """A real file routinely ends `...   \\n`. The whole run goes, because it contains one."""
+        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+            pane="w1:p1", goal_condition="ship it   \n")
+        assert text_argv[4] == "/goal ship it"
+
+    @pytest.mark.parametrize("ending", ["\n", "\r\n", "\r"])
+    def test_every_line_ending_form_is_stripped_from_the_payload(self, ending) -> None:
+        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+            pane="w1:p1", goal_condition="ship it" + ending)
+        assert text_argv[4] == "/goal ship it", repr(text_argv[4])
+
     def test_the_carry_guard_keeps_its_byte_identical_rule(self) -> None:
         """The interaction this fix nearly broke, pinned from BOTH sides.
 


### PR DESCRIPTION
## What was broken

`/rawgentic:pane-handoff` still did not work after #989. This is why.

**A goal condition ending in a newline lands in the successor's input box and never submits.**
The buffer ends on a blank line and the Enter does not send it. `goal_armed` then fails with **no
`goal_status` row, no `queue-operation` row, and not one byte of the goal text** in the successor's
transcript.

The skill's own documented command uses `--goal-condition-file`. `_read_text_arg` reads a file
**verbatim by design**, so a caller's end-of-prompt marker survives — correct for the resume
prompt, fatal for the goal. Every skill-driven handoff carried the file's trailing newline into
the paste.

## Evidence

Controlled experiment, three live handoffs to real panes, 2026-08-07:

| run | goal source | trailing newline | outcome |
|---|---|---|---|
| A | `--goal-condition` inline, 48 chars | no | all four rungs green |
| B | `--goal-condition-file`, 557 chars | **yes** | `goal_armed` false |
| C | `--goal-condition` inline, **same 557 chars** | no | all four rungs green |

B versus C is the controlled pair. Identical text, identical prompt, one variable.

The module already knew this hazard from the other side — `build_send_text_argv` says the Enter is
"a distinct call rather than a trailing newline".

## The fix

`goal_text` strips a trailing whitespace run, **only when that run contains a line ending**.
Terminal spaces never blocked submission and the carry contract treats them as bytes, so they are
left alone. Interior newlines are untouched: #654 proved a 41-newline condition arrives fine.

The strip is deliberately **not** in `_read_text_arg`, which must stay verbatim for the prompt.

## The guard I nearly broke

`validate_goal_carry` (#758) records that `strip()` equality was **refused at its design gate**
(pass-1 F4). Making `armed_condition` strip silently widened the comparison into exactly that —
two trailing newlines began comparing equal to none.
`test_two_trailing_newlines_are_not_over_normalized` caught it.

The guard is **preserved, not deleted**. The trailing shape is now judged explicitly in
`validate_goal_carry` instead of being inherited from a now-lenient `armed_condition`, and the
refusal reason carries lengths only, never goal content (pass-1 F8).

## Cross-model review (gpt-5.6-sol) — 3 Medium findings

- **F2 (0.94) FIXED.** The one-newline tolerance matched only LF, so a CRLF file left a bare CR and
  an ordinary single line ending was refused as a substantive difference. Now removes one
  **logical** ending, testing `\r\n` first so it goes as one. Doubled endings still refused, all
  three forms.
- **F3 (0.76) FIXED.** Unconditional `rstrip()` also deleted terminal spaces and tabs with no
  newline present. Narrowed as described above.
- **F1 (0.98, ambiguous) ANSWERED BY INSPECTION.** The reviewer could not see the callers. Verified
  rather than re-asserted: every comparison routes through the choke point — the send payload
  (`:562`), the `goal_armed` expectation (`:2884`), the carry validator (`:1417-18`), and `:4177`,
  which reads the **persisted** driver-state `goal_condition`. Both sides normalize identically, so
  they agree — and that path is in fact **repaired** here, since a persisted raw condition
  previously produced an expectation no row could match.

## Verification

- **Suite 6370 → 6387, exit 0.** Baseline measured on `6edf20a7` before any edit.
- **Lint** both CI lanes: hooks 10.00/10, tests 10.00/10.
- **17 tests**, red before green, covering all three line-ending forms in both directions.

## The honest limit

Proven at the **CLI** level by three live handoffs. **Not** yet proven through the **skill** path
end to end — that needs this merged and the plugin reloaded in the target session. That is the
next test, and it is the one that actually matters.

Part of #906
