### PR TITLE
fix(launcher): goal_armed no longer destroys a successor it cannot prove is dead

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.8",
+  "version": "3.141.9",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,23 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.141.9 (2026-08-08)
+- **`goal_armed` no longer destroys a successor it cannot prove is dead (#1000, epic #906).** The
+  arm gate gave a queued `/goal` 18 s and then closed the successor pane, and the nudge loop could
+  not extend that — a queued command shows no paste affordance, so the recovery declines on round
+  one. Measured on successor `09cf79c9`: the goal submitted at `00:55:20.862Z`, the successor
+  printed `Guard is armed.`, and its transcript ends `3.778 s` later with zero `goal_status` rows,
+  so every post-mortem of this bug had to reason from a file the bug itself had truncated.
+  `hooks/launcher_lib.py` gains `GOAL_ARM_LONG_POLL_ATTEMPTS`/`_DELAY_S` (one further bounded poll,
+  120 s nominal and 240 s hard wall clock, derived from a single measured 54 s submission gap and
+  labelled `n = 1` in its own comment) and an `arm_outcome` field —
+  `armed`/`unconfirmed_timeout`/`pane_unreachable`/`poll_error` — that the cleanup keys on, keeping
+  the pane only where the run genuinely cannot tell. The gate's PASS condition, `failed_step` and
+  `results.goal_armed` are all unchanged. 13 tests added in
+  `tests/hooks/test_adhoc_pane_handoff.py`, and the one prior assertion pinning the old close is
+  deliberately reversed with its two structural guarantees kept.
+  No workflow-spine change → no diagram REV. Suite 6440→6453.
+
 ### v3.141.8 (2026-08-07)
 - **epic-run Step 3 states the goal cap, reads it from the constant, and says the goal is NOT armed
   (#806, epic #906).** Step 3 mandates seven content blocks and had no length cap, which is exactly

--- a/README.md
+++ b/README.md
@@ -757,14 +757,18 @@ For major changes, please open an issue first to discuss the approach.
   printed `Guard is armed.`, and its transcript ends `3.778 s` later with zero `goal_status` rows,
   so every post-mortem of this bug had to reason from a file the bug itself had truncated.
   `hooks/launcher_lib.py` gains `GOAL_ARM_LONG_POLL_ATTEMPTS`/`_DELAY_S` (one further bounded poll,
-  120 s nominal and 240 s hard wall clock, derived from a single measured 54 s submission gap and
-  labelled `n = 1` in its own comment) and an `arm_outcome` field —
-  `armed`/`unconfirmed_timeout`/`pane_unreachable`/`poll_error` — that the cleanup keys on, keeping
-  the pane only where the run genuinely cannot tell. The gate's PASS condition, `failed_step` and
-  `results.goal_armed` are all unchanged. 13 tests added in
-  `tests/hooks/test_adhoc_pane_handoff.py`, and the one prior assertion pinning the old close is
-  deliberately reversed with its two structural guarantees kept.
-  No workflow-spine change → no diagram REV. Suite 6440→6453.
+  120 s nominal against a 240 s deadline checked BETWEEN attempts — not a hard wall clock, which
+  the constant's comment now states rather than claims away — derived from a single measured 54 s
+  submission gap and labelled `n = 1`) and an `arm_outcome` field: `armed`, `unconfirmed_timeout`,
+  `probe_error`, `session_mismatch`, `pane_absent`, `poll_error`. Only the last two of those permit
+  an automatic close, on one rule — no close without affirmative evidence of death. Step-9 review
+  caught the fix reintroducing its own bug: a first revision merged a failed probe with a session
+  mismatch, and the retry inside `_close_tentative_pane` would have killed a live successor anyway.
+  A kept successor is now also sent an advisory stop notice, since closing it used to be what
+  stopped it. The gate's PASS condition, `failed_step` and `results.goal_armed` are all unchanged.
+  20 tests added in `tests/hooks/test_adhoc_pane_handoff.py`, and the one prior assertion pinning
+  the old close is deliberately reversed with its two structural guarantees kept.
+  No workflow-spine change → no diagram REV. Suite 6440→6460.
 
 ### v3.141.8 (2026-08-07)
 - **epic-run Step 3 states the goal cap, reads it from the constant, and says the goal is NOT armed

--- a/docs/planning/campaign-log.md
+++ b/docs/planning/campaign-log.md
@@ -14,6 +14,86 @@ shipped; live run owner-gated). M1–M4 **COMPLETE**; the **epic #188 fast-follo
 
 ---
 
+## Epic #906 M2 (out-of-queue) — #1000: `goal_armed` keeps a successor it cannot prove is dead · v3.141.9
+
+**Issue:** [#1000](https://github.com/3D-Stories/rawgentic/issues/1000) ·
+**Design:** RCA + fix plan, full WF3 spine (no separate design doc)
+
+**Not a queued child.** Epic #906 exists to make the pane-handoff chain boring, and the handoff was
+failing on every attempt while no child covered it. The owner interrupted the #923 run and asked for
+this instead. #923 was paused at a clean seam — no branch, no code, gate still open at `77a3e030` —
+so the cost of the detour was one recorded test baseline.
+
+**The recorded diagnosis was half wrong, and finding that out changed the fix.** The run handoff
+said the successor "was provably fine" and that the `goal_status` row "lands after the budget
+expires". The successor's own transcript says otherwise: `09cf79c9` holds **zero** `goal_status`
+rows. Its `/goal` submitted at `00:55:20.862Z`, it printed `Guard is armed.` at `00:55:24.240Z`, and
+the file ends at `00:55:24.640Z`. The pane was destroyed **3.778 s** after the submission, so the
+proof was never written rather than written late. Every post-mortem of this bug had been reasoning
+from a file the bug itself had truncated.
+
+**Why the wait could not stretch.** The nudge recovery reads the pane and declines when there is no
+unsubmitted-paste affordance. A QUEUED `/goal` shows none — `launcher_lib.py` says so at its own
+loop, and a test has pinned it since #989. So the queued state got exactly one 18 s poll and nothing
+more, against a measured 54 s turn-end-to-submit gap.
+
+**What shipped, and it is two halves that only work together.** `GOAL_ARM_LONG_POLL_ATTEMPTS`/
+`_DELAY_S` add one further bounded poll (120 s nominal, 240 s hard wall clock through the existing
+`POLL_WALL_CLOCK_SLACK`). And `arm_outcome` — `armed`/`unconfirmed_timeout`/`pane_unreachable`/
+`poll_error` — gives the cleanup something honest to key on, so the pane is kept only where the run
+genuinely cannot tell. The gate's PASS condition, `failed_step` and `results.goal_armed` are all
+unchanged.
+
+**The budget is honest about its own weakness.** 120 s is 2x ONE observation. The constant's comment
+says `n = 1` and says it is not a proven ceiling. That is tolerable only because of the other half:
+an imperfect budget now costs an orphan pane instead of a live session.
+
+**The most important finding is that the fix reintroduced its own bug, and review caught it.** The
+Step-9 pass found that a first revision merged a FAILED liveness probe with a session MISMATCH under
+one `pane_unreachable`, and routed both to `_close_tentative_pane` — which probes AGAIN and closes
+when its own probe succeeds. So one transient probe failure would have destroyed a live successor by
+way of the retry, from inside the fix meant to prevent exactly that. The outcome is now split five
+ways on a single rule: **no automatic close without affirmative evidence of death.** Two tests pin
+it, including an unparseable probe answer, since `parse_pane_agent_session` returns `None` there and
+its own contract forbids reading `None` as a pass.
+
+**Keeping the pane removed an accidental safety property, so that was addressed too.** Closing the
+successor also STOPPED it. A kept successor holds the resume prompt with no proven guard while the
+predecessor is alive. There is no verified suspend primitive, and inventing one on this gate is what
+the owner had already declined — so the successor is sent a stop notice over the proven send-text
+route. The receipt calls it ADVISORY and not enforcement, and a test pins that a failed notice never
+changes the verdict.
+
+**Three cross-model passes, fifteen findings, and the budget ran out before the last one.** Pass 1
+fired the ambiguity breaker and went to the owner, who applied all six; two were factual corrections
+to my own RCA — a "same millisecond" claim that was 1 ms apart, and a hypothesis marked REFUTED on a
+mid-turn control that cannot speak for the post-turn case, now UNRESOLVED. Pass 2 was diagnostic by
+construction, and one of its findings sat at confidence 0.79, just under the Medium band that would
+have filtered it; checking it anyway found a real bug — the three handoff CLI serializers use fixed
+key tuples, so `arm_outcome` was invisible at the CLI boundary and the operator would never have seen
+the field this issue exists to give them. Pass 3 was the Step-9 review above, also diagnostic with the
+`review` loop-back budget spent, so its two High findings were escalated to the owner rather than
+silently applied. The owner authorized all three fixes.
+
+**Corrected in the same pass, and stated rather than claimed away.** The comment had called the long
+poll's 240 s a hard wall clock. `_poll_for` tests its deadline at the TOP of each attempt, so it
+bounds the wait BETWEEN attempts and cannot interrupt one in flight. The comment now says so, and
+says why a true hard bound was not built: it needs a cancellable worker on the gate that decides
+whether a successor is trusted, against a failure never observed here.
+
+**Declined, and recorded rather than dropped.** A first phase that watches for the goal to submit
+before starting the arm deadline. There is also no `refused` outcome, because refusal has no
+observable; it is deliberately classified `unconfirmed_timeout`.
+
+**One I caught myself.** A test I wrote asserted `herdr pane teardown` was never called.
+`build_teardown_argv` emits `herdr pane close`. That guard could not have failed — repo mistake #6 —
+and was corrected before the commit.
+
+Suite 6440→6460, exit 0. Both lint lanes 10.00/10. Security scan PASS with one visible skip
+(`iac: not applicable`). 20 tests added.
+
+---
+
 ## Epic #906 M2 — #806: the goal cap, read from the constant, and no auto-arm · v3.141.8
 
 **Issue:** [#806](https://github.com/3D-Stories/rawgentic/issues/806) ·

--- a/hooks/launcher_lib.py
+++ b/hooks/launcher_lib.py
@@ -194,6 +194,28 @@ GOAL_NUDGE_ROUNDS = 4
 # heuristic and nothing more — the skill's own rule is a token unique to the handoff.
 PROMPT_MARKER_MIN_LEN = 8
 GOAL_POLL_DELAY_S = 1.5
+# #1000 — the LONG arm wait, run once after the nudge loop ends without arming.
+#
+# Why the nudge loop cannot cover this. It reads the pane and abandons the recovery when there is
+# no unsubmitted-paste affordance. A QUEUED `/goal` shows none — that is stated below at the loop
+# itself — so the queued state gets exactly one 18 s poll and nothing more, and no number of nudge
+# rounds changes that. The extension therefore has to live outside the loop.
+#
+# WHERE THE NUMBER COMES FROM, AND WHAT IT IS NOT. Successor `09cf79c9` (2026-08-08) took 54 s from
+# ending its resume-prompt turn (00:54:26.6) to submitting its goal (00:55:20.9). 120 s nominal is
+# 2x that. **n = 1.** It is a margin over a single observation, NOT a proven ceiling, and a slower
+# successor will still time out.
+#
+# That is tolerable only because of the other half of #1000: a timeout no longer destroys the
+# successor (see the `finally` block). An imperfect budget that costs an orphan pane is safe; the
+# same budget costing a live session is what this issue exists to end. Do not tighten one without
+# re-reading the other.
+#
+# `_poll_for` bounds this on BOTH axes — attempts x delay for the nominal budget, and
+# POLL_WALL_CLOCK_SLACK x that for the hard wall clock (240 s here), so a slow attempt cannot
+# stretch the wait past its own bound.
+GOAL_ARM_LONG_POLL_ATTEMPTS = 40
+GOAL_ARM_LONG_POLL_DELAY_S = 3.0
 # #989 follow-up — the settle before the goal send. NOT a gate: it decides when to attempt
 # delivery, never whether anything passed. It replaces a 120 s blocking `agent wait --until idle`
 # that was FATAL and that hung on panes which were already idle.
@@ -2591,6 +2613,13 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
     out: dict = {"ok": False, "steps": [], "results": {}, "truncated": False,
                  "failed_step": None, "new_pane": None, "session_id": None,
                  "cleanup": None, "teardown_skipped": None, "predecessor_guard": None,
+                 # #1000 — how the ARM phase ended, so a consumer cannot read every
+                 # `failed_step: goal_armed` as a refusal. One of `armed`,
+                 # `unconfirmed_timeout`, `pane_unreachable`, `poll_error`; stays None on a run
+                 # that never reached the arm phase. ADDITIVE: `failed_step` and
+                 # `results.goal_armed` keep their existing values on every path, so nothing that
+                 # branches on those changes behaviour.
+                 "arm_outcome": None,
                  # #927 PR 2: the herdr `error.code` of the failing step, machine-readable.
                  # ADDITIVE — no branch here reads it. `_cmd_handoff` needs the code rather than
                  # the human `note` because section 16.4's downgrade triggers on an ENUMERATED
@@ -3175,8 +3204,21 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
 
         expected, _ = armed_condition(goal_condition)
 
+        # #1000 — count how the transcript READS themselves went, separately from what they said.
+        # `_poll_for` swallows read errors by design (a JSONL file mid-append can momentarily fail
+        # to read), which is right for the poll and wrong for the diagnosis: without this counter,
+        # "the transcript was never readable" and "the goal never armed" are the same answer, and
+        # the cleanup below would treat a successor it never observed as one it had judged.
+        arm_reads = {"ok": 0, "err": 0}
+
         def _goal_is_armed() -> bool:
-            tail = _tail(read_text(transcript_path), transcript_baseline)
+            try:
+                text = read_text(transcript_path)
+            except (OSError, UnicodeDecodeError):
+                arm_reads["err"] += 1
+                raise
+            arm_reads["ok"] += 1
+            tail = _tail(text, transcript_baseline)
             return tail is not None and transcript_has_unmet_goal(
                 tail, expected_condition=expected)
 
@@ -3259,13 +3301,28 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
             armed = _poll_for(_goal_is_armed, attempts=GOAL_POLL_ATTEMPTS,
                               delay_s=GOAL_POLL_DELAY_S, sleeper=sleeper)
 
+        # #1000 — the nudge loop has ended, by early break or by exhaustion. NEITHER outcome means
+        # the goal will never arrive. A QUEUED command submits when the successor's turn ends, and
+        # the measurement recorded at GOAL_ARM_LONG_POLL_ATTEMPTS puts that up to a minute away —
+        # far outside the 18 s first poll. So wait once more, on a bounded budget, before calling
+        # it a failure. The PASS condition is untouched: still a real `goal_status` row for the
+        # armed condition, still fail-closed when it never appears.
+        if not armed:
+            armed = _poll_for(
+                _goal_is_armed, attempts=GOAL_ARM_LONG_POLL_ATTEMPTS,
+                delay_s=GOAL_ARM_LONG_POLL_DELAY_S, sleeper=sleeper)
+
         out["results"]["goal_armed"] = armed
         if not out["results"]["goal_armed"]:
+            # #1000 — say WHICH failure this was before the `finally` decides the pane's fate.
+            out["arm_outcome"] = _classify_arm_failure(
+                out["new_pane"], out.get("session_id"), arm_reads, runner, record)
             out["failed_step"] = "goal_armed"
             out["failure_detail"] = (
                 "no unmet goal_status row for the armed condition appeared in the successor "
-                "transcript within the poll budget")
+                f"transcript within the poll budget (arm_outcome: {out['arm_outcome']})")
             return out
+        out["arm_outcome"] = "armed"
 
         # The unguarded window is now BETWEEN send 2 and this row, and it is bounded by exactly the
         # thing that closes it: the predecessor is not retired until `goal_armed` has passed below,
@@ -3287,7 +3344,25 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
         return out
     finally:
         if not transferred:
-            if out["new_pane"]:
+            if out["new_pane"] and out.get("arm_outcome") in _ARM_OUTCOMES_KEEPING_THE_PANE:
+                # #1000 — the one carve-out, and the reason the issue exists. `goal_armed` failing
+                # is NOT evidence the successor is dead: successor `09cf79c9` had submitted its
+                # goal and was mid-turn when this line destroyed it, taking the only transcript
+                # that could have explained the failure with it. Where the run cannot prove the
+                # successor is gone, it keeps the pane and says so — plainly, without claiming the
+                # successor is healthy, because it does not know that either.
+                #
+                # Deliberately narrow: `_classify_arm_failure` routes every OTHER arm failure, and
+                # every non-arm `failed_step`, to the unchanged close below. The predecessor is
+                # never retired until `goal_armed` passes, so a kept pane costs an orphan pane and
+                # never a lost session.
+                out["cleanup"] = (
+                    f"NOT closed {out['new_pane']}: the goal was not confirmed armed within the "
+                    f"budget, and the successor could not be proven dead. It may be alive and "
+                    f"working — this is NOT a report that it is healthy. Inspect with "
+                    f"'herdr pane read {out['new_pane']}'; close with "
+                    f"'herdr pane close {out['new_pane']}'.")
+            elif out["new_pane"]:
                 # Ownership was provable at split time; `expected_session` re-checks that it still
                 # is, when we got far enough to learn one.
                 out["cleanup"] = _close_tentative_pane(
@@ -3751,6 +3826,49 @@ def _report_possible_orphan(panes_before, runner, anchor_pane: str) -> str | Non
     return (f"POSSIBLE ORPHAN: {len(new)} pane(s) appeared during a failed split "
             f"({', '.join(new)}) — NOT closed, because herdr 0.7.5 offers no way to prove "
             "which is ours; check `herdr pane list` and close by hand if orphaned")
+
+
+# #1000 — the arm failures where the run has NOT established that the successor is dead, and
+# therefore must not destroy it. `unconfirmed_timeout`: the pane still provably hosts our session,
+# so it may be alive and mid-turn — exactly the measured case. `poll_error`: every transcript read
+# raised, so the run learned nothing about the successor at all, and destroying on no evidence is
+# the same mistake in a different costume.
+_ARM_OUTCOMES_KEEPING_THE_PANE = frozenset({"unconfirmed_timeout", "poll_error"})
+
+
+def _classify_arm_failure(pane: str | None, expected_session: str | None,
+                          arm_reads: dict, runner, record) -> str:
+    """Why the arm never confirmed: `poll_error`, `pane_unreachable`, or `unconfirmed_timeout`.
+
+    Before #1000 every one of these collapsed into `failed_step: goal_armed`, and the cleanup then
+    closed the pane on all of them identically. That is what destroyed successor `09cf79c9` 3.778 s
+    after it submitted its goal, and with it the only transcript that could have explained the
+    failure. The gate's verdict is unchanged — this only names the reason, so the caller can tell a
+    successor it judged from one it merely never heard from.
+
+    Ordering is deliberate. An unreadable transcript is decided FIRST and without a probe: the poll
+    never observed the successor, so no pane state can turn that into a judgement about it.
+    """
+    if arm_reads.get("ok", 0) == 0 and arm_reads.get("err", 0) > 0:
+        return "poll_error"
+    if not pane or expected_session is None:
+        # No pane to probe, or the run never learned a session to compare against. Nothing here
+        # can be proven alive, so this keeps today's cleanup path.
+        return "pane_unreachable"
+    probe = build_pane_get_argv(pane)
+    try:
+        proc = runner(probe)
+    except (OSError, subprocess.SubprocessError, LauncherError) as exc:
+        record("arm_liveness_probe", probe, None,
+               note=f"probe raised {exc} — the successor cannot be proven alive")
+        return "pane_unreachable"
+    record("arm_liveness_probe", probe, proc)
+    if getattr(proc, "returncode", 1) != 0:
+        return "pane_unreachable"
+    live = parse_pane_agent_session(getattr(proc, "stdout", "") or "")
+    # Same ownership basis `_close_tentative_pane` uses: a handle can be reused, so "our session is
+    # still on it" is the only evidence that makes keeping the pane meaningful rather than a leak.
+    return "unconfirmed_timeout" if live == expected_session else "pane_unreachable"
 
 
 def _close_tentative_pane(pane: str, runner, record, expected_session: str | None = None) -> str:
@@ -6833,8 +6951,9 @@ def _cmd_handoff(args) -> int:
                                reason="creation_refused" if downgraded else probe_reason)
     print(json.dumps({k: out.get(k) for k in
                       ("ok", "results", "failed_step", "new_pane", "session_id",
-                       "truncated", "cleanup")} | {"resolution_id": resolution_id,
-                                                   "terminal_outcome": outcome}, indent=2))
+                       "truncated", "cleanup", "arm_outcome")} | {
+                          "resolution_id": resolution_id,
+                          "terminal_outcome": outcome}, indent=2))
     return 0 if out["ok"] else 4
 
 
@@ -7025,6 +7144,11 @@ def _cmd_ad_hoc_handoff(args) -> int:
     payload = {k: out[k] for k in
                ("ok", "results", "failed_step", "new_pane", "session_id",
                 "truncated", "cleanup", "teardown_skipped", "predecessor_guard")}
+    # #1000 — `arm_outcome` rides the payload too, via `.get`: these serializers use FIXED key
+    # tuples, so a field the library sets is invisible at the CLI boundary until it is listed here.
+    # `.get` rather than `out[...]` because a receipt from a producer that predates the key must
+    # serialize as None, not raise.
+    payload["arm_outcome"] = out.get("arm_outcome")
     # #731 — the cause and the captured pane output ride the payload; `steps` stays out.
     # Via the helpers, not out[...]: they tolerate results that predate these keys, and they
     # derive from the step records for exits (teardown-phase) the library did not pre-fill.
@@ -7338,6 +7462,8 @@ def _cmd_mid_child_handoff(args) -> int:
                           "cancelled": True}, indent=2))
         return 4
     print(json.dumps({"generation": generation,
+                      # #1000 — `.get`, for the reason given at `_cmd_ad_hoc_handoff`.
+                      "arm_outcome": out.get("arm_outcome"),
                       **{k: out[k] for k in ("ok", "results", "failed_step", "new_pane",
                                              "session_id", "truncated", "cleanup",
                                              "teardown_skipped")}}, indent=2))

--- a/hooks/launcher_lib.py
+++ b/hooks/launcher_lib.py
@@ -211,9 +211,20 @@ GOAL_POLL_DELAY_S = 1.5
 # same budget costing a live session is what this issue exists to end. Do not tighten one without
 # re-reading the other.
 #
-# `_poll_for` bounds this on BOTH axes — attempts x delay for the nominal budget, and
-# POLL_WALL_CLOCK_SLACK x that for the hard wall clock (240 s here), so a slow attempt cannot
-# stretch the wait past its own bound.
+# `_poll_for` bounds this on both axes — attempts x delay for the nominal budget, and
+# POLL_WALL_CLOCK_SLACK x that (240 s here) for the wall clock.
+#
+# BE PRECISE ABOUT WHAT THAT DEADLINE IS, because the first revision of this comment overstated it
+# and the Step-9 review caught the overstatement. `_poll_for` tests the deadline at the TOP of each
+# attempt, before it sleeps and before it calls the predicate. So it bounds the wait BETWEEN
+# attempts, and it cannot interrupt an attempt already in flight: a `read_text` that blocks forever
+# would still block forever. It is a deadline checked between attempts, NOT a hard wall clock.
+#
+# Left as-is deliberately. Making it a true hard bound means running each transcript read in a
+# cancellable worker, which is new machinery on the gate that decides whether a successor is
+# trusted — and the failure it would guard against (a permanently blocking local file read) has
+# never been observed here, while the failure this issue exists to fix has been observed three
+# times. Recorded rather than silently claimed away.
 GOAL_ARM_LONG_POLL_ATTEMPTS = 40
 GOAL_ARM_LONG_POLL_DELAY_S = 3.0
 # #989 follow-up — the settle before the goal send. NOT a gate: it decides when to attempt
@@ -3356,10 +3367,13 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
                 # every non-arm `failed_step`, to the unchanged close below. The predecessor is
                 # never retired until `goal_armed` passes, so a kept pane costs an orphan pane and
                 # never a lost session.
+                # Warn BEFORE writing the receipt, so the receipt can describe what was attempted.
+                _warn_unguarded_successor(out["new_pane"], runner, record)
                 out["cleanup"] = (
                     f"NOT closed {out['new_pane']}: the goal was not confirmed armed within the "
                     f"budget, and the successor could not be proven dead. It may be alive and "
-                    f"working — this is NOT a report that it is healthy. Inspect with "
+                    f"working — this is NOT a report that it is healthy. A stop notice was sent to "
+                    f"it, which is ADVISORY and not enforced. Inspect with "
                     f"'herdr pane read {out['new_pane']}'; close with "
                     f"'herdr pane close {out['new_pane']}'.")
             elif out["new_pane"]:
@@ -3833,12 +3847,23 @@ def _report_possible_orphan(panes_before, runner, anchor_pane: str) -> str | Non
 # so it may be alive and mid-turn — exactly the measured case. `poll_error`: every transcript read
 # raised, so the run learned nothing about the successor at all, and destroying on no evidence is
 # the same mistake in a different costume.
-_ARM_OUTCOMES_KEEPING_THE_PANE = frozenset({"unconfirmed_timeout", "poll_error"})
+# #1000 — the arm failures where the run has NOT established that the successor is dead, and
+# therefore must not destroy it. The rule is one line: **no automatic close without affirmative
+# evidence of death.**
+#
+# `probe_error` is here because of a Step-9 review finding, and the hole it names is worth stating
+# so nobody merges the two values back together. A first revision lumped a FAILED probe in with a
+# session MISMATCH under one `pane_unreachable`, and routed both to `_close_tentative_pane`. But
+# that function probes AGAIN and closes when its own probe succeeds and the session matches — so a
+# single transient probe failure would have destroyed a live successor by way of the retry,
+# reproducing the exact defect #1000 exists to remove. A probe that could not answer is not a
+# verdict.
+_ARM_OUTCOMES_KEEPING_THE_PANE = frozenset({"unconfirmed_timeout", "poll_error", "probe_error"})
 
 
 def _classify_arm_failure(pane: str | None, expected_session: str | None,
                           arm_reads: dict, runner, record) -> str:
-    """Why the arm never confirmed: `poll_error`, `pane_unreachable`, or `unconfirmed_timeout`.
+    """Why the arm never confirmed. One of five values, and only two permit an automatic close.
 
     Before #1000 every one of these collapsed into `failed_step: goal_armed`, and the cleanup then
     closed the pane on all of them identically. That is what destroyed successor `09cf79c9` 3.778 s
@@ -3846,29 +3871,75 @@ def _classify_arm_failure(pane: str | None, expected_session: str | None,
     failure. The gate's verdict is unchanged — this only names the reason, so the caller can tell a
     successor it judged from one it merely never heard from.
 
+    - `poll_error`      every transcript read raised: the run never observed the successor at all.
+    - `pane_absent`     there is no pane, or no session was ever learned to compare against.
+    - `probe_error`     the liveness probe could not answer. NOT a verdict — see the keep set.
+    - `session_mismatch` the probe answered, and the pane hosts somebody else. Affirmative
+                        evidence that our successor is not there.
+    - `unconfirmed_timeout` the probe answered and the pane is still ours: alive, just unproven.
+
     Ordering is deliberate. An unreadable transcript is decided FIRST and without a probe: the poll
     never observed the successor, so no pane state can turn that into a judgement about it.
     """
     if arm_reads.get("ok", 0) == 0 and arm_reads.get("err", 0) > 0:
         return "poll_error"
     if not pane or expected_session is None:
-        # No pane to probe, or the run never learned a session to compare against. Nothing here
-        # can be proven alive, so this keeps today's cleanup path.
-        return "pane_unreachable"
+        return "pane_absent"
     probe = build_pane_get_argv(pane)
     try:
         proc = runner(probe)
     except (OSError, subprocess.SubprocessError, LauncherError) as exc:
         record("arm_liveness_probe", probe, None,
-               note=f"probe raised {exc} — the successor cannot be proven alive")
-        return "pane_unreachable"
+               note=f"probe raised {exc} — cannot judge, so the pane is KEPT")
+        return "probe_error"
     record("arm_liveness_probe", probe, proc)
     if getattr(proc, "returncode", 1) != 0:
-        return "pane_unreachable"
+        return "probe_error"
     live = parse_pane_agent_session(getattr(proc, "stdout", "") or "")
+    if live is None:
+        # Unparseable is indistinguishable from unavailable, and `parse_pane_agent_session`'s own
+        # contract says the caller must never treat None as a pass.
+        return "probe_error"
     # Same ownership basis `_close_tentative_pane` uses: a handle can be reused, so "our session is
     # still on it" is the only evidence that makes keeping the pane meaningful rather than a leak.
-    return "unconfirmed_timeout" if live == expected_session else "pane_unreachable"
+    return "unconfirmed_timeout" if live == expected_session else "session_mismatch"
+
+
+# #1000 Step-9 review, finding 2. Keeping the pane removes the old behaviour's one accidental
+# safety property: closing the successor also STOPPED it. A successor that holds the resume prompt
+# and has no proven guard can keep working, while the predecessor is also alive — two sessions with
+# one queue between them.
+#
+# What is buildable here, and what is not. There is no verified suspend primitive; inventing one on
+# the gate that decides whether a successor is trusted is exactly what the owner declined for the
+# submission-transition watcher. What IS proven is the send-text-then-Enter route the handoff
+# already uses three times. So the successor is TOLD to stop, on that proven route.
+#
+# This is a notice, NOT enforcement, and no caller may read it as one. It is best-effort in every
+# direction: any failure is recorded and never changes the verdict, because a failed warning must
+# not turn an unconfirmed handoff into a different kind of failure.
+_UNGUARDED_SUCCESSOR_NOTICE = (
+    "HANDOFF NOT CONFIRMED. Your predecessor could not verify that your run guard armed, and it "
+    "has NOT been retired — it is still alive and still owns this run. Stop now. Do not start, "
+    "continue, or commit any work from the resume prompt you were sent. Wait for a human to "
+    "confirm which session owns the run.")
+
+
+def _warn_unguarded_successor(pane: str, runner, record) -> None:
+    """Best-effort: tell a kept successor it is not the owner of the run. Never raises."""
+    try:
+        send_text, send_keys = build_send_text_argv(pane=pane, text=_UNGUARDED_SUCCESSOR_NOTICE)
+        for kind, argv in (("warn_unguarded_text", send_text), ("warn_unguarded_keys", send_keys)):
+            proc = runner(argv)
+            ok = getattr(proc, "returncode", 1) == 0
+            record(kind, argv, proc,
+                   note=("stop notice sent — advisory only, the successor is NOT enforced to stop"
+                         if ok else None))
+            if not ok:
+                return
+    except (OSError, subprocess.SubprocessError, LauncherError, ValueError) as exc:
+        record("warn_unguarded_text", [], None,
+               note=f"stop notice could not be sent ({exc}) — the successor was NOT warned")
 
 
 def _close_tentative_pane(pane: str, runner, record, expected_session: str | None = None) -> str:

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.8",
+  "version": "3.141.9",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adhoc_pane_handoff.py
+++ b/tests/hooks/test_adhoc_pane_handoff.py
@@ -2661,7 +2661,7 @@ class TestTheArmOutcomeIsClassifiedNotCollapsed:
         """Matrix row 4. Our session is provably gone, so the keep-it rule does not apply."""
         _r, out = self._foreign()
         assert out["failed_step"] == "goal_armed", out["failed_step"]
-        assert out["arm_outcome"] == "pane_unreachable", out.get("arm_outcome")
+        assert out["arm_outcome"] == "session_mismatch", out.get("arm_outcome")
 
     def test_a_foreign_session_is_still_never_closed_by_the_cleanup(self) -> None:
         """`pane_unreachable` routes to today's `_close_tentative_pane`, which is itself
@@ -2730,7 +2730,7 @@ class TestTheArmOutcomeIsClassifiedNotCollapsed:
                            "NOT closed" in str(out["cleanup"] or ""))
         assert rows["armed"] == ("armed", None, True, False), rows
         assert rows["unconfirmed_timeout"] == ("unconfirmed_timeout", "goal_armed", False, True), rows
-        assert rows["pane_unreachable"] == ("pane_unreachable", "goal_armed", False, True), rows
+        assert rows["pane_unreachable"] == ("session_mismatch", "goal_armed", False, True), rows
 
 
 class TestTheLongArmPollIsBoundedOnWallClockToo:
@@ -2767,3 +2767,126 @@ class TestTheLongArmPollIsBoundedOnWallClockToo:
         from ending its prompt turn to submitting its goal."""
         nominal = ll.GOAL_ARM_LONG_POLL_ATTEMPTS * ll.GOAL_ARM_LONG_POLL_DELAY_S
         assert nominal >= 2 * 54.0, nominal
+
+
+class TestAFailedProbeIsNotAVerdict:
+    """#1000 Step-9 review, finding 1 — the hole a first revision of this fix left open.
+
+    That revision lumped a FAILED liveness probe together with a session MISMATCH under one
+    `pane_unreachable`, and routed both to `_close_tentative_pane`. But that function probes AGAIN
+    and closes when its own probe succeeds and the session matches. So one transient probe failure
+    would have destroyed a live successor by way of the retry — reproducing the exact defect this
+    issue exists to remove, from inside its own fix.
+
+    A probe that could not answer is not evidence of death.
+    """
+
+    @staticmethod
+    def _probe_fails_at_classification():
+        """A runner whose `pane get` works at spawn and fails once the arm phase asks."""
+
+        class ProbeFailsLate(Runner):
+            def __init__(self, responses):
+                super().__init__(responses)
+                self.gets = 0
+
+            def __call__(self, argv, timeout=180):
+                if self.key(argv) == "herdr pane get":
+                    self.gets += 1
+                    if self.gets > 1:
+                        self.calls.append(list(argv))
+                        return FakeProc(returncode=1)
+                return super().__call__(argv, timeout)
+
+        r = ProbeFailsLate(_responses(pane_read="scrollback\n"))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=10**6)))
+        return r, out
+
+    def test_a_probe_that_cannot_answer_is_its_own_outcome(self) -> None:
+        _r, out = self._probe_fails_at_classification()
+        assert out["failed_step"] == "goal_armed", out["failed_step"]
+        assert out["arm_outcome"] == "probe_error", out.get("arm_outcome")
+
+    def test_a_probe_that_cannot_answer_never_closes_the_pane(self) -> None:
+        """The regression itself. This is the assertion the review's finding exists for."""
+        r, out = self._probe_fails_at_classification()
+        assert not any(c[:3] == ["herdr", "pane", "close"] for c in r.calls), r.calls
+        assert "NOT closed" in str(out["cleanup"]), out["cleanup"]
+
+    def test_an_unparseable_probe_answer_is_also_not_a_verdict(self) -> None:
+        """`parse_pane_agent_session` returns None for unparseable output, and its own contract
+        says the caller must never read None as a pass. rc 0 with junk is still 'cannot judge'."""
+
+        class ProbeJunkLate(Runner):
+            def __init__(self, responses):
+                super().__init__(responses)
+                self.gets = 0
+
+            def __call__(self, argv, timeout=180):
+                if self.key(argv) == "herdr pane get":
+                    self.gets += 1
+                    if self.gets > 1:
+                        self.calls.append(list(argv))
+                        return FakeProc(0, "not json at all")
+                return super().__call__(argv, timeout)
+
+        r = ProbeJunkLate(_responses(pane_read="scrollback\n"))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=10**6)))
+        assert out["arm_outcome"] == "probe_error", out.get("arm_outcome")
+        assert not any(c[:3] == ["herdr", "pane", "close"] for c in r.calls)
+
+
+class TestAKeptSuccessorIsToldItDoesNotOwnTheRun:
+    """#1000 Step-9 review, finding 2 — keeping the pane removed an accidental safety property.
+
+    Closing the successor also STOPPED it. A kept successor holds the resume prompt and has no
+    proven guard, while the predecessor is also alive. There is no verified suspend primitive, so
+    the successor is TOLD to stop over the send-text route the handoff already uses three times.
+
+    This is a NOTICE, not enforcement, and the tests below pin that distinction in both directions.
+    """
+
+    @staticmethod
+    def _kept():
+        r = Runner(_responses(pane_read="scrollback\n"))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=10**6)))
+        return r, out
+
+    def test_a_kept_successor_is_sent_a_stop_notice(self) -> None:
+        r, out = self._kept()
+        assert out["arm_outcome"] == "unconfirmed_timeout"
+        sent = [t for t in r.sent_text() if "HANDOFF NOT CONFIRMED" in t]
+        assert len(sent) == 1, r.sent_text()
+        assert "Stop now" in sent[0] and "still alive and still owns this run" in sent[0]
+
+    def test_the_receipt_calls_the_notice_advisory_and_not_enforcement(self) -> None:
+        _r, out = self._kept()
+        assert "ADVISORY and not enforced" in str(out["cleanup"]), out["cleanup"]
+
+    def test_a_failed_notice_does_not_change_the_verdict(self) -> None:
+        """A warning that could not be delivered must not turn an unconfirmed arm into some other
+        failure — the operator still needs `goal_armed` and the kept pane."""
+
+        class SendTextFailsAfterGoal(Runner):
+            def __call__(self, argv, timeout=180):
+                if (self.key(argv) == "herdr pane send-text"
+                        and "HANDOFF NOT CONFIRMED" in " ".join(argv)):
+                    self.calls.append(list(argv))
+                    return FakeProc(returncode=1)
+                return super().__call__(argv, timeout)
+
+        r = SendTextFailsAfterGoal(_responses(pane_read="scrollback\n"))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=10**6)))
+        assert out["failed_step"] == "goal_armed"
+        assert out["arm_outcome"] == "unconfirmed_timeout"
+        assert "NOT closed" in str(out["cleanup"])
+
+    def test_a_successful_handoff_is_never_warned(self) -> None:
+        r = Runner(_responses())
+        out = ll.perform_handoff(**_handoff(r, read_text=Artifacts(r, marker_after_nudges=0)))
+        assert out["ok"] is True, out["failed_step"]
+        assert not any("HANDOFF NOT CONFIRMED" in t for t in r.sent_text())

--- a/tests/hooks/test_adhoc_pane_handoff.py
+++ b/tests/hooks/test_adhoc_pane_handoff.py
@@ -136,14 +136,21 @@ class Artifacts:
     `goal_row_after_nudges` is the same idea for the GOAL paste (#835). It defaults to 0, so the
     predicate is always true and every test written before it behaves identically; a goal-nudge
     test raises it to express the state the goal recovery exists for.
+
+    `goal_row_after_reads` is the #1000 axis, and it is deliberately NOT the nudge count. The
+    queued state produces no nudges at all — that is the defect — so nudges cannot express "the
+    row arrives later in TIME". Transcript reads can: `_poll_for` reads once per attempt, so the
+    read count IS elapsed polling under the injected sleeper. Defaults to 0, so every test written
+    before it behaves identically.
     """
 
     def __init__(self, runner, *, marker_after_nudges=0, goal_row=GOAL_ROW,
-                 goal_row_after_nudges=0, registry_row=None):
+                 goal_row_after_nudges=0, goal_row_after_reads=0, registry_row=None):
         self.runner = runner
         self.marker_after_nudges = marker_after_nudges
         self.goal_row = goal_row
         self.goal_row_after_nudges = goal_row_after_nudges
+        self.goal_row_after_reads = goal_row_after_reads
         # #800 — which REPRESENTATION the successor writes for `project_path`. Defaults to the
         # workspace-relative row every other test in this file assumes, so their behaviour is
         # unchanged; the absolute variant is the live failure the gate used to refuse.
@@ -160,7 +167,8 @@ class Artifacts:
         text = ""
         if len(self.runner.nudges()) >= self.marker_after_nudges:
             text += RESUME_PROMPT + "\n"
-        if len(self.runner.nudges()) >= self.goal_row_after_nudges:
+        if (len(self.runner.nudges()) >= self.goal_row_after_nudges
+                and n >= self.goal_row_after_reads):
             text += self.goal_row + "\n"
         return text
 
@@ -749,17 +757,26 @@ class TestTheSettleIsNotAGate:
         The #989 revert removed one of the four assertions this once made — "no work reaches an
         unguarded successor" — because the goal goes last again and the prompt is already out.
         The three that remain are the ones that were ever structural.
+
+        #1000 REVERSED the second assertion, deliberately. It used to require the successor pane
+        to be CLOSED, on the reasoning that an unarmed successor is an orphan. Measurement
+        falsified the premise: successor `09cf79c9` had submitted its goal and was mid-turn when
+        that close destroyed it, along with the only transcript that could explain the failure.
+        `goal_armed` failing is not evidence the successor is dead. So the property is now the
+        opposite — the pane is KEPT — while the two that were ever structural are unchanged.
         """
         r = Runner(_responses(pane_read="unrelated scrollback\n"))
         out = ll.perform_handoff(**_handoff(
             r, teardown=True,
             read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=99)))
-        # 1. it fails, and names the gate rather than the settle
+        # 1. it fails, and names the gate rather than the settle — UNCHANGED
         assert out["ok"] is False and out["failed_step"] == "goal_armed"
-        # 2. the successor pane is cleaned up — no orphan
+        # 2. #1000 — the successor pane is KEPT, because the run cannot prove it is dead
+        assert out["arm_outcome"] == "unconfirmed_timeout", out.get("arm_outcome")
         assert out["cleanup"] and "w1:pZZ" in str(out["cleanup"]), out["cleanup"]
-        assert any(c[:3] == ["herdr", "pane", "close"] and c[3] == "w1:pZZ" for c in r.calls)
-        # 3. the PREDECESSOR survives, even though teardown was requested
+        assert not any(c[:3] == ["herdr", "pane", "close"] and c[3] == "w1:pZZ"
+                       for c in r.calls), "an unconfirmed arm must not destroy the successor"
+        # 3. the PREDECESSOR survives, even though teardown was requested — UNCHANGED
         assert not any(c[:3] == ["herdr", "pane", "close"] and c[3] == "w1:p1"
                        for c in r.calls), "the predecessor must never be retired on a failed gate"
 
@@ -2517,3 +2534,236 @@ class TestStep11WaveFixes:
         assert out["failed_step"] == "predecessor_goal_clear"
         assert out["failure_detail"], "a teardown-phase exit must not be bare at the library level"
         assert out["failure_detail"] == out["predecessor_guard"]
+
+
+# ---------------------------------------------------------------------------
+# #1000 — the arm wait ends before the row can exist, and the timeout then
+# destroys a successor the run cannot prove is dead
+# ---------------------------------------------------------------------------
+
+class TestTheArmWaitOutlivesASlowSubmission:
+    """#1000 — a queued `/goal` submits LATE, and the gate must still be waiting when it does.
+
+    The measured failure (successor `09cf79c9`, 2026-08-08): the `/goal` submitted 54 s after the
+    successor's prompt turn ended, the successor printed `Guard is armed.`, and the pane was
+    destroyed 3.778 s later with zero `goal_status` rows ever written.
+
+    The nudge loop cannot cover this. A queued command shows no paste affordance, so
+    `pane_shows_unsubmitted_paste` declines and the loop breaks on round one — leaving exactly one
+    18 s poll (`GOAL_POLL_ATTEMPTS` x `GOAL_POLL_DELAY_S`) against a submission far outside it.
+    """
+
+    def test_a_row_that_lands_past_the_short_budget_still_arms(self) -> None:
+        """Matrix row 1. Today this fails `goal_armed`; the long poll must reach it."""
+        r = Runner(_responses(pane_read="some unrelated scrollback\n"))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=20)))
+        assert out["ok"] is True, out["failed_step"]
+        assert out["results"]["goal_armed"] is True
+        assert out["arm_outcome"] == "armed", out.get("arm_outcome")
+        assert r.nudges() == [], "a queued command still offers nothing for a bare Enter"
+
+    def test_the_long_wait_is_bounded_and_still_fails_closed(self) -> None:
+        """Matrix row 2. Patience is not surrender: a row that never lands still fails."""
+        r = Runner(_responses(pane_read="some unrelated scrollback\n"))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=10**6)))
+        assert out["ok"] is False and out["failed_step"] == "goal_armed"
+        assert out["results"]["goal_armed"] is False, "the PASS condition must not have moved"
+
+
+class TestAnUnconfirmedArmDoesNotDestroyTheSuccessor:
+    """#1000 R2 — the timeout destroyed a live session AND the evidence that would explain it.
+
+    `goal_armed` cannot distinguish a late submission from a refusal, a dead pane or an unreadable
+    transcript, so it must not act as though it can. Where the run cannot prove the successor is
+    dead, the pane is kept and the receipt says exactly that — never that the successor is healthy.
+    """
+
+    def test_the_pane_is_kept_when_the_arm_is_merely_unconfirmed(self) -> None:
+        """Matrix row 3. The whole point of the issue."""
+        r = Runner(_responses(pane_read="some unrelated scrollback\n"))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=10**6)))
+        assert out["failed_step"] == "goal_armed"
+        assert out["arm_outcome"] == "unconfirmed_timeout", out.get("arm_outcome")
+        # `build_teardown_argv` emits `herdr pane close <pane>`, so THAT is the call that must be
+        # absent. Asserting on a name the code never emits would be a guard that cannot fail.
+        assert not any(Runner.key(c) == "herdr pane close" for c in r.calls), \
+            "an unconfirmed arm must never tear the successor down"
+        assert "NOT closed" in str(out["cleanup"]), out["cleanup"]
+
+    def test_the_receipt_names_the_pane_and_how_to_inspect_it(self) -> None:
+        """A kept pane is an orphan unless the operator is told which one and what to run."""
+        r = Runner(_responses(pane_read="some unrelated scrollback\n"))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=10**6)))
+        cleanup = str(out["cleanup"])
+        assert out["new_pane"] and out["new_pane"] in cleanup, cleanup
+        assert "herdr pane read" in cleanup and "herdr pane close" in cleanup, cleanup
+
+    def test_the_receipt_never_claims_the_successor_is_healthy(self) -> None:
+        """The run could not prove the successor is alive. It must not imply that it did."""
+        r = Runner(_responses(pane_read="some unrelated scrollback\n"))
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=10**6)))
+        assert out["results"]["goal_armed"] is False
+        assert "could not be proven dead" in str(out["cleanup"]), out["cleanup"]
+
+
+PANE_GET_FOREIGN = json.dumps({"result": {"pane": {
+    "pane_id": "w1:pZZ", "agent_status": "idle",
+    "agent_session": {"agent": "claude", "kind": "id", "source": "herdr:claude",
+                      "value": "somebody-elses-session"}}}})
+
+
+class FlippingGetRunner(Runner):
+    """A runner whose `pane get` starts as OURS and later reports somebody else's session.
+
+    A pane handle can be reused, and the case that matters is a pane that WAS ours at spawn and is
+    not ours by cleanup time. Seeding a foreign session from call one cannot express that: the
+    successor's own id is read from `pane get`, so a foreign value there breaks `project_switched`
+    long before the arm phase and the test would never reach the code it means to exercise.
+    """
+
+    def __init__(self, responses, *, flip_after):
+        super().__init__(responses)
+        self.flip_after = flip_after
+        self.gets = 0
+
+    def __call__(self, argv, timeout=180):
+        if self.key(argv) == "herdr pane get":
+            self.gets += 1
+            if self.gets > self.flip_after:
+                self.calls.append(list(argv))
+                return FakeProc(0, PANE_GET_FOREIGN)
+        return super().__call__(argv, timeout)
+
+
+class TestTheArmOutcomeIsClassifiedNotCollapsed:
+    """#1000 — four different things used to reach `failed_step: goal_armed` identically.
+
+    A late submission, an unreadable transcript, a dead-or-reused pane and a real refusal all land
+    on the same failure. The cleanup then treated them the same way, which is how a live successor
+    was destroyed. `arm_outcome` names which one it was, so the pane decision has something honest
+    to key on. The gate's verdict is untouched: `failed_step` and `results.goal_armed` are the
+    same on every row below as they were before this change.
+    """
+
+    def _foreign(self):
+        """A handoff whose pane was ours at spawn and belongs to somebody else by cleanup."""
+        r = FlippingGetRunner(_responses(pane_read="some unrelated scrollback\n"), flip_after=1)
+        out = ll.perform_handoff(**_handoff(
+            r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=10**6)))
+        return r, out
+
+    def test_a_foreign_session_on_the_pane_is_not_kept(self) -> None:
+        """Matrix row 4. Our session is provably gone, so the keep-it rule does not apply."""
+        _r, out = self._foreign()
+        assert out["failed_step"] == "goal_armed", out["failed_step"]
+        assert out["arm_outcome"] == "pane_unreachable", out.get("arm_outcome")
+
+    def test_a_foreign_session_is_still_never_closed_by_the_cleanup(self) -> None:
+        """`pane_unreachable` routes to today's `_close_tentative_pane`, which is itself
+        ownership-gated: it re-probes and REPORTS rather than closing a handle that may have been
+        reused. Asserted here so routing an outcome to that path can never be read as licence to
+        destroy somebody else's pane."""
+        r, out = self._foreign()
+        assert not any(c[:3] == ["herdr", "pane", "close"] for c in r.calls), r.calls
+        assert "NOT closed" in str(out["cleanup"]), out["cleanup"]
+
+    def test_a_transcript_that_never_reads_keeps_the_pane(self) -> None:
+        """Matrix row 5. Every read raised, so the run learned NOTHING about the successor.
+        Destroying on no evidence is the same mistake as destroying on a timeout."""
+        r = Runner(_responses(pane_read="some unrelated scrollback\n"))
+        art = Artifacts(r, marker_after_nudges=0)
+
+        def read_text(path):
+            # Fail ONLY once the goal has gone out. A transcript that raises from the start never
+            # reaches the arm phase at all — it dies at `transcript_baseline_unreadable` — so it
+            # cannot exercise `poll_error`.
+            if any(t.startswith("/goal") for t in r.sent_text()):
+                raise OSError("transcript unreadable during the arm poll")
+            return art(path)
+
+        out = ll.perform_handoff(**_handoff(r, read_text=read_text))
+        assert out["failed_step"] == "goal_armed", out["failed_step"]
+        assert out["arm_outcome"] == "poll_error", out.get("arm_outcome")
+        assert not any(c[:3] == ["herdr", "pane", "close"] for c in r.calls)
+        assert "NOT closed" in str(out["cleanup"]), out["cleanup"]
+
+    def test_a_non_arm_failure_still_closes_the_pane_exactly_as_before(self) -> None:
+        """Matrix row 6. The carve-out is for `goal_armed` alone. Every other failure keeps
+        today's cleanup, or this change would leak a pane on every unrelated fault."""
+        r = Runner(_responses(), fail_on="herdr pane send-text")
+        out = ll.perform_handoff(**_handoff(r, read_text=Artifacts(r)))
+        assert out["failed_step"] != "goal_armed", out["failed_step"]
+        assert out["arm_outcome"] is None, "a run that never armed sets no arm outcome"
+        assert "NOT closed" not in str(out["cleanup"] or ""), out["cleanup"]
+
+    def test_the_happy_path_does_no_extra_polling_and_reads_no_pane(self) -> None:
+        """Matrix row 7. The long poll must cost a healthy handoff nothing at all."""
+        slept: list[float] = []
+        r = Runner(_responses())
+        out = ll.perform_handoff(**_handoff(
+            r, sleeper=slept.append, read_text=Artifacts(r, marker_after_nudges=0)))
+        assert out["ok"] is True, out["failed_step"]
+        assert out["arm_outcome"] == "armed"
+        assert not any(Runner.key(c) == "herdr pane read" for c in r.calls), \
+            "an arm that confirmed must not trigger the recovery or the liveness probe"
+        assert ll.GOAL_ARM_LONG_POLL_DELAY_S not in slept, \
+            "the long poll must not run when the short one already armed"
+
+    def test_the_receipt_table_is_asserted_per_outcome(self) -> None:
+        """Matrix row 10. The four fields, side by side, so their meanings cannot drift apart."""
+        rows = {}
+        for label, responses, reads in (
+                ("armed", _responses(), 0),
+                ("unconfirmed_timeout", _responses(pane_read="scrollback\n"), 10**6),
+                ("pane_unreachable", "FLIP", 10**6)):
+            r = (FlippingGetRunner(_responses(pane_read="scrollback\n"), flip_after=1)
+                 if responses == "FLIP" else Runner(responses))
+            out = ll.perform_handoff(**_handoff(
+                r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_reads=reads)))
+            rows[label] = (out["arm_outcome"], out["failed_step"],
+                           out["results"].get("goal_armed"),
+                           "NOT closed" in str(out["cleanup"] or ""))
+        assert rows["armed"] == ("armed", None, True, False), rows
+        assert rows["unconfirmed_timeout"] == ("unconfirmed_timeout", "goal_armed", False, True), rows
+        assert rows["pane_unreachable"] == ("pane_unreachable", "goal_armed", False, True), rows
+
+
+class TestTheLongArmPollIsBoundedOnWallClockToo:
+    """#1000 — an attempt count is not a time bound when each attempt can block.
+
+    `_poll_for` already enforces both axes; this pins that the LONG budget inherits it, because a
+    120 s nominal wait whose attempts each block would otherwise become an unbounded one.
+    """
+
+    def test_a_slow_poll_stops_at_the_deadline_not_the_attempt_count(self) -> None:
+        clock = {"t": 0.0}
+        attempts = {"n": 0}
+
+        def now():
+            return clock["t"]
+
+        def check():
+            attempts["n"] += 1
+            clock["t"] += 30.0     # each attempt burns far more than its nominal delay
+            return False
+
+        ok = ll._poll_for(check, attempts=ll.GOAL_ARM_LONG_POLL_ATTEMPTS,
+                          delay_s=ll.GOAL_ARM_LONG_POLL_DELAY_S,
+                          sleeper=lambda _s: None, now=now)
+        assert ok is False
+        bound = (ll.GOAL_ARM_LONG_POLL_ATTEMPTS * ll.GOAL_ARM_LONG_POLL_DELAY_S
+                 * ll.POLL_WALL_CLOCK_SLACK)
+        assert clock["t"] <= bound + 30.0, (clock["t"], bound)
+        assert attempts["n"] < ll.GOAL_ARM_LONG_POLL_ATTEMPTS, \
+            "the wall clock, not the attempt count, must be what stopped it"
+
+    def test_the_long_budget_actually_exceeds_the_measured_submission_gap(self) -> None:
+        """The number has to beat the thing it was derived from: successor `09cf79c9` took 54 s
+        from ending its prompt turn to submitting its goal."""
+        nominal = ll.GOAL_ARM_LONG_POLL_ATTEMPTS * ll.GOAL_ARM_LONG_POLL_DELAY_S
+        assert nominal >= 2 * 54.0, nominal

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.141.8"
+EXPECTED_PLUGIN_VERSION = "3.141.9"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_launcher_lib.py
+++ b/tests/hooks/test_launcher_lib.py
@@ -1565,7 +1565,13 @@ class TestBoundedPolling:
         out = ll.perform_handoff(runner=r, **_handoff(
             read_text=Artifacts(transcript=""), sleeper=slept.append))
         assert out["ok"] is False and out["failed_step"] == "goal_armed"
-        assert len(slept) <= ll.GOAL_POLL_ATTEMPTS, "polling must be bounded"
+        # #1000 — the arm phase now polls TWICE: the short budget, then, when that does not arm,
+        # one longer bounded poll (a queued `/goal` submits up to a minute after the send). The
+        # property under test is unchanged — polling must be BOUNDED — so the bound is widened to
+        # both budgets plus the single settle sleep, not removed. Each `_poll_for` sleeps between
+        # attempts, hence `attempts - 1` each.
+        ceiling = 1 + (ll.GOAL_POLL_ATTEMPTS - 1) + (ll.GOAL_ARM_LONG_POLL_ATTEMPTS - 1)
+        assert len(slept) <= ceiling, f"polling must be bounded (slept {len(slept)}x)"
         assert not _predecessor_closed(r)
 
     def test_a_partial_multibyte_read_is_retried_not_fatal(self) -> None:


### PR DESCRIPTION
## What this fixes

`/rawgentic:pane-handoff` created a healthy successor and then destroyed it. Three attempts on
2026-08-07, three kills.

Read directly from successor `09cf79c9`'s own transcript (68 lines, `00:53:46.147Z`–`00:55:24.640Z`):

| Time (UTC 2026-08-08) | Event |
|---|---|
| `00:54:26.482` | successor answers the resume prompt, turn ENDS |
| `00:55:20.862` | `UserPromptSubmit` fires — the `/goal` submits |
| `00:55:24.240` | successor prints `Guard is armed.` |
| `00:55:24.640` | transcript ENDS — pane destroyed, **3.778 s** later |

Zero `goal_status` rows exist in it. The proof was never written, because the close destroyed the
session that was about to write it.

**This corrects the record.** `claude_docs/epic-906-run-handoff.md` concluded the row "lands after
the budget expires". It never landed at all. That distinction decided the fix: widening a budget
alone would leave a real timeout still deleting a real session.

## Why the wait could not stretch

`GOAL_POLL_ATTEMPTS x GOAL_POLL_DELAY_S` = 18 s. The nudge recovery that would re-poll reads the
pane and declines when there is no unsubmitted-paste affordance — and a QUEUED `/goal` shows none,
which `launcher_lib.py` states at the loop itself and a test has pinned since #989. So the queued
state got one 18 s poll against a measured **54 s** turn-end-to-submit gap.

## What changed

1. **`GOAL_ARM_LONG_POLL_ATTEMPTS = 40` / `_DELAY_S = 3.0`.** One further bounded poll after the
   nudge loop ends without arming. 120 s nominal. The comment records that this is 2x **one**
   observation, `n = 1`, and is not a proven ceiling.
2. **`arm_outcome`** — `armed`, `unconfirmed_timeout`, `probe_error`, `session_mismatch`,
   `pane_absent`, `poll_error` — on one rule: **no automatic close without affirmative evidence of
   death.** Only `session_mismatch` and `pane_absent` reach the old cleanup.
3. **An advisory stop notice** to a kept successor, over the send-text route the handoff already
   uses three times.
4. `arm_outcome` added to the three handoff CLI serializers, which use fixed key tuples.

**The gate's PASS condition is untouched.** Still a real `goal_status` row for the armed condition,
still fail-closed. `failed_step` stays `goal_armed` and `results.goal_armed` stays `false`.

## What review caught, including in this fix

Three cross-model passes, fifteen findings.

- **The fix reintroduced its own bug.** A first revision merged a FAILED probe with a session
  MISMATCH and routed both to `_close_tentative_pane`, which probes AGAIN and closes when its own
  probe succeeds. One transient probe failure would have killed a live successor by way of the
  retry. Split into `probe_error` (keep) and `session_mismatch` (old path), with two tests.
- **A finding at confidence 0.79 — under the Medium 0.80 band that would have filtered it — was
  checked anyway and was a real bug.** The CLI serializers use fixed key tuples, so `arm_outcome`
  was invisible at the CLI boundary; the operator would never have seen the field this issue exists
  to give them.
- **Two factual corrections to my own RCA.** A "same millisecond" claim that was 1 ms apart, and a
  hypothesis marked REFUTED on a mid-turn control that cannot speak for the post-turn state — now
  UNRESOLVED, and the fix deliberately does not depend on the answer.

## Trade-offs, stated rather than buried

- **A kept successor may keep working with no proven guard, while the predecessor is also alive.**
  Closing it used to be what stopped it. The stop notice is advisory, not enforcement, and the
  receipt says so. The predecessor is never retired until `goal_armed` passes, so the run is not
  lost — but two sessions can briefly both be live.
- **Orphan panes are now possible by design.** The receipt names the pane and gives the exact
  inspect and close commands.
- **The 240 s figure is a deadline checked BETWEEN attempts, not a hard wall clock.** `_poll_for`
  cannot interrupt an attempt in flight. The comment says this rather than claiming otherwise; a
  true hard bound needs a cancellable worker on the gate that decides whether a successor is
  trusted, against a failure never observed here.
- **A failing handoff now takes longer** — up to ~5 minutes worst case across both polls.

## Deliberately reversed

`test_goal_armed_is_still_the_gate_and_still_fails_closed` asserted the pane was CLOSED. That
assertion is inverted on purpose; its two structural guarantees — the gate still fails closed, the
predecessor still survives — are unchanged and still asserted.

## Not built

A first phase watching for the goal to submit before starting the arm deadline. There is also no
`refused` outcome, because refusal has no observable; it is classified `unconfirmed_timeout`.

## Verification

- Full suite **6440 → 6460, exit 0**. Baseline recorded before any change.
- Red before green: 4 of the first 5 tests failed against unmodified code.
- Both lint lanes **10.00/10**.
- Security scan **PASS**, one visible skip: `iac: not applicable to this project`.
- 20 tests added.
- No workflow-spine change → **no diagram REV**.

**Not verified live.** Every test uses the injected runner fakes. No live pane handoff was run
against this build, so the end-to-end behavior on real herdr is inferred from precedented call
sites, not measured. The next real handoff is the test.

Closes #1000
