### PR TITLE
chore(wf2): measure the SKILL.md word budget, and report the trim shortfall (#899)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.9",
+  "version": "3.141.10",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -752,8 +752,8 @@ For major changes, please open an issue first to discuss the approach.
 ### v3.141.10 (2026-08-08)
 - **The WF2 prose corpus now measures WORDS, not only bytes (#899, epic #906).** `tests/test_wf2_prose_budget.py`
   gains `SKILL_WORD_CEILINGS` and a `word_violations()` helper mirroring the existing byte-budget
-  reporting shape, plus six tests. `skills/implement-feature/SKILL.md` is pinned at 6,764 words
-  (actual 6,442 + 322 allowed headroom) and the guard fails in BOTH directions, so the ceiling must
+  reporting shape, plus six tests. `skills/implement-feature/SKILL.md` is pinned at 6,765 words
+  (actual 6,442 + the 323 `allowed_headroom()` returns) and the guard fails in BOTH directions, so the ceiling must
   come down as prose shrinks. Proof it bites: against the 6,292 count #899 recorded at `0d2ba0e0`
   the guard reports `OVER WORD CEILING: SKILL.md is 6442 words — 150 over`, so the exact drift the
   issue was filed about would have failed CI. AC1's 5,000-word target is NOT met and is reported

--- a/README.md
+++ b/README.md
@@ -749,6 +749,21 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.141.10 (2026-08-08)
+- **The WF2 prose corpus now measures WORDS, not only bytes (#899, epic #906).** `tests/test_wf2_prose_budget.py`
+  gains `SKILL_WORD_CEILINGS` and a `word_violations()` helper mirroring the existing byte-budget
+  reporting shape, plus six tests. `skills/implement-feature/SKILL.md` is pinned at 6,764 words
+  (actual 6,442 + 322 allowed headroom) and the guard fails in BOTH directions, so the ceiling must
+  come down as prose shrinks. Proof it bites: against the 6,292 count #899 recorded at `0d2ba0e0`
+  the guard reports `OVER WORD CEILING: SKILL.md is 6442 words — 150 over`, so the exact drift the
+  issue was filed about would have failed CI. AC1's 5,000-word target is NOT met and is reported
+  instead via AC1's own alternative branch: `docs/planning/2026-08-08-899-wf2-word-budget-shortfall.md`
+  measures every block and finds ZERO words free to move — 2,112 are synced by
+  `sync_shared_blocks.py` (one shared with fix-bug, which AC3 protects), 753 are AC2's named blocks,
+  2,718 are cross-step, and six more are global spine content no step file reads. #874 already
+  moved everything step-scoped. Owner decision D304. no workflow-spine change → no diagram REV.
+  Suite 6460→6466.
+
 ### v3.141.9 (2026-08-08)
 - **`goal_armed` no longer destroys a successor it cannot prove is dead (#1000, epic #906).** The
   arm gate gave a queued `/goal` 18 s and then closed the successor pane, and the nudge loop could

--- a/docs/planning/2026-08-08-899-wf2-word-budget-shortfall.md
+++ b/docs/planning/2026-08-08-899-wf2-word-budget-shortfall.md
@@ -96,8 +96,8 @@ was filed and false by the time it ran**. The right response is the one AC1 itse
 **AC4, in full**, and it is the durable half. `tests/test_wf2_prose_budget.py` gains a word budget
 beside its byte ceilings, reusing the existing violation-reporting shape:
 
-- `SKILL_WORD_CEILINGS` pins `SKILL.md` at **6,764** = actual 6,442 + 322 allowed headroom, matching
-  how the byte ceilings are calibrated.
+- `SKILL_WORD_CEILINGS` pins `SKILL.md` at **6,765** = actual 6,442 + the 323 that `allowed_headroom()` returns,
+  matching how the byte ceilings are calibrated (`ceiling == actual + allowed_headroom()`).
 - `word_violations()` mirrors `budget_violations()`: same classes, same "name the path, carry actual
   + ceiling + delta" contract, same never-quote-content rule.
 - The guard fails in **both** directions — growth past the ceiling, and a ceiling left stale above a

--- a/docs/planning/2026-08-08-899-wf2-word-budget-shortfall.md
+++ b/docs/planning/2026-08-08-899-wf2-word-budget-shortfall.md
@@ -1,0 +1,160 @@
+# #899 — the SKILL.md word shortfall, reported per AC1's own alternative
+
+**Issue:** #899 (epic #906 M2) · **Date:** 2026-08-08 · **Head:** `c7eb1fce`
+**Decision:** D304 · **Baseline:** 6460 passed, 0 failed, exit 0
+
+---
+
+## The answer first
+
+`skills/implement-feature/SKILL.md` is **6,442 words**. AC1's target is **5,000**, so **1,442 words**
+must go. By AC1's stated means — *"moving genuinely step-scoped prose into the step files #874
+created"* — the number of words that can move is **zero**.
+
+AC1 anticipated this and supplies the alternative in its own text:
+
+> `implement-feature/SKILL.md` is **at or under 5,000 words** — **or, if that proves to require
+> moving an always-loaded contract, the shortfall is reported with the specific blocks that would
+> have to move and why they cannot.**
+
+This document is that report.
+
+## The measurement
+
+Every XML-ish block in `SKILL.md` at `c7eb1fce`, classified and summed:
+
+| Class | Words | Why it cannot move |
+|---|---:|---|
+| **SYNCED** | **2,112** | Generated into `SKILL.md` by `scripts/sync_shared_blocks.py`. |
+| **AC2-protected** | **753** | AC2 names these three explicitly and re-confirms them cross-step. |
+| **Cross-step** | **2,718** | Each is read by several steps; moving any into one step file breaks the others — the same argument AC2 makes for its three. |
+| Headings, the step list, spine prose | 859 | The spine itself. Not a block, not movable. |
+| **Genuinely free to move** | **0** | — |
+| **Total** | **6,442** | |
+
+### The synced blocks (2,112 words)
+
+| Block | Words | Synced into |
+|---|---:|---|
+| `model-routing-resolve` | 774 | implement-feature |
+| `review-severity` | 544 | implement-feature **and fix-bug** |
+| `loop-back-budget` | 442 | implement-feature |
+| `config-loading` | 352 | implement-feature |
+
+Moving one out means editing `scripts/sync_shared_blocks.py`'s MANIFEST. `review-severity` is
+**shared with `fix-bug`**, and **AC3 forbids touching it here**:
+
+> **Shared-block sources are NOT edited here** — `shared/blocks/review-severity.md` is shared with
+> **fix-bug**, so reshaping it changes WF3. That belongs in its own issue if ever wanted.
+
+Verified at `c7eb1fce`: `scripts/sync_shared_blocks.py:63` reads
+`"review-severity.md": ["implement-feature", "fix-bug"]`.
+
+### The AC2-protected blocks (753 words)
+
+| Block | Words | Read by |
+|---|---:|---|
+| `completion-gate` | 454 | `step-05.md`, `step-09.md`, `step-12.md`, `state-and-resume.md` |
+| `early-smoke-install` | 159 | `step-08.md`, `step-15.md` |
+| `probe-before-design` | 140 | `step-03.md`, `step-04.md` |
+
+All three re-verified live at `c7eb1fce` by grepping the `references/` directory. AC2 is correct and
+remains correct.
+
+### The cross-step blocks (2,718 words) — the finding AC1 did not anticipate
+
+These carry no AC protection, and they are the obvious candidates for a trim. **They cannot move for
+exactly AC2's reason**: each is read by more than one step, so relocating it into a single step file
+breaks every other reader.
+
+| Block | Words | Why it is cross-step |
+|---|---:|---|
+| `mandatory-steps` | 714 | Names which steps may never be skipped — a statement ABOUT all steps. |
+| `step-tracking` | 539 | The marker contract every step's DONE line must satisfy. |
+| `test-run-discipline` | 291 | Binds Step 2 (baseline) and Step 9 (regression gate) TOGETHER. |
+| `constants` | 176 | Read by Steps 4, 8a and 11. |
+| `review-lens-routing` | 177 | Assigns lenses at Steps 4, 8a and 11. |
+| `happy-path` | 174 | The spine's own ordering. |
+| `review-pipelining` | 158 | Applies at every review wave (4, 8a, 11). |
+| `references` | 104 | The read-set contract for the step files. |
+| `ambiguity-circuit-breaker` | 73 | Active at Steps 4, 6, 9, 11, 15. |
+| `error-protocol` | 209 | Any step may hit a blocker. |
+| `role` | 66 | The orchestrator's identity. |
+| `termination-rule` | 37 | WF2's terminal condition. |
+
+## Why this is the state, and not a failure
+
+**#874 already did the work #899 assumes is still available.** It split `references/steps.md` into
+per-step files and moved every genuinely step-scoped paragraph out. What remains in `SKILL.md` is,
+by construction, the part that is *not* step-scoped: the always-loaded contract.
+
+That makes AC1's premise — that step-scoped prose is still sitting in the body — **true when #899
+was filed and false by the time it ran**. The right response is the one AC1 itself names.
+
+## What ships instead
+
+**AC4, in full**, and it is the durable half. `tests/test_wf2_prose_budget.py` gains a word budget
+beside its byte ceilings, reusing the existing violation-reporting shape:
+
+- `SKILL_WORD_CEILINGS` pins `SKILL.md` at **6,764** = actual 6,442 + 322 allowed headroom, matching
+  how the byte ceilings are calibrated.
+- `word_violations()` mirrors `budget_violations()`: same classes, same "name the path, carry actual
+  + ceiling + delta" contract, same never-quote-content rule.
+- The guard fails in **both** directions — growth past the ceiling, and a ceiling left stale above a
+  shrink — so the ceiling must come DOWN as prose shrinks.
+
+**Proof it bites, measured before shipping:** run against the live file with the ceiling set to
+**6,292** — the count #899's body recorded at `0d2ba0e0` — the guard reports
+`OVER WORD CEILING: SKILL.md is 6442 words — 150 over its 6292-word ceiling`. **The exact drift
+#899 was filed about would have failed CI** had this guard existed at #874.
+
+## The follow-on, named rather than implied
+
+Reaching 5,000 words needs a change AC3 deliberately puts out of scope: reshaping the shared blocks,
+starting with `review-severity` (544 words, shared with `fix-bug`). That is a WF3-affecting change
+and belongs in its own issue with its own review. **Not filed** — per the issue throttle, filing is
+the owner's call, not this run's.
+
+The word ceiling lowers as prose shrinks, so the guard tracks progress toward 5,000 automatically
+rather than needing to be remembered again.
+
+## The claim most likely to be wrong — checked, and it WAS partly wrong
+
+I first wrote that the twelve "cross-step" blocks were classified by reading what each is *about*
+rather than by grepping for readers, and that a block with exactly one reader would be movable.
+**I then ran that grep instead of leaving it as a caveat.** The result corrected the reasoning:
+
+| Block | Step-file readers |
+|---|---|
+| `references` | 9 — step-02, 04, 05, 06, 08, 09, 14, 15, 16 |
+| `role` | 5 — step-00-preamble, 04, 08, 11, run-record |
+| `test-run-discipline` | 4 — step-02, 08, 09, 12 |
+| `constants` | 3 — step-08, 11, run-record |
+| `review-lens-routing` | 3 — step-04, 08, 11 |
+| `review-pipelining` | 3 — step-04, 08, 11 |
+| `mandatory-steps` | **0** |
+| `step-tracking` | **0** |
+| `error-protocol` | **0** |
+| `happy-path` | **0** |
+| `ambiguity-circuit-breaker` | **0** |
+| `termination-rule` | **0** |
+
+Six blocks (1,746 words) have **zero** readers among the step files. My stated test would have
+called those the movable ones. **That reading is wrong, and the opposite is true:** a block no step
+file references cannot be moved *into* a step file, because no step would then read it.
+`mandatory-steps` is the clearest case — it states which steps may never be skipped, so filing it
+under `step-08.md` hides it from Steps 1-7. These six are global spine content that the orchestrator
+reads directly from `SKILL.md`.
+
+So the conclusion stands — zero words are movable — but for two distinct reasons, not one: six
+blocks are cross-step (multiple readers, moving breaks the others), and six are global (no step
+owns them). The original single-reader test was the wrong instrument; it would have identified a
+movable block correctly, but there are none, and it says nothing about the global six.
+
+**What I would now most expect to be wrong:** that the six zero-reader blocks are all genuinely
+load-bearing rather than merely unreferenced. A block with no readers could also be *dead prose* —
+and dead prose is trimmable without moving anything. **What would confirm or refute it:** for each
+of the six, find the behaviour it governs and the run that would change if it were deleted.
+`termination-rule` (37 words) and `ambiguity-circuit-breaker` (73) are the cheapest to check and the
+likeliest to be genuinely load-bearing; `happy-path` (174) restates the spine that the step list
+below it already gives, and is the one I would examine first for redundancy.

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.9",
+  "version": "3.141.10",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.141.9"
+EXPECTED_PLUGIN_VERSION = "3.141.10"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/test_wf2_prose_budget.py
+++ b/tests/test_wf2_prose_budget.py
@@ -374,3 +374,135 @@ def test_live_corpus_has_no_stale_ceilings():
                                       TOTAL_CEILING_BYTES)
          if "STALE" in m]
     assert v == [], "stale ceilings in the live budget:\n" + "\n".join(v)
+
+
+# --- #899: the WORD budget, alongside the byte ceilings -------------------
+#
+# Anthropic's stated guideline for a SKILL.md body is 5,000 WORDS. This file
+# measured BYTES only, so the word guideline was remembered rather than
+# measured — and it had drifted 6_292 -> 6_442 between #874 and #899 with
+# nothing failing. Bytes and words are not interchangeable here: a
+# compression that shortens identifiers drops bytes while leaving the word
+# count (and so the load on the model's context) untouched.
+#
+# WHY THE CEILING IS 6_442 AND NOT 5_000 (#899, owner decision D304).
+# The 5,000 target is unreachable by the means #899's AC1 names — "moving
+# genuinely step-scoped prose into the step files #874 created". Measured at
+# c7eb1fce, every block in SKILL.md is one of:
+#   * SYNCED (2_112 words) -- config-loading, model-routing-resolve,
+#     loop-back-budget, review-severity are GENERATED into SKILL.md by
+#     scripts/sync_shared_blocks.py. Moving one edits that manifest, and
+#     review-severity is shared with fix-bug, which AC3 forbids touching.
+#   * AC2-PROTECTED (753) -- completion-gate, probe-before-design,
+#     early-smoke-install; AC2 names these and re-confirms them cross-step.
+#   * CROSS-STEP (2_718) -- mandatory-steps, step-tracking, happy-path,
+#     constants, references, role, termination-rule, error-protocol,
+#     ambiguity-circuit-breaker, review-pipelining, test-run-discipline,
+#     review-lens-routing. Each is read by SEVERAL steps, so moving any into
+#     one step file breaks the others -- the same argument AC2 makes.
+#   * the remaining 859 are headings and the one-line-per-step spine.
+# Genuinely free to move: ZERO. #874 already moved everything step-scoped.
+#
+# AC1 anticipated exactly this and supplies the alternative in its own text:
+# report the shortfall with the specific blocks and why they cannot move.
+# That report is docs/planning/2026-08-08-899-wf2-word-budget-shortfall.md.
+#
+# So this guard's job is NOT to enforce 5,000 today. It is to stop the drift
+# that went unmeasured: the ceiling is pinned at the measured actual plus the
+# same allowed headroom the byte ceilings use, and the SYMMETRIC stale check
+# means the ceiling must come DOWN as prose shrinks. Lowering it to 5,000 is
+# the follow-on work, not a number to assert before the prose can meet it.
+SKILL_WORD_CEILINGS = {
+    "SKILL.md": 6_764,          # actual 6_442 + headroom 322
+}
+
+STALE_WORD_PCT = 0.05
+STALE_WORD_MIN_WORDS = 64
+
+
+def measured_words() -> dict:
+    """Relative path -> word count for every .md under the skill dir."""
+    return {
+        p.relative_to(SKILL_DIR).as_posix(): len(
+            p.read_text(encoding="utf-8").split()
+        )
+        for p in SKILL_DIR.rglob("*.md")
+    }
+
+
+def word_violations(words: dict, ceilings: dict) -> list:
+    """Word-budget violations, one message per violation.
+
+    Mirrors `budget_violations`' shape deliberately (#899 AC4 says to reuse
+    it): the same UNBUDGETED / STALE BUDGET / OVER / STALE classes, the same
+    "name the path, carry actual + ceiling + delta" contract, and the same
+    never-quote-content rule. Only the budgeted SUBSET is checked -- unlike
+    bytes, where every corpus file carries a ceiling, the word guideline is
+    about the always-loaded SKILL.md body, so an unbudgeted file here is not
+    a violation.
+    """
+    violations = []
+    for path in sorted(ceilings.keys() - words.keys()):
+        violations.append(
+            f"STALE WORD BUDGET: {path} has a word ceiling but no file on disk "
+            f"— a rename or split must update SKILL_WORD_CEILINGS in the same "
+            f"commit (#899)."
+        )
+    for path in sorted(ceilings.keys() & words.keys()):
+        count, ceiling = words[path], ceilings[path]
+        if count > ceiling:
+            violations.append(
+                f"OVER WORD CEILING: {path} is {count} words — "
+                f"{count - ceiling} over its {ceiling}-word ceiling. Trim it, "
+                f"or raise the ceiling in the same commit and say why in the "
+                f"PR (#899)."
+            )
+        else:
+            allowed = allowed_headroom(count, STALE_WORD_PCT, STALE_WORD_MIN_WORDS)
+            excess = ceiling - count - allowed
+            if excess > 0:
+                violations.append(
+                    f"STALE WORD CEILING: {path} is {count} words but its "
+                    f"ceiling is {ceiling} — {ceiling - count} words of "
+                    f"headroom against an allowed {allowed} ({excess} too "
+                    f"much). Lower the ceiling to actual + allowed in the "
+                    f"same commit as the shrink (#899)."
+                )
+    return violations
+
+
+def test_word_clean_budget_yields_no_violations():
+    assert word_violations({"SKILL.md": 100}, {"SKILL.md": 105}) == []
+
+
+def test_word_over_ceiling_names_path_and_delta():
+    (v,) = word_violations({"SKILL.md": 200}, {"SKILL.md": 150})
+    assert v.startswith("OVER WORD CEILING: SKILL.md")
+    assert "200 words" in v and "50 over" in v and "150-word" in v
+
+
+def test_word_stale_ceiling_is_named():
+    (v,) = word_violations({"SKILL.md": 100}, {"SKILL.md": 1_000})
+    assert v.startswith("STALE WORD CEILING: SKILL.md")
+    assert "100 words" in v and "1000" in v
+
+
+def test_word_stale_budget_entry_is_named():
+    (v,) = word_violations({}, {"gone.md": 100})
+    assert v.startswith("STALE WORD BUDGET: gone.md")
+
+
+def test_word_violations_never_quote_file_content():
+    body = "SECRET-CANARY-STRING"
+    for v in word_violations({"SKILL.md": 999}, {"SKILL.md": 1}):
+        assert body not in v
+
+
+def test_skill_body_stays_within_its_word_ceiling():
+    """The live guard: SKILL.md's word count against its pinned ceiling.
+
+    This is the measurement #899 exists to add. It fails in BOTH directions —
+    growth past the ceiling, and a ceiling left stale above a shrink.
+    """
+    violations = word_violations(measured_words(), SKILL_WORD_CEILINGS)
+    assert not violations, "\n".join(violations)

--- a/tests/test_wf2_prose_budget.py
+++ b/tests/test_wf2_prose_budget.py
@@ -395,11 +395,17 @@ def test_live_corpus_has_no_stale_ceilings():
 #     review-severity is shared with fix-bug, which AC3 forbids touching.
 #   * AC2-PROTECTED (753) -- completion-gate, probe-before-design,
 #     early-smoke-install; AC2 names these and re-confirms them cross-step.
-#   * CROSS-STEP (2_718) -- mandatory-steps, step-tracking, happy-path,
-#     constants, references, role, termination-rule, error-protocol,
-#     ambiguity-circuit-breaker, review-pipelining, test-run-discipline,
-#     review-lens-routing. Each is read by SEVERAL steps, so moving any into
-#     one step file breaks the others -- the same argument AC2 makes.
+#   * CROSS-STEP (972) -- references, role, test-run-discipline, constants,
+#     review-lens-routing, review-pipelining. Each is read by 3-9 step files,
+#     so moving any into one breaks the others -- the same argument AC2 makes.
+#   * GLOBAL SPINE (1_746) -- mandatory-steps, step-tracking, error-protocol,
+#     happy-path, ambiguity-circuit-breaker, termination-rule. These have ZERO
+#     step-file readers, and that is why they cannot move EITHER: a block no
+#     step file references cannot be relocated INTO one, because no step would
+#     then read it. mandatory-steps is the clearest case -- it says which steps
+#     may never be skipped, so filing it under step-08.md hides it from Steps
+#     1-7. (Step-11 R4: an earlier version of this comment called all twelve
+#     "cross-step", which was a false explanation for 1_746 of the words.)
 #   * the remaining 859 are headings and the one-line-per-step spine.
 # Genuinely free to move: ZERO. #874 already moved everything step-scoped.
 #
@@ -413,7 +419,7 @@ def test_live_corpus_has_no_stale_ceilings():
 # means the ceiling must come DOWN as prose shrinks. Lowering it to 5,000 is
 # the follow-on work, not a number to assert before the prose can meet it.
 SKILL_WORD_CEILINGS = {
-    "SKILL.md": 6_764,          # actual 6_442 + headroom 322
+    "SKILL.md": 6_765,          # actual 6_442 + allowed_headroom() 323
 }
 
 STALE_WORD_PCT = 0.05
@@ -434,12 +440,16 @@ def word_violations(words: dict, ceilings: dict) -> list:
     """Word-budget violations, one message per violation.
 
     Mirrors `budget_violations`' shape deliberately (#899 AC4 says to reuse
-    it): the same UNBUDGETED / STALE BUDGET / OVER / STALE classes, the same
-    "name the path, carry actual + ceiling + delta" contract, and the same
-    never-quote-content rule. Only the budgeted SUBSET is checked -- unlike
-    bytes, where every corpus file carries a ceiling, the word guideline is
-    about the always-loaded SKILL.md body, so an unbudgeted file here is not
-    a violation.
+    it): the same "name the path, carry actual + ceiling + delta" contract and
+    the same never-quote-content rule.
+
+    THREE classes, not four (Step-11 R5 -- an earlier docstring claimed the
+    same four and then described the opposite, contradicting its own code):
+    STALE WORD BUDGET, OVER WORD CEILING, STALE WORD CEILING. There is
+    deliberately NO unbudgeted class. Every corpus file carries a BYTE ceiling,
+    so the byte guard must catch a new file; the WORD guideline is about the
+    always-loaded SKILL.md body specifically, so a .md file with no word
+    ceiling is out of scope here rather than a violation.
     """
     violations = []
     for path in sorted(ceilings.keys() - words.keys()):
@@ -492,10 +502,26 @@ def test_word_stale_budget_entry_is_named():
     assert v.startswith("STALE WORD BUDGET: gone.md")
 
 
-def test_word_violations_never_quote_file_content():
-    body = "SECRET-CANARY-STRING"
-    for v in word_violations({"SKILL.md": 999}, {"SKILL.md": 1}):
-        assert body not in v
+def test_word_violations_never_quote_file_content(tmp_path):
+    """Step-11 R3: the first version of this test was VACUOUS.
+
+    It bound a canary to a local and asserted it was absent from messages the
+    canary had never been given to — guaranteed to pass however badly a future
+    reporting path leaked. This version writes the canary into a real .md file,
+    measures THAT directory, and drives the violation path with the resulting
+    counts, so the assertion can actually fail.
+    """
+    canary = "SECRET-CANARY-STRING-do-not-quote-me"
+    (tmp_path / "SKILL.md").write_text(f"{canary} " * 50, encoding="utf-8")
+    words = {
+        p.relative_to(tmp_path).as_posix(): len(p.read_text(encoding="utf-8").split())
+        for p in tmp_path.rglob("*.md")
+    }
+    assert words == {"SKILL.md": 50}, "the fixture must measure as real content"
+    violations = word_violations(words, {"SKILL.md": 1})
+    assert violations, "the fixture must PRODUCE a violation, or nothing is checked"
+    for v in violations:
+        assert canary not in v
 
 
 def test_skill_body_stays_within_its_word_ceiling():


### PR DESCRIPTION
## What ships

**AC4 in full**, and **AC1 via its own alternative branch**.

`tests/test_wf2_prose_budget.py` measured **bytes only**, so Anthropic's 5,000-word SKILL.md
guideline was remembered rather than measured — and it had drifted **6,292 → 6,442** between #874
and #899 with nothing failing. Bytes and words are not interchangeable here: shortening identifiers
drops bytes while leaving the word count, and so the load on the model's context, untouched.

Adds `SKILL_WORD_CEILINGS`, `measured_words()` and `word_violations()`, mirroring the existing
violation-reporting shape as AC4 asks — same "name the path, carry actual + ceiling + delta"
contract, same never-quote-content rule. Six tests.

**Proof the guard bites, run before shipping.** Against the 6,292 count #899's body recorded at
`0d2ba0e0`, it reports:

```
OVER WORD CEILING: SKILL.md is 6442 words — 150 over its 6292-word ceiling.
```

**The exact drift this issue was filed about would have failed CI** had the guard existed at #874.
It fails in **both** directions — a ceiling left stale above a shrink also fires — so the ceiling
must come DOWN as prose shrinks, and it tracks progress toward 5,000 automatically instead of
needing to be remembered again.

## AC1 is NOT met, and that is the reported outcome

AC1 asks for ≤5,000 words by *"moving genuinely step-scoped prose into the step files #874 created"*,
**or**, in its own words, *"if that proves to require moving an always-loaded contract, the shortfall
is reported with the specific blocks that would have to move and why they cannot."*

Measured at `c7eb1fce`, **zero words are free to move**:

| Class | Words | Why it cannot move |
|---|---:|---|
| SYNCED | 2,112 | Generated into SKILL.md by `sync_shared_blocks.py`; `review-severity` among them is shared with **fix-bug**, which **AC3 forbids touching here** |
| AC2-protected | 753 | The three blocks AC2 names, re-verified cross-step |
| CROSS-STEP | 972 | 3–9 step-file readers each; moving one breaks the others |
| GLOBAL SPINE | 1,746 | **Zero** step-file readers — cannot move *into* a step file, because no step would then read it |
| Headings + step list | 859 | The spine itself |

**#874 already moved everything step-scoped.** AC1's premise was true when #899 was filed and false
by the time it ran. Full analysis:
`docs/planning/2026-08-08-899-wf2-word-budget-shortfall.md`. Owner decision **D304**.

## Review

Ran the small-standard lane (`plan_lib.lane_decision` → `tier='lane'`, standard_feature, 3 impl
files). Steps 3/4/5/9 collapsed and Step 6 skipped; **Step 11, Step 11.5 and TDD red-before-green
ran at full strength**, per the lane's own rules.

Step 11 returned 5 findings — **no Critical, no High**. Three were real defects and are fixed in
`273264ef`:

- **R3** — the canary test was **vacuous**: it asserted a string was absent from messages it had
  never been given to. Rewritten to write the canary into a real file and drive the violation path.
  **Verified by breaking the helper**: against a deliberately leaking `word_violations` the test now
  fails. Before, it passed.
- **R4** — a source comment called all twelve blocks "cross-step", a false explanation for 1,746 of
  the words. Now split into CROSS-STEP and GLOBAL SPINE.
- **R5** — the docstring claimed four violation classes and then described three.

**R2 (ambiguous) was resolved by measurement, not waived.** The reviewer could not verify the count
because the diff excludes unchanged files. Measured live: 6,442 words; `allowed_headroom(6442, 0.05,
64)` returns **323**; ceiling 6,765. A self-review had already caught an off-by-one here before the
review returned — the comment said 322 — and that correction is in this PR.

**R1 accepted as a disclosed limit.** Whether the six zero-reader blocks are load-bearing or dead
prose is what the shortfall doc names as its OWN most-likely-wrong claim, and 1,746 words exceed the
1,442 shortfall, so it stays stated rather than quietly resolved.

## Verification

- **Suite 6460 → 6466, exit 0.** Baseline recorded at `c7eb1fce` before work started; +6 is exactly
  the six tests added.
- Both lint lanes **10.00/10**.
- Security scan **PASS** (`iac` skipped — not applicable to this project; a visible skip).
- Three version surfaces bumped **3.141.9 → 3.141.10**, verified equal.
- **Diagram decision: no workflow-spine change → no diagram REV.** This adds a test guard and a
  planning doc; no step, gate, or loop-back changes.

Closes #899
Part of #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)
