### PR TITLE
feat(epic-run): Step 3 states the goal cap and stops until the owner arms it (#806)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.7",
+  "version": "3.141.8",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -770,7 +770,15 @@ For major changes, please open an issue first to discuss the approach.
   precise rather than rewritten. The issue's bonus — change "version bump ×3 surfaces" to four — is
   DECLINED: `hooks/canary.py` was retired in #866 M0d, there are three surfaces, and the skill
   already says three. 4 drift guards added in `tests/test_epic_run_clarity.py`.
-  No workflow-spine change, so no diagram REV. Suite 6434→6438.
+  Step-11 review then found five more. Four fixed: nothing told Step 3 to STOP until the owner
+  confirms the goal armed, so the run could proceed unguarded — the precise risk the rescope
+  introduces; guard-critical terms could move behind a mutable file pointer, so only EXPLANATORY
+  detail may move now and permissions stay inline; the cap is defined over `/goal ` plus the
+  condition while the count instruction measured only the condition; and the drift guard could not
+  fail, because it searched all of Step 3 for the number and Step 3 already contains other figures
+  — it is now anchored to the cap sentence and was DEMONSTRATED to fail on a drifted value. 7 drift
+  guards added.
+  No workflow-spine change, so no diagram REV. Suite 6434→6440.
 
 ### v3.141.7 (2026-08-07)
 - **Both destructive handoff paths derive the successor's guard from trusted rows only (#772, epic

--- a/README.md
+++ b/README.md
@@ -749,6 +749,29 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.141.8 (2026-08-07)
+- **epic-run Step 3 states the goal cap, reads it from the constant, and says the goal is NOT armed
+  (#806, epic #906).** Step 3 mandates seven content blocks and had no length cap, which is exactly
+  the pattern `skills/pane-handoff/SKILL.md` warns about — owner goals run 1,200–2,000 characters
+  while model-drafted successor goals ballooned to 4,000–5,400. Measured on the epic #756 run: a
+  faithful draft reached 5,014 characters and the owner rejected it. The cap has existed as
+  `launcher_lib.GOAL_MAX_CHARS` all along; Step 3 simply did not know about it. It now states the
+  cap bound to that constant (a drift guard asserts the prose and the Python agree, per the repo's
+  mirrored-constant convention), states the drafted condition's actual character count to the owner
+  before handing it over, and shortens an over-cap draft by moving detail into the run-contract file
+  and pointing at it — never by truncating, because the same #756 run's hand-pasted goal lost its
+  trailing clause and what went missing was the instruction not to start two other children.
+  **Scoped by epic #906 item 6 to cap and exact-text display, NO auto-arm**, and the reason is
+  measured: `validate_inserted_prompt` records the #718 finding that a bare slash command inserted
+  into a session with an unmet `/goal` sat queued through five goal-driven turns, and Step 3 runs
+  inside the operator's own session mid-turn, so it can neither execute a `/goal` nor verify one it
+  sent. The issue's AC7 called the existing *"you cannot invoke /goal for them"* sentence stale; on
+  that evidence it is substantially CORRECT for the operator's own pane, so it was kept and made
+  precise rather than rewritten. The issue's bonus — change "version bump ×3 surfaces" to four — is
+  DECLINED: `hooks/canary.py` was retired in #866 M0d, there are three surfaces, and the skill
+  already says three. 4 drift guards added in `tests/test_epic_run_clarity.py`.
+  No workflow-spine change, so no diagram REV. Suite 6434→6438.
+
 ### v3.141.7 (2026-08-07)
 - **Both destructive handoff paths derive the successor's guard from trusted rows only (#772, epic
   #906).** Campaign `handoff` and `mid-child-handoff` both derived it with

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.7",
+  "version": "3.141.8",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/skills/epic-run/SKILL.md
+++ b/skills/epic-run/SKILL.md
@@ -113,6 +113,50 @@ it is session-level). The condition must contain, explicitly:
   excluded from trimming, the durable store is the one that gets injected and the
   one `--overturnable` is enforced in.
 
+### The 4,000-character cap, and how to stay under it (#806)
+
+**The cap is `launcher_lib.GOAL_MAX_CHARS` = 4,000 characters**, and it covers the WHOLE command
+including the `/goal ` prefix — so a 4,000-character condition does not itself fit. Read it from
+that constant rather than trusting this sentence; a drift guard asserts the two agree
+(`tests/test_epic_run_clarity.py::TestStep3StatesTheGoalCap`).
+
+This is not a preference. `hooks/launcher_lib.py` has enforced it all along, and
+`skills/pane-handoff/SKILL.md` names the failure it exists for: owner goals run 1,200–2,000
+characters while model-drafted successor goals ballooned to 4,000–5,400. Step 3 is a model-drafting
+path, which is exactly that pattern. Measured on the epic #756 run (2026-08-01): a faithful draft of
+the blocks above reached **5,014 characters** and the owner rejected it.
+
+**State the count before you hand the block over.** `wc -c` on the drafted condition, said out loud
+to the owner, so they are not left to count it. A draft that is over cap is a draft you have not
+finished.
+
+**When it is over cap, shorten by POINTING — never by truncating.** Move the detail into the
+run-contract file and reference that file from the condition. The rewrite that worked on #756
+reached 3,007 characters by replacing the inline per-child checklist with a pointer to
+`projects/rawgentic/CLAUDE.md` §5. Truncating mid-sentence is the one thing never to do: the same
+run's hand-pasted goal lost its trailing clause, and what went missing was the instruction not to
+start two other children — the guard's most important stop, silently absent.
+
+If anything downstream reports `truncated`, surface it. `goal_text()` returns that flag rather than
+discarding it, and a silently shortened goal guards less than the owner supplied.
+
+### Do NOT arm the goal yourself — hand it over and say it is unarmed
+
+Epic #906 item 6 rescoped this step to **cap and exact-text display, no auto-arm**, and the reason is
+measured rather than stylistic. `validate_inserted_prompt` (`hooks/launcher_lib.py`) records the
+#718 finding that **a bare slash command is inert**: inserted into a session with an unmet `/goal`,
+`/tasklist` sat queued through five goal-driven turns. Step 3 runs inside the operator's OWN session,
+mid-turn, so it can neither execute a `/goal` nor verify one it sent — the row it would check for
+cannot appear until the turn doing the checking has ended.
+
+The sentence above — *you cannot invoke /goal for them* — is therefore correct for THIS pane, and
+must not be rewritten to say otherwise. What `launcher_lib` genuinely can do is arm a goal in a
+**different** pane (a fresh successor), gated and verified; that is `pane-handoff`, not this step.
+
+So print the block, state its character count, and say plainly that it is **not armed
+automatically** and the owner must verify it took. Reporting a goal as set when nothing armed it is
+the failure this wording exists to prevent.
+
 ## Step 3b: Put up the run task list (#517)
 
 The operator gets an on-screen checklist of the whole run — filed from live

--- a/skills/epic-run/SKILL.md
+++ b/skills/epic-run/SKILL.md
@@ -126,14 +126,22 @@ characters while model-drafted successor goals ballooned to 4,000–5,400. Step 
 path, which is exactly that pattern. Measured on the epic #756 run (2026-08-01): a faithful draft of
 the blocks above reached **5,014 characters** and the owner rejected it.
 
-**State the count before you hand the block over.** `wc -c` on the drafted condition, said out loud
-to the owner, so they are not left to count it. A draft that is over cap is a draft you have not
-finished.
+**State the count before you hand the block over.** Measure the WHOLE command — `/goal ` plus the
+condition — because that is what the cap covers, so the condition's own budget is
+`GOAL_MAX_CHARS - len("/goal ")`. Say the number out loud to the owner rather than leaving them to
+count it. A draft that is over cap is a draft you have not finished.
 
 **When it is over cap, shorten by POINTING — never by truncating.** Move the detail into the
 run-contract file and reference that file from the condition. The rewrite that worked on #756
 reached 3,007 characters by replacing the inline per-child checklist with a pointer to
-`projects/rawgentic/CLAUDE.md` §5. Truncating mid-sentence is the one thing never to do: the same
+`projects/rawgentic/CLAUDE.md` §5.
+
+**Only EXPLANATORY detail may move.** A merge authorization, an exclusion, a stop condition, the
+queue order, or anything else the guard is meant to ENFORCE stays inline in the text the owner
+arms. A referenced file is mutable after arming, so delegating a guard-critical term through one
+means the effective guard can change without the owner ever re-arming it — which would quietly
+widen exactly the authority this condition exists to bound. Checklists and contracts a reader
+consults are fine to point at; permissions and prohibitions are not. Truncating mid-sentence is the one thing never to do: the same
 run's hand-pasted goal lost its trailing clause, and what went missing was the instruction not to
 start two other children — the guard's most important stop, silently absent.
 
@@ -156,6 +164,12 @@ must not be rewritten to say otherwise. What `launcher_lib` genuinely can do is 
 So print the block, state its character count, and say plainly that it is **not armed
 automatically** and the owner must verify it took. Reporting a goal as set when nothing armed it is
 the failure this wording exists to prevent.
+
+**Then STOP.** Do not proceed to Step 3b, and do not begin any child, until the owner confirms the
+goal is armed. Without that confirmation the run has no definition of done and no merge
+authorization, so continuing means running an epic unguarded — the precise failure the guard
+exists to prevent, reached by skipping the one manual step this rescope introduces. Advancing on the
+assumption that a printed block was submitted is the same mistake as reporting it armed.
 
 ## Step 3b: Put up the run task list (#517)
 

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.141.7"
+EXPECTED_PLUGIN_VERSION = "3.141.8"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/test_epic_run_clarity.py
+++ b/tests/test_epic_run_clarity.py
@@ -249,16 +249,56 @@ class TestStep3StatesTheGoalCap:
         sys.path.insert(0, str(REPO_ROOT / "hooks"))
         import launcher_lib  # noqa: E402
 
+        import re
+
         step3 = self._step3()
         assert "GOAL_MAX_CHARS" in step3, "Step 3 must name the constant it is bound to"
-        assert f"{launcher_lib.GOAL_MAX_CHARS:,}" in step3 or \
-               str(launcher_lib.GOAL_MAX_CHARS) in step3, (
-            f"Step 3's stated cap has drifted from launcher_lib.GOAL_MAX_CHARS "
-            f"({launcher_lib.GOAL_MAX_CHARS})")
+        # ANCHORED to the one sentence that states the cap, not searched across all of Step 3.
+        # Step-11 review caught the first version being unable to fail: it looked for the number
+        # anywhere in the section, and Step 3 already contains other figures (the measured 5,014
+        # and 3,007 character counts). Changing the constant to one of those would have left a
+        # stale instruction with a green guard — the whole-corpus substring defect this repo
+        # records as mistake #6.
+        m = re.search(r"`launcher_lib\.GOAL_MAX_CHARS`\s*=\s*([\d,]+)\s*characters", step3)
+        assert m, ("Step 3 must state the cap in the form "
+                   "'`launcher_lib.GOAL_MAX_CHARS` = <number> characters' so a guard can anchor "
+                   "to it")
+        stated = int(m.group(1).replace(",", ""))
+        assert stated == launcher_lib.GOAL_MAX_CHARS, (
+            f"Step 3 states a cap of {stated} but launcher_lib.GOAL_MAX_CHARS is "
+            f"{launcher_lib.GOAL_MAX_CHARS}")
 
     def test_the_draft_length_is_stated_to_the_owner(self):
-        """AC2 — the owner should not have to count it themselves."""
-        assert "wc -c" in self._step3() or "character count" in self._step3()
+        """AC2 — the owner should not have to count it themselves.
+
+        And it must measure the WHOLE command: Step-11 review caught the cap being defined over
+        `/goal ` plus the condition while the count instruction measured only the condition, so a
+        draft six characters under the line would be reported as fitting and then rejected.
+        """
+        step3 = self._step3()
+        assert "character count" in step3 or "wc -c" in step3
+        assert "WHOLE command" in step3 and "/goal " in step3
+
+    def test_step_3_stops_until_the_owner_confirms_the_goal_armed(self):
+        """Step-11 review, High: without this the run proceeds UNGUARDED.
+
+        The rescope removed the auto-arm, which introduces one manual step. Nothing said to wait
+        for it, so a driver could print the block and walk straight into the first child with no
+        definition of done and no merge authorization in force.
+        """
+        step3 = self._step3()
+        assert "Then STOP" in step3
+        assert "until the owner confirms the goal is armed" in step3
+
+    def test_only_explanatory_detail_may_move_behind_a_pointer(self):
+        """Step-11 review, High: a referenced file is mutable after arming.
+
+        Shortening by pointing is right for checklists. Moving a merge authorization or a stop
+        condition there would let the effective guard change without the owner re-arming it.
+        """
+        step3 = self._step3()
+        assert "Only EXPLANATORY detail may move" in step3
+        assert "merge authorization" in step3 and "stays inline" in step3
 
     def test_over_cap_shortens_by_pointing_not_by_truncating(self):
         """AC3 — truncation mid-sentence silently drops the end of a guard.
@@ -280,6 +320,15 @@ class TestStep3StatesTheGoalCap:
         verify its own guard. Saying so keeps a future reader from re-litigating it.
         """
         step3 = self._step3()
+        # DECLINED, with reason, from Step-11 review: it asked for a BEHAVIOURAL test proving
+        # `/goal` inertness rather than a prose guard. That test cannot exist here — proving it
+        # means inserting a slash command into a live session and watching it not execute, which
+        # is neither hermetic nor safe in CI, and would disturb a real run guard. The evidence is
+        # the #718 measurement already in the repo. What this guard CAN do, and now does, is
+        # require the prose to CITE that measurement, so the claim stays traceable to evidence
+        # instead of floating free.
+        assert "validate_inserted_prompt" in step3 and "#718" in step3, (
+            "the no-auto-arm claim must cite the measurement it rests on")
         assert "cannot invoke /goal for them" in step3, (
             "the sentence is substantially CORRECT for the operator's own pane and must not be "
             "rewritten to imply Step 3 can arm the current session's goal")

--- a/tests/test_epic_run_clarity.py
+++ b/tests/test_epic_run_clarity.py
@@ -224,3 +224,63 @@ class TestCampaignMergesGoThroughTheBroker:
         drive = _section(_text(), "## Step 4:", "## Step 5:")
         assert "refused, nothing merged" in drive
         assert "never route around it" in drive
+
+
+class TestStep3StatesTheGoalCap:
+    """#806 (rescoped by epic #906 item 6: cap + exact-text display, NO auto-arm).
+
+    Step 3 is a model-DRAFTING path with no length cap, which is precisely the pattern
+    `skills/pane-handoff/SKILL.md` warns about: owner goals run 1,200-2,000 chars while
+    model-drafted successor goals ballooned to 4,000-5,400. The cap already exists as a constant;
+    Step 3 simply did not know about it. Measured on the epic #756 run: a faithful draft reached
+    5,014 characters and the owner rejected it.
+    """
+
+    def _step3(self) -> str:
+        return _section(_text(), "## Step 3:", "## Step 3b:")
+
+    def test_the_stated_cap_matches_the_constant(self):
+        """AC1 — read from `launcher_lib.GOAL_MAX_CHARS`, never a second hard-coded 4000.
+
+        This is the repo's mirrored-constant convention (mistake #21): the number may appear in
+        prose, but a guard asserts it equals the Python source of truth, so the two cannot drift.
+        """
+        import sys
+        sys.path.insert(0, str(REPO_ROOT / "hooks"))
+        import launcher_lib  # noqa: E402
+
+        step3 = self._step3()
+        assert "GOAL_MAX_CHARS" in step3, "Step 3 must name the constant it is bound to"
+        assert f"{launcher_lib.GOAL_MAX_CHARS:,}" in step3 or \
+               str(launcher_lib.GOAL_MAX_CHARS) in step3, (
+            f"Step 3's stated cap has drifted from launcher_lib.GOAL_MAX_CHARS "
+            f"({launcher_lib.GOAL_MAX_CHARS})")
+
+    def test_the_draft_length_is_stated_to_the_owner(self):
+        """AC2 — the owner should not have to count it themselves."""
+        assert "wc -c" in self._step3() or "character count" in self._step3()
+
+    def test_over_cap_shortens_by_pointing_not_by_truncating(self):
+        """AC3 — truncation mid-sentence silently drops the end of a guard.
+
+        The measured harm: an over-long goal lost the clause that said do NOT start two other
+        children, so the run would have been guarded by a condition missing its most important
+        stop.
+        """
+        step3 = self._step3()
+        assert "never by truncating" in step3 or "never truncate" in step3
+        assert "run-contract file" in step3 or "run contract file" in step3
+
+    def test_the_no_auto_arm_rescope_is_explicit(self):
+        """Epic #906 item 6 rescoped this to NO auto-arm, and the reason is measured.
+
+        A bare slash command inserted into a session with an unmet `/goal` is inert —
+        `validate_inserted_prompt` records `/tasklist` sitting queued through five goal-driven
+        turns. Step 3 runs inside the operator's own session, mid-turn, so it cannot arm and then
+        verify its own guard. Saying so keeps a future reader from re-litigating it.
+        """
+        step3 = self._step3()
+        assert "cannot invoke /goal for them" in step3, (
+            "the sentence is substantially CORRECT for the operator's own pane and must not be "
+            "rewritten to imply Step 3 can arm the current session's goal")
+        assert "not armed automatically" in step3 or "must verify" in step3


### PR DESCRIPTION
## Summary

Step 3 mandates seven content blocks and had **no length cap**. That is exactly the pattern
`skills/pane-handoff/SKILL.md` warns about: owner goals run 1,200–2,000 characters while
model-drafted successor goals ballooned to 4,000–5,400. Measured on the epic #756 run — a faithful
draft reached **5,014 characters** and the owner rejected it.

The cap has existed as `launcher_lib.GOAL_MAX_CHARS` all along. Step 3 simply did not know about it.
It now:

- states the cap **bound to that constant**, with a drift guard asserting the prose and the Python
  agree (the repo's mirrored-constant convention);
- states the drafted condition's actual character count before handing it over, measured over the
  **whole command** (`/goal ` + condition), which is what the cap covers;
- shortens an over-cap draft by moving detail into the run-contract file and **pointing** at it,
  never by truncating — the same #756 run's hand-pasted goal lost its trailing clause, and what went
  missing was the instruction not to start two other children;
- says plainly the goal is **not armed automatically**, and **STOPS** until the owner confirms it is.

Closes #806
Part of #906

## Scope: no auto-arm, and the reason is measured

Epic **#906 item 6** rescoped this issue to *"goal cap read from the constant + exact-text display;
no auto-arm"*. AC4 and AC5 are out of scope by that rescope.

**I initially posted a blocker on this issue asking for that decision, without having read the epic
item that already made it.** I corrected it on the issue and requeued. Recording the mistake because
the revalidation passes I ran checked the issue's own body and comments but never the epic item that
governs it — a gap worth knowing about.

The technical content stands and is now the recorded reason for the rescope: `validate_inserted_prompt`
(`hooks/launcher_lib.py`) records the #718 measurement that a bare slash command inserted into a
session with an unmet `/goal` **sat queued through five goal-driven turns**. Step 3 runs inside the
operator's own session, mid-turn, so it can neither execute a `/goal` nor verify one it sent — the
row it would check for cannot appear until the turn doing the checking has ended. This run
reproduced the same class twice today, when two live `ad-hoc-handoff` attempts timed out at
`goal_armed`.

**AC7 is deliberately NOT satisfied as written.** It calls this sentence stale:

> Hand the user a block they can paste into `/goal` (you cannot invoke /goal for them — it is
> session-level).

On the evidence it is substantially **correct** for the operator's own pane. It is kept and made
precise rather than rewritten into something false: `launcher_lib` can arm a goal in a *different*
pane, gated and verified, and that is `pane-handoff`, not this step.

**The issue's bonus is DECLINED with reason.** It asks to change *"version bump ×3 surfaces"* to
four, citing `hooks/canary.py`. That file was retired in #866 M0d — there are **three**, and the
skill already says three. Acting on the bonus would have written a wrong count into the skill.

## Step 11 found five, and the most important one was that my own guard could not fail

- **My drift guard was vacuous.** It searched all of Step 3 for the constant's value, and Step 3
  already contains other figures (5,014 and 3,007). Changing the constant to one of those would have
  left a stale instruction with a green test — the whole-corpus substring defect this repo records
  as mistake #6. It is now anchored to the cap sentence and parses the number out of it.
  **Demonstrated to bite:** with the cap drifted to 5,014 the test fails; restored, it passes.
- **Nothing said to STOP** until the owner confirms the goal armed, so the run could proceed
  unguarded — the precise risk removing the auto-arm introduces.
- **Guard-critical terms could move behind a mutable pointer.** Only explanatory detail may move
  now; authorizations, exclusions and stop conditions stay inline in the text the owner arms.
- **The cap covers `/goal ` + condition** but the count instruction measured only the condition.
- **Declined:** a behavioural test proving `/goal` inertness. It cannot be hermetic or safe in CI —
  it means inserting a slash command into a live session — so the guard instead requires the prose
  to CITE the #718 measurement, keeping the claim traceable.

Two findings carried `ambiguity_flag: true` while the owner was out. The breaker says stop and ask;
the away-mode rule says decide and record. Both were dispositioned on their merits. Precedent D292.

## Verification

- Baseline before any work: **6434 passed, exit 0**. Final gate: **6440 passed, exit 0** (+6).
- Both lint lanes 10.00/10. Security scan clean. `sync_shared_blocks --check` clean.
- 7 drift guards, red before green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
