### PR TITLE
fix(context-meter): make prolonged blindness visible and say what is true now (#734)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.4",
+  "version": "3.141.5",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -769,7 +769,12 @@ For major changes, please open an issue first to discuss the approach.
   one-issue convention: `skills/pane-handoff/SKILL.md` now records that a `/goal` arms only when it
   leads the submitted text, so a hand-carried handoff must print the goal in its own block and say
   how to send it — the wired path already did this and is unchanged.
-  No workflow-spine change, so no diagram REV. Suite 6393→6402.
+  Cross-model review then refused the first revision's `== BLIND_STREAK_WARN` gate: a counter
+  arriving already past the threshold would increment straight past equality and never warn at all,
+  which is a fail-open on the one signal this issue adds. It is now `>=` plus an explicit
+  once-per-episode flag cleared on a successful reading, so the guarantee holds for any starting
+  value. 12 tests added in total.
+  No workflow-spine change, so no diagram REV. Suite 6393→6405.
 
 ### v3.141.4 (2026-08-07)
 - **#989's send reorder is REVERTED — `/goal` goes last again (epic #906).** #989 moved the goal

--- a/README.md
+++ b/README.md
@@ -749,6 +749,28 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.141.5 (2026-08-07)
+- **The context meter now says when it is blind, and its state says what is true NOW (#734, epic
+  #906).** `hooks/context_meter.py` records a diagnostic through `_diagnose`, which is
+  once-per-session, so a session that could take no reading emitted one stderr line and then went
+  quiet — measured at 44 minutes and 368,175 tokens with a single warning fired before any of it.
+  Two additive changes: `blind_streak` counts consecutive checks that took no reading and resets on
+  a successful one, and a second stderr warning fires when it reaches `BLIND_STREAK_WARN` (5), on
+  `==` so it is exactly once per blind episode and re-arms only after a real reading. Both blind
+  kinds count toward the streak, because the issue's own live reproduction was blind via
+  `no_usage_row` rather than `transcript_unresolved`. Separately, `diagnostics_current` is rebuilt
+  every check and persisted next to the append-only `diagnostics` ledger, which nothing ever cleared
+  — reading that ledger as current state is the misreading #734 was originally filed on, and it is
+  what made `session_unbound` appear to persist after a later bind. Two of the issue's own
+  acceptance criteria already held and are now pinned by regression tests rather than changed:
+  resolution was never latched, and `turns` counting prompts rather than tool calls is by design, so
+  AC4 is pinned against `last_check_ts` per the issue's 2026-08-07 revalidation. 9 tests added in
+  `tests/hooks/test_context_meter.py`. Also folded in by owner decision, against the usual one-PR-
+  one-issue convention: `skills/pane-handoff/SKILL.md` now records that a `/goal` arms only when it
+  leads the submitted text, so a hand-carried handoff must print the goal in its own block and say
+  how to send it — the wired path already did this and is unchanged.
+  No workflow-spine change, so no diagram REV. Suite 6393→6402.
+
 ### v3.141.4 (2026-08-07)
 - **#989's send reorder is REVERTED — `/goal` goes last again (epic #906).** #989 moved the goal
   ahead of the resume prompt on the reasoning that a bare slash command pasted into a busy pane is

--- a/docs/planning/campaign-log.md
+++ b/docs/planning/campaign-log.md
@@ -14,6 +14,54 @@ shipped; live run owner-gated). M1–M4 **COMPLETE**; the **epic #188 fast-follo
 
 ---
 
+## Epic #906 M2 — #734: the context meter says when it is blind · v3.141.5
+
+**Issue:** [#734](https://github.com/3D-Stories/rawgentic/issues/734) ·
+**Design:** brief note, small-standard lane (no separate design doc)
+
+**The issue's headline fix was falsified, and the run said so instead of building it.** #734 was
+filed on the reading that the meter latches an unresolved transcript and never recovers. It does
+not. `resolve_transcript` runs fresh on every non-throttled check, after the throttle, and the
+`transcript_unresolved` branch sets no suppression flag — verified against the code rather than
+taken from the issue's own later revalidation comment. Two of the six acceptance criteria therefore
+described behavior that already worked, so this slot pins them with regression tests rather than
+changing code, and says so in the PR body so a reviewer does not have to infer it.
+
+**What was actually broken was the reporting, in two ways.** First, `diagnostics` is append-only and
+nothing ever removed an entry, so it means "happened at least once", never "is true now" — which is
+why a state file frozen at turn 3 reads as permanently blind, and it is the misreading the issue was
+originally filed on. `diagnostics_current` is now rebuilt every check alongside it, which is what
+makes `session_unbound` stop being reported after a later bind. Second, `_diagnose` is
+once-per-session, so a genuinely blind session emitted one stderr line at minute 0 and nothing for
+the next 44 minutes while it consumed 368,175 tokens. A `blind_streak` counter now drives one
+further warning once blindness outlives five checks, and both blind kinds count toward it because
+the issue's own live reproduction was blind via `no_usage_row`, not `transcript_unresolved`.
+
+**A third acceptance criterion was aimed at the wrong field and was re-aimed, not quietly
+satisfied.** AC4 asks that `turns` advance over a session driven mainly by tool calls. `turns`
+increments at exactly one site, guarded by `event == "UserPromptSubmit"`, so a tool-driven session
+leaving it frozen is by design. The test drives the hook through `PostToolUse` payloads only, exactly
+as the criterion asks, and pins `last_check_ts` instead. The re-aim is posted as a comment on the
+issue.
+
+**What review caught.** The cross-model pass refused the first cut's `== BLIND_STREAK_WARN` gate: a
+counter arriving already past the threshold increments straight past equality and then never warns
+at all, which is a fail-open on the one signal the issue exists to add, in a state file the user can
+write. Now `>=` plus an explicit once-per-episode flag, so the guarantee holds for any starting
+value. It also caught a constant comment claiming 5 was "one full cadence arm" when it is five
+intervals. Declined with recorded reason: a High finding recommending the `/goal` send order be
+inverted — that is this diff's prose only, it did not create the window, and the same
+recommendation shipped as #989 and was reverted by owner decision D298 one day earlier on measured
+evidence.
+
+**Deviation, recorded.** `skills/pane-handoff/SKILL.md` carries an unrelated prose change in this PR
+— a `/goal` arms only when it leads the submitted text — folded in by owner decision after the
+mixed-scope concern was raised. Repo convention is one PR per issue.
+
+Suite 6393→6405, exit 0. Both lint lanes 10.00/10. Security scan clean. 12 tests added.
+
+---
+
 ## Epic #871 M4 — #944: claim-inventory coverage + the obsolete-child owner gate · v3.136.0
 
 **Two documented holes, closed.** The receipt used to attest only *that a look happened and left

--- a/hooks/context_meter.py
+++ b/hooks/context_meter.py
@@ -94,9 +94,15 @@ DEFAULT_EVERY_SECONDS = 300
 # #734 — how many CONSECUTIVE checks may take no reading before the meter says so a
 # second time. `_diagnose` is once-per-session, so without this a session that stays
 # blind emits one stderr line at minute 0 and nothing for the next 44 minutes, which is
-# the window the issue measured. 5 is one full cadence arm (DEFAULT_EVERY_TURNS), so the
-# warning lands only after blindness has outlived a normal check interval rather than
-# firing on a single early miss — the transcript genuinely does not exist yet at turn 1.
+# the window the issue measured.
+#
+# Five NON-THROTTLED CHECKS, which is five cadence intervals and not one. Under the
+# defaults that is about 25 turns or about 25 minutes of continuous blindness. An earlier
+# comment here called it "one full cadence arm", which was simply wrong, and cross-model
+# review caught it. The delay is deliberate at this length: the measured blind window ran
+# 44 minutes, so a warning at roughly 25 sits well inside it, while a threshold of 1 or 2
+# would fire on the ordinary first-turn miss where the transcript does not exist yet —
+# which is the noise the once-per-session design was avoiding in the first place.
 BLIND_STREAK_WARN = 5
 
 _BLOCK = 65536
@@ -1420,20 +1426,31 @@ def cmd_hook(argv) -> int:
         current.append(blind_kind)
         state["diagnostics_current"] = current
         _diagnose(state, blind_kind, blind_message)
-        streak = (_as_int(state.get("blind_streak")) or 0) + 1
+        # `max(0, ...)` so a corrupt or hand-edited NEGATIVE counter cannot park the
+        # streak below zero and delay the warning by that many checks.
+        streak = max(0, _as_int(state.get("blind_streak")) or 0) + 1
         state["blind_streak"] = streak
         # ONE further warning once blindness PERSISTS. `_diagnose` above is
         # once-per-session by design, which is correct for a transient first-turn miss
         # and wrong for a meter that never recovers: the measured case went 44 minutes
         # and 368,175 tokens with exactly one stderr line, emitted before any of it.
         #
-        # `==`, not `>=`: that makes it exactly once per blind EPISODE rather than once
-        # per call, and it re-arms only after a real reading resets the streak to 0. A
-        # second episode is new information and deserves to be said again.
+        # `>=` PLUS an explicit once-flag, rather than an `== BLIND_STREAK_WARN` gate.
+        # The equality form was the first revision and cross-model review refused it: a
+        # state file arriving with a counter already past the threshold — corrupt, hand
+        # edited, or written by a future version — increments straight past equality and
+        # then never warns at all, for the whole session. That is a fail-OPEN on the one
+        # signal this issue exists to add. The flag makes "exactly one warning per blind
+        # episode" hold for ANY starting value, which is what the acceptance criterion
+        # actually asks for.
+        #
+        # The flag is cleared on a successful reading below, so a SECOND blind episode
+        # warns again. That is deliberate: a fresh episode is new information.
         #
         # Precedent for speaking up at all: the unwritable-state-dir warning below. A
         # self-disabled meter is never invisible — that is this module's contract.
-        if streak == BLIND_STREAK_WARN:
+        if streak >= BLIND_STREAK_WARN and not state.get("blind_warning_emitted"):
+            state["blind_warning_emitted"] = True
             _warn(f"context_meter: blind for {streak} consecutive checks "
                   f"({blind_kind}) — no context reading has been taken for this "
                   "session, so no advisory or directive can fire however large it "
@@ -1445,6 +1462,7 @@ def cmd_hook(argv) -> int:
     # blind kinds. `session_unbound` may still be in `current` — that is a separate,
     # still-true condition and it stays until a later bind clears it.
     state["blind_streak"] = 0
+    state["blind_warning_emitted"] = False
     state["diagnostics_current"] = current
 
     window, provenance = resolve_window(cfg.get("windowSize"),

--- a/hooks/context_meter.py
+++ b/hooks/context_meter.py
@@ -91,6 +91,13 @@ DEFAULT_ACT_PCT = 75              # AC3 — act now (gap 20, above MIN_TIER_GAP_
 MIN_TIER_GAP_PCT = 10
 DEFAULT_EVERY_TURNS = 5
 DEFAULT_EVERY_SECONDS = 300
+# #734 — how many CONSECUTIVE checks may take no reading before the meter says so a
+# second time. `_diagnose` is once-per-session, so without this a session that stays
+# blind emits one stderr line at minute 0 and nothing for the next 44 minutes, which is
+# the window the issue measured. 5 is one full cadence arm (DEFAULT_EVERY_TURNS), so the
+# warning lands only after blindness has outlived a normal check interval rather than
+# firing on a single early miss — the transcript genuinely does not exist yet at turn 1.
+BLIND_STREAK_WARN = 5
 
 _BLOCK = 65536
 DEFAULT_MAX_BYTES = 4 * 1024 * 1024   # the largest transcript here is 83 MB
@@ -1327,6 +1334,12 @@ def cmd_hook(argv) -> int:
     if event == "Stop" and payload.get("stop_hook_active") is not True:
         return 0
 
+    # `turns` counts PROMPTS, not tool calls, and that is deliberate — this is the only
+    # site that increments it. #734 was filed partly on the reading that a frozen `turns`
+    # over a long tool-driven run proves the meter is dead; it does not. An agentic run
+    # that submits one prompt and then makes two hundred tool calls correctly shows
+    # `turns: 1`. The field that tracks whether the meter is ALIVE is `last_check_ts`,
+    # which every non-throttled check advances below.
     if event == "UserPromptSubmit":
         state["turns"] = (_as_int(state.get("turns")) or 0) + 1
 
@@ -1353,10 +1366,20 @@ def cmd_hook(argv) -> int:
             save_state(home, session_id, state)
         return 0
 
+    # #734 — `diagnostics` is an append-only LEDGER. It records that a kind happened at
+    # least once; nothing anywhere removes an entry. So a state file carrying
+    # `transcript_unresolved` does NOT prove the meter is blind at read time, and reading
+    # it that way is the mistake this issue was originally filed on. `current` is rebuilt
+    # from scratch on every check and persisted as `diagnostics_current`, so there is one
+    # field that answers "what is wrong RIGHT NOW". The ledger keeps its meaning because
+    # the history is worth having — and because existing tests pin it.
+    current = []
+
     workspace = find_workspace(payload.get("cwd"))
     project, project_path = (bound_project(workspace, session_id)
                              if workspace else (None, None))
     if workspace and project is None:
+        current.append("session_unbound")
         # Visible degradation, not a silent one: without the bound project there is no
         # config, so the window falls back to the conservative default and the nag may
         # fire early. Say so once rather than letting it look like a real reading.
@@ -1377,18 +1400,52 @@ def cmd_hook(argv) -> int:
     state["last_check_turn"] = _as_int(state.get("turns")) or 0
     state["last_check_ts"] = now
 
+    # #734 — the two ways a check takes NO reading. They are handled together because
+    # they are the same thing from the operator's seat: no tier is evaluated, so no
+    # advisory and no directive can fire however large the session grows. The issue's own
+    # live reproduction (session 51f74d5b) was blind via `no_usage_row`, not
+    # `transcript_unresolved`, so covering only the latter would miss the case that
+    # prompted the report.
+    blind_kind, blind_message = None, None
     if transcript is None:
-        _diagnose(state, "transcript_unresolved",
-                  f"could not resolve a transcript for session {session_id} "
-                  "— the meter is inactive for this session")
+        blind_kind = "transcript_unresolved"
+        blind_message = (f"could not resolve a transcript for session {session_id} "
+                         "— the meter is inactive for this session")
+    elif used is None:
+        blind_kind = "no_usage_row"
+        blind_message = (f"no parseable message.usage row in {session_id}.jsonl "
+                         "— the meter is inactive for this session")
+
+    if blind_kind is not None:
+        current.append(blind_kind)
+        state["diagnostics_current"] = current
+        _diagnose(state, blind_kind, blind_message)
+        streak = (_as_int(state.get("blind_streak")) or 0) + 1
+        state["blind_streak"] = streak
+        # ONE further warning once blindness PERSISTS. `_diagnose` above is
+        # once-per-session by design, which is correct for a transient first-turn miss
+        # and wrong for a meter that never recovers: the measured case went 44 minutes
+        # and 368,175 tokens with exactly one stderr line, emitted before any of it.
+        #
+        # `==`, not `>=`: that makes it exactly once per blind EPISODE rather than once
+        # per call, and it re-arms only after a real reading resets the streak to 0. A
+        # second episode is new information and deserves to be said again.
+        #
+        # Precedent for speaking up at all: the unwritable-state-dir warning below. A
+        # self-disabled meter is never invisible — that is this module's contract.
+        if streak == BLIND_STREAK_WARN:
+            _warn(f"context_meter: blind for {streak} consecutive checks "
+                  f"({blind_kind}) — no context reading has been taken for this "
+                  "session, so no advisory or directive can fire however large it "
+                  "grows. This warning does not repeat until a reading succeeds.")
         save_state(home, session_id, state)
         return 0
-    if used is None:
-        _diagnose(state, "no_usage_row",
-                  f"no parseable message.usage row in {session_id}.jsonl "
-                  "— the meter is inactive for this session")
-        save_state(home, session_id, state)
-        return 0
+
+    # A reading succeeded, so the streak is spent and the current view is clean of both
+    # blind kinds. `session_unbound` may still be in `current` — that is a separate,
+    # still-true condition and it stays until a later bind clears it.
+    state["blind_streak"] = 0
+    state["diagnostics_current"] = current
 
     window, provenance = resolve_window(cfg.get("windowSize"),
                                         env.get("RAWGENTIC_CONTEXT_WINDOW"),

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.4",
+  "version": "3.141.5",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/skills/pane-handoff/SKILL.md
+++ b/skills/pane-handoff/SKILL.md
@@ -173,6 +173,27 @@ owner is away, never a change embedded inside a >500-character paste — and onl
 `--goal-rewrite-approved '<the owner's verbatim answer>'`, which rides the output JSON as the
 audit record. Multiline is fine — put it in a file and pass the path.
 
+**A `/goal` arms only when it STARTS the text that gets submitted (measured 2026-08-07).** The
+command already respects this: it sends `/goal <condition>` as its own paste with nothing in front
+of it, and it refuses to send the goal at all until `prompt_landed` has proven the resume prompt
+already submitted — which is why `--prompt-marker` is `required=True` rather than optional
+("a skipped check is not a gate", `hooks/launcher_lib.py`). So nothing here needs changing for the
+wired path.
+
+It is the **hand-carried** path that breaks, and it broke twice on 2026-08-07. The owner pasted ONE
+block holding the resume prompt and the goal together: no goal armed, nothing warned, and the
+successor ran unguarded while looking guarded. Typing `/goal` first and pasting the condition after
+it armed first time. So whenever you hand a HUMAN a goal to carry — a herdr-less fallback, a
+`/clear` resume, any block the owner pastes themselves — print the goal in its own block AND say how
+to send it:
+
+> Submit this on its own, AFTER the resume prompt. Type `/goal` first, then paste the condition.
+> A `/goal` that is not the first thing you send does not arm.
+
+This is the same defect as the bare-`/tasklist` finding above, seen from the other side: that one is
+a slash command inert at the END of a prompt, this one is a slash command inert in the MIDDLE of a
+paste. One rule covers both — a slash command runs only when it leads the submission.
+
 **Where it runs.** Read your own binding rather than guessing:
 
 ```bash

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.141.4"
+EXPECTED_PLUGIN_VERSION = "3.141.5"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_context_meter.py
+++ b/tests/hooks/test_context_meter.py
@@ -2067,3 +2067,162 @@ class TestInsertPromptAtTheActTier:
         assert "insert-prompt" in argv and "w1:pQQ" in argv
         assert seen["timeout"] == cm.INSERT_TIMEOUT_S
         assert not argv[-1].startswith("/"), "AC3 — the payload must be prose"
+
+
+# --------------------------------------------------------------------------
+# T12 — #734: prolonged blindness must be VISIBLE, and the state file must say
+# what is true NOW, not merely what happened once.
+#
+# Scope note, because this issue's body is partly falsified by its own later
+# revalidation (comment 2026-08-07T14:54Z, re-verified against the code here):
+#   * There is NO latch on resolution. `resolve_transcript` is called fresh on
+#     every non-throttled check and the unresolved branch sets no suppression
+#     flag. AC1/AC2 therefore already HOLD — these tests pin them so a future
+#     change cannot reintroduce the latch the issue body describes.
+#   * `turns` advancing only on `UserPromptSubmit` is BY DESIGN. AC4 is pinned
+#     against `last_check_ts`, the field that actually tracks liveness.
+# What is genuinely broken, and what the rest of this block covers: a session
+# that IS blind says nothing after its first stderr line, because `_diagnose`
+# is once-per-session.
+# --------------------------------------------------------------------------
+
+def _state(tmp_path, sid=None):
+    return json.loads((tmp_path / ".rawgentic" / "context-meter"
+                       / f"{sid or SID}.json").read_text())
+
+
+# Every invocation is "due" so a streak accumulates instead of being throttled away.
+EVERY_TURN = {"RAWGENTIC_CONTEXT_EVERY_TURNS": "1"}
+
+
+def _blind(tmp_path, event="UserPromptSubmit"):
+    """One check with NO transcript anywhere — the meter can take no reading."""
+    return _run({"session_id": SID, "cwd": str(tmp_path),
+                 "hook_event_name": event}, home=tmp_path, extra_env=EVERY_TURN)
+
+
+def test_blind_streak_counts_consecutive_checks_that_took_no_reading(tmp_path):
+    """AC3's counter. `diagnostics` cannot answer this: it only ever appends."""
+    for _ in range(3):
+        _blind(tmp_path)
+    assert _state(tmp_path)["blind_streak"] == 3
+
+
+def test_a_successful_reading_resets_the_blind_streak(tmp_path):
+    """AC1 — recovery without restarting the session, now observable in state."""
+    for _ in range(2):
+        _blind(tmp_path)
+    assert _state(tmp_path)["blind_streak"] == 2
+    _transcript(tmp_path, SID, [_row(_usage(inp=1, cr=10))])   # far below any tier
+    _run({"session_id": SID, "cwd": str(tmp_path),
+          "hook_event_name": "UserPromptSubmit"}, home=tmp_path, extra_env=EVERY_TURN)
+    assert _state(tmp_path)["blind_streak"] == 0
+
+
+def test_prolonged_blindness_warns_once_not_on_every_call(tmp_path):
+    """AC3 + AC6. The precedent is the unwritable-state-dir warning."""
+    stderr = ""
+    for _ in range(cm.BLIND_STREAK_WARN + 3):
+        stderr += _blind(tmp_path).stderr
+    assert stderr.count("blind for") == 1, (
+        "the prolonged-blindness warning must fire once per episode, not per call")
+
+
+def test_the_prolonged_blindness_warning_rearms_after_a_real_recovery(tmp_path):
+    """A SECOND blind episode is new information and deserves a second warning."""
+    first = ""
+    for _ in range(cm.BLIND_STREAK_WARN):
+        first += _blind(tmp_path).stderr
+    assert first.count("blind for") == 1
+    p = _transcript(tmp_path, SID, [_row(_usage(inp=1, cr=10))])
+    _run({"session_id": SID, "cwd": str(tmp_path),
+          "hook_event_name": "UserPromptSubmit"}, home=tmp_path, extra_env=EVERY_TURN)
+    p.unlink()
+    second = ""
+    for _ in range(cm.BLIND_STREAK_WARN):
+        second += _blind(tmp_path).stderr
+    assert second.count("blind for") == 1
+
+
+def test_a_session_that_resolves_immediately_is_unchanged(tmp_path):
+    """AC6's control arm — no streak, no warning, no new noise."""
+    p = _transcript(tmp_path, SID, [_row(_usage(inp=1, cr=10))])
+    r = _run({"session_id": SID, "cwd": str(tmp_path), "transcript_path": str(p),
+              "hook_event_name": "UserPromptSubmit"}, home=tmp_path)
+    assert r.returncode == 0
+    assert "blind for" not in r.stderr
+    assert _state(tmp_path)["blind_streak"] == 0
+
+
+def test_diagnostics_current_says_what_is_true_now_while_diagnostics_latches(tmp_path):
+    """AC2, and the root of F1's misreading: `diagnostics` means 'ever', not 'now'."""
+    _blind(tmp_path)
+    blind = _state(tmp_path)
+    assert "transcript_unresolved" in blind["diagnostics"]
+    assert "transcript_unresolved" in blind["diagnostics_current"]
+    _transcript(tmp_path, SID, [_row(_usage(inp=1, cr=10))])
+    _run({"session_id": SID, "cwd": str(tmp_path),
+          "hook_event_name": "UserPromptSubmit"}, home=tmp_path, extra_env=EVERY_TURN)
+    healed = _state(tmp_path)
+    assert "transcript_unresolved" in healed["diagnostics"], "the ledger still latches"
+    assert healed["diagnostics_current"] == [], "but the CURRENT view must have cleared"
+
+
+def test_session_unbound_clears_from_the_current_view_after_a_later_bind(tmp_path):
+    """AC2 — a bind that lands after the meter's first look must stop being reported."""
+    root, proj = _workspace(tmp_path)
+    reg = root / "claude_docs" / "session_registry.jsonl"
+    reg.write_text("", encoding="utf-8")                       # not yet bound
+    _transcript(tmp_path, SID, [_row(_usage(inp=1, cr=10))])
+    _run({"session_id": SID, "cwd": str(proj), "hook_event_name": "UserPromptSubmit"},
+         home=tmp_path, cwd=proj, extra_env=EVERY_TURN)
+    assert "session_unbound" in _state(tmp_path)["diagnostics_current"]
+    reg.write_text(json.dumps({"session_id": SID, "project": "p",
+                               "project_path": "./projects/p"}) + "\n", encoding="utf-8")
+    _run({"session_id": SID, "cwd": str(proj), "hook_event_name": "UserPromptSubmit"},
+         home=tmp_path, cwd=proj, extra_env=EVERY_TURN)
+    state = _state(tmp_path)
+    assert "session_unbound" in state["diagnostics"], "the ledger keeps the history"
+    assert "session_unbound" not in state["diagnostics_current"]
+
+
+def test_last_check_ts_advances_on_a_tool_driven_session_while_turns_does_not(tmp_path):
+    """AC4, RE-AIMED.
+
+    The criterion as filed asks that `turns` advance over a tool-driven session.
+    It cannot: `turns` increments at exactly one site, guarded by
+    `event == "UserPromptSubmit"`, so it counts PROMPTS, not tool calls. That is
+    by design, not the defect. `last_check_ts` is the liveness field, and this
+    drives the hook via `PostToolUse` payloads ONLY, exactly as AC4 asks.
+    """
+    p = _transcript(tmp_path, SID, [_row(_usage(inp=1, cr=10))])
+    payload = {"session_id": SID, "cwd": str(tmp_path), "transcript_path": str(p),
+               "hook_event_name": "PostToolUse", "tool_name": "Bash"}
+    _run(payload, home=tmp_path)
+    first = _state(tmp_path)
+    # Age the cached reading past the cadence rather than sleeping through it, so the
+    # test stays deterministic and costs no wall-clock.
+    sfile = tmp_path / ".rawgentic" / "context-meter" / f"{SID}.json"
+    aged = json.loads(sfile.read_text())
+    aged["last_check_ts"] = aged["last_check_ts"] - 10_000
+    sfile.write_text(json.dumps(aged), encoding="utf-8")
+    _run(payload, home=tmp_path)
+    second = _state(tmp_path)
+    assert second["last_check_ts"] > aged["last_check_ts"], (
+        "a tool-driven session must still show a live meter")
+    # Absent, not zero: the increment is the only writer, so a session that submitted no
+    # prompt never creates the key at all. Asserted via .get so the test states the real
+    # shape rather than a tidier one.
+    assert second.get("turns", 0) == first.get("turns", 0) == 0, (
+        "`turns` counts prompts, not tool calls — advancing it here would be the bug")
+
+
+def test_a_malformed_blind_streak_is_tolerated_and_never_raises(tmp_path):
+    """Fail-open (AC5): a corrupt state value must not break the hook."""
+    d = tmp_path / ".rawgentic" / "context-meter"
+    d.mkdir(parents=True)
+    (d / f"{SID}.json").write_text(json.dumps(
+        {"session_id": SID, "blind_streak": "not-a-number"}), encoding="utf-8")
+    r = _blind(tmp_path)
+    assert r.returncode == 0
+    assert _state(tmp_path)["blind_streak"] == 1

--- a/tests/hooks/test_context_meter.py
+++ b/tests/hooks/test_context_meter.py
@@ -2226,3 +2226,42 @@ def test_a_malformed_blind_streak_is_tolerated_and_never_raises(tmp_path):
     r = _blind(tmp_path)
     assert r.returncode == 0
     assert _state(tmp_path)["blind_streak"] == 1
+
+
+def _seed_state(tmp_path, **fields):
+    d = tmp_path / ".rawgentic" / "context-meter"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{SID}.json").write_text(
+        json.dumps({"session_id": SID, **fields}), encoding="utf-8")
+
+
+def test_a_counter_already_past_the_threshold_still_warns(tmp_path):
+    """Step-11 F2. The first revision gated on `== BLIND_STREAK_WARN`.
+
+    A state file arriving with the counter already past the threshold incremented
+    straight past equality and then never warned for the rest of the session — a
+    fail-open on the one signal this issue exists to add.
+    """
+    _seed_state(tmp_path, blind_streak=cm.BLIND_STREAK_WARN + 40)
+    assert "blind for" in _blind(tmp_path).stderr
+
+
+def test_a_negative_counter_does_not_delay_the_warning(tmp_path):
+    """Step-11 F2. A negative value must not buy extra silent checks."""
+    _seed_state(tmp_path, blind_streak=-1)
+    stderr = ""
+    for _ in range(cm.BLIND_STREAK_WARN):
+        stderr += _blind(tmp_path).stderr
+    assert stderr.count("blind for") == 1
+    assert _state(tmp_path)["blind_streak"] == cm.BLIND_STREAK_WARN
+
+
+def test_the_once_flag_clears_only_on_a_real_reading(tmp_path):
+    """The flag is what makes 'exactly once per episode' hold for any start value."""
+    _seed_state(tmp_path, blind_streak=cm.BLIND_STREAK_WARN)
+    _blind(tmp_path)
+    assert _state(tmp_path)["blind_warning_emitted"] is True
+    _transcript(tmp_path, SID, [_row(_usage(inp=1, cr=10))])
+    _run({"session_id": SID, "cwd": str(tmp_path),
+          "hook_event_name": "UserPromptSubmit"}, home=tmp_path, extra_env=EVERY_TURN)
+    assert _state(tmp_path)["blind_warning_emitted"] is False


### PR DESCRIPTION
## Summary

The context meter could take no reading for a long stretch of a session and, after one stderr line at
the very start, never mention it again. Measured in the reporting session: 44 minutes and 368,175
tokens with a single warning, emitted before any of it. `_diagnose` is once-per-session by design,
which is right for a transient first-turn miss and wrong for a meter that stays blind.

Two additive changes in `hooks/context_meter.py`, plus one correction to the record:

- **`blind_streak`** counts consecutive non-throttled checks that took no reading, and resets to 0 on
  a successful one. A second stderr warning fires once the streak reaches `BLIND_STREAK_WARN` (5),
  gated on `>=` plus an explicit `blind_warning_emitted` flag so the "exactly one warning per blind
  episode" guarantee holds for any starting counter value. Both blind kinds count toward the streak,
  because the issue's own live reproduction was blind via `no_usage_row` rather than
  `transcript_unresolved`.
- **`diagnostics_current`** is rebuilt on every check and persisted next to the existing
  `diagnostics` list. `diagnostics` is append-only and nothing ever removed an entry, so it means
  "happened at least once", never "is true now". Reading it as current state is the misreading this
  issue was originally filed on, and it is why `session_unbound` appeared to persist after a later
  bind.
- A comment at the `turns` increment recording that `turns` counts **prompts**, not tool calls.

Closes #734
Part of #906

## Design Decisions

**Two of the issue's own acceptance criteria already held, so this PR pins them with regression tests
rather than changing code.** That is stated here because a reviewer should not have to infer it.

- **There is no latch on resolution.** The body's proposed fix 1 says "never latch an unresolved
  transcript". `resolve_transcript` is already called fresh on every non-throttled check, after the
  throttle, and the `transcript_unresolved` branch sets no suppression flag. I verified this against
  the code rather than taking the issue's later revalidation comment on trust. AC1 and AC2 therefore
  describe behavior that works; what did not work is that the *record* of it lied.
- **AC4 is re-aimed at `last_check_ts`.** As filed it asks that `turns` advance over a session driven
  mainly by tool calls. `turns` increments at exactly one site, guarded by
  `event == "UserPromptSubmit"`, so a tool-driven session leaving it frozen is by design, not the
  defect. The test drives the hook via `PostToolUse` payloads only, exactly as AC4 asks, and asserts
  `last_check_ts` advances while `turns` does not. This re-aim is posted as a comment on #734 rather
  than left silent.

**Scope deviation, taken deliberately and recorded.** `skills/pane-handoff/SKILL.md` carries an
unrelated prose change: a `/goal` arms only when it leads the submitted text, so a hand-carried
handoff must print the goal in its own block and say how to send it. The wired path already does
this and is unchanged. Repo convention is one PR per issue. The owner was asked, the mixed-scope
concern was raised, and the owner chose the fold.

## Verification

- Baseline recorded before any work, on a tree identical to `origin/main`: **6393 passed, exit 0**.
- Final gate: **6405 passed, exit 0**. Delta **+12**, exactly the tests this PR adds.
- Both lint lanes, verbatim from `.github/workflows/lint.yml`: **10.00/10** and **10.00/10**.
- Fail-open contract unchanged: no new path raises, blocks a turn, or gates on anything. A malformed
  or negative `blind_streak` is tolerated and covered by a test.

Every acceptance criterion has a covering test:

| AC | Covering test |
|---|---|
| 1 unresolvable-then-resolvable recovery | `test_a_successful_reading_resets_the_blind_streak` |
| 2 `session_unbound` re-resolves after a later bind | `test_session_unbound_clears_from_the_current_view_after_a_later_bind` |
| 3 prolonged blindness warns exactly once | `test_prolonged_blindness_warns_once_not_on_every_call` |
| 4 state advances on a tool-driven session | `test_last_check_ts_advances_on_a_tool_driven_session_while_turns_does_not` |
| 5 fail-open unchanged | `test_a_malformed_blind_streak_is_tolerated_and_never_raises` |
| 6 the four named tests | all present, plus 3 from the review round |

## Quality Gate Summary

- Design critique (Step 4): 5 findings, 5 resolved, 0 Critical, 1 High
- Plan drift check (Step 6): skipped — small-standard lane
- Per-task review (Step 8a): skipped — no task carried `riskLevel: high`
- Implementation drift check (Step 9): 0 findings
- Code review (Step 11): 3 findings, 3 resolved (0 Critical; the 1 High is declined with reason below)
- Security scan (Step 11.5): 0 blocking, 0 advisory, skipped: `iac` (not applicable to a library)
- Loop-backs used: 1 of 3
- Branch protection on `main`: **unknown** — the probe returned 404 and the classifier only reads
  GitHub's explicit "Branch not protected" body as `unprotected`. Treat the CI lanes, not the server,
  as what enforces these gates.

### The one High finding, declined with reason

Cross-model review (`gpt-5.6-sol`, confidence 0.90) reported that the documented `/goal` ordering
leaves a window in which the successor runs before the guard is armed, and recommended sending the
goal first. Declined on two independent grounds:

1. **Scope.** This PR's change to that file is prose only. It documents the hand-carried path and
   does not touch the send order, so it did not create the window.
2. **Already settled, one day earlier, on measured evidence.** That exact recommendation shipped as
   #989 and was reverted as PR 993 / v3.141.4 by owner decision D298 on 2026-08-07, because the
   original order was measured running reliably for weeks and #989's idle-wait became the top failure
   mode. The residual window is documented in the code itself and bounded by teardown: the
   predecessor is not retired until `goal_armed` passes.

The finding is real and known, not refuted. Reversing a one-day-old owner decision inside an
unrelated folded doc change would be the wrong place to do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
